### PR TITLE
feat: add dark/light theme toggle with localStorage persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#030712" />
-    <meta name="color-scheme" content="dark" />
+    <meta name="color-scheme" content="dark light" />
     <meta name="description" content="Stellar Unified Price Oracle & Aggregator - Developer Portal & Analytics Dashboard" />
     <meta property="og:title" content="Stellar Oracle - Developer Portal & Analytics Dashboard" />
     <meta property="og:description" content="Stellar Unified Price Oracle & Aggregator - Developer Portal & Analytics Dashboard" />
@@ -19,6 +19,14 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <title>Stellar Oracle - Developer Portal & Analytics Dashboard</title>
     <script>
+      // Apply theme before paint to avoid flash
+      (function () {
+        var stored = localStorage.getItem('stellar-oracle-theme');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (stored === 'dark' || (!stored && prefersDark)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
           navigator.serviceWorker.register('/sw.js').catch(() => {});
@@ -26,7 +34,7 @@
       }
     </script>
   </head>
-  <body class="bg-gray-950 text-gray-100">
+  <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/components/ConnectionBadge.tsx
+++ b/src/components/ConnectionBadge.tsx
@@ -10,7 +10,7 @@ const STATUS_MAP: Record<ConnectionStatus, { label: string; color: string }> = {
 export function ConnectionBadge({ status }: { status: ConnectionStatus }) {
   const s = STATUS_MAP[status]
   return (
-    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-800 text-gray-300" role="status" aria-label={`WebSocket ${s.label}`}>
+    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300" role="status" aria-label={`WebSocket ${s.label}`}>
       <span className={`w-2 h-2 rounded-full ${s.color} ${status === 'connected' ? 'animate-pulse' : ''}`} aria-hidden="true" />
       {s.label}
     </span>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -28,18 +28,18 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     if (this.state.hasError) {
       if (this.props.fallback) return this.props.fallback
       return (
-        <div className="min-h-screen bg-gray-950 flex items-center justify-center p-4">
-          <div className="bg-gray-900 border border-gray-800 rounded-xl p-8 max-w-md w-full text-center">
-            <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-red-900/30 flex items-center justify-center">
-              <svg className="w-8 h-8 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center p-4">
+          <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-8 max-w-md w-full text-center">
+            <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+              <svg className="w-8 h-8 text-red-500 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
               </svg>
             </div>
-            <h2 className="text-xl font-bold text-white mb-2">Something went wrong</h2>
-            <p className="text-sm text-gray-500 mb-6">{this.state.error?.message ?? 'An unexpected error occurred.'}</p>
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">Something went wrong</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-500 mb-6">{this.state.error?.message ?? 'An unexpected error occurred.'}</p>
             <button
               onClick={() => window.location.reload()}
-              className="px-6 py-2.5 bg-cyan-500/10 border border-cyan-500/30 text-cyan-400 rounded-lg text-sm font-medium hover:bg-cyan-500/20 transition-colors cursor-pointer"
+              className="px-6 py-2.5 bg-cyan-500/10 border border-cyan-500/30 text-cyan-600 dark:text-cyan-400 rounded-lg text-sm font-medium hover:bg-cyan-500/20 transition-colors cursor-pointer"
             >
               Reload page
             </button>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,24 +1,50 @@
 import { useState, type ReactNode } from 'react'
 import { Link, useLocation } from 'react-router-dom'
+import { useTheme } from '../hooks/useTheme'
 
-const NAV_ITEMS = [
-  { path: '/', label: 'Dashboard' },
-]
+const NAV_ITEMS = [{ path: '/', label: 'Dashboard' }]
+
+function SunIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 3v1m0 16v1m8.66-9h-1M4.34 12h-1m15.07-6.07-.71.71M6.34 17.66l-.71.71m12.73 0-.71-.71M6.34 6.34l-.71-.71M12 7a5 5 0 100 10A5 5 0 0012 7z"
+      />
+    </svg>
+  )
+}
+
+function MoonIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"
+      />
+    </svg>
+  )
+}
 
 export function Layout({ children }: { children: ReactNode }) {
   const location = useLocation()
   const [menuOpen, setMenuOpen] = useState(false)
+  const { theme, toggleTheme } = useTheme()
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <nav className="border-b border-gray-800 bg-gray-900/80 backdrop-blur-sm sticky top-0 z-50">
+    <div className="min-h-screen flex flex-col bg-white dark:bg-gray-950 transition-colors duration-200">
+      <nav className="border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             <Link to="/" className="flex items-center gap-3">
               <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-cyan-400 to-blue-600 flex items-center justify-center text-xs font-bold text-white">
                 O
               </div>
-              <span className="font-semibold text-lg hidden sm:block">
+              <span className="font-semibold text-lg hidden sm:block text-gray-900 dark:text-white">
                 Stellar Oracle
               </span>
             </Link>
@@ -30,8 +56,8 @@ export function Layout({ children }: { children: ReactNode }) {
                   to={item.path}
                   className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                     location.pathname === item.path
-                      ? 'bg-gray-800 text-cyan-400'
-                      : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/50'
+                      ? 'bg-gray-100 dark:bg-gray-800 text-cyan-600 dark:text-cyan-400'
+                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800/50'
                   }`}
                 >
                   {item.label}
@@ -39,19 +65,29 @@ export function Layout({ children }: { children: ReactNode }) {
               ))}
             </div>
 
-            <button
-              onClick={() => setMenuOpen(!menuOpen)}
-              className="sm:hidden p-2 rounded-lg text-gray-400 hover:text-gray-200 hover:bg-gray-800"
-              aria-label="Toggle menu"
-            >
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                {menuOpen ? (
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                ) : (
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                )}
-              </svg>
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={toggleTheme}
+                className="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+              >
+                {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
+              </button>
+
+              <button
+                onClick={() => setMenuOpen(!menuOpen)}
+                className="sm:hidden p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+                aria-label="Toggle menu"
+              >
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  {menuOpen ? (
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  ) : (
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                  )}
+                </svg>
+              </button>
+            </div>
           </div>
 
           {menuOpen && (
@@ -63,8 +99,8 @@ export function Layout({ children }: { children: ReactNode }) {
                   onClick={() => setMenuOpen(false)}
                   className={`block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                     location.pathname === item.path
-                      ? 'bg-gray-800 text-cyan-400'
-                      : 'text-gray-400 hover:text-gray-200'
+                      ? 'bg-gray-100 dark:bg-gray-800 text-cyan-600 dark:text-cyan-400'
+                      : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
                   }`}
                 >
                   {item.label}
@@ -79,8 +115,8 @@ export function Layout({ children }: { children: ReactNode }) {
         {children}
       </main>
 
-      <footer className="border-t border-gray-800 py-6 text-center text-sm text-gray-500">
-        Stellar Unified Price Oracle &middot; Developer Portal & Analytics Dashboard
+      <footer className="border-t border-gray-200 dark:border-gray-800 py-6 text-center text-sm text-gray-400 dark:text-gray-500">
+        Stellar Unified Price Oracle &middot; Developer Portal &amp; Analytics Dashboard
       </footer>
     </div>
   )

--- a/src/components/NetworkStatusBanner.tsx
+++ b/src/components/NetworkStatusBanner.tsx
@@ -7,13 +7,13 @@ export function NetworkStatusBanner() {
 
   return (
     <div className="fixed bottom-4 right-4 z-50" role="alert">
-      <div className="bg-yellow-900/90 border border-yellow-700/50 backdrop-blur-sm rounded-xl px-4 py-3 shadow-lg shadow-black/30 flex items-center gap-3">
-        <svg className="w-5 h-5 text-yellow-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div className="bg-yellow-50 dark:bg-yellow-900/90 border border-yellow-200 dark:border-yellow-700/50 backdrop-blur-sm rounded-xl px-4 py-3 shadow-lg shadow-black/10 dark:shadow-black/30 flex items-center gap-3">
+        <svg className="w-5 h-5 text-yellow-500 dark:text-yellow-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
         <div>
-          <p className="text-sm font-medium text-yellow-300">No internet connection</p>
-          <p className="text-xs text-yellow-500">Data may be stale until you reconnect</p>
+          <p className="text-sm font-medium text-yellow-700 dark:text-yellow-300">No internet connection</p>
+          <p className="text-xs text-yellow-600 dark:text-yellow-500">Data may be stale until you reconnect</p>
         </div>
       </div>
     </div>

--- a/src/components/PriceCard.tsx
+++ b/src/components/PriceCard.tsx
@@ -3,10 +3,10 @@ import type { PriceData } from '../types'
 import { formatPrice, timeAgo } from '../utils/format'
 
 const SOURCE_COLORS: Record<string, string> = {
-  chainlink: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
-  redstone: 'bg-red-500/20 text-red-400 border-red-500/30',
-  band: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
-  reflector: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30',
+  chainlink: 'bg-blue-500/20 text-blue-600 dark:text-blue-400 border-blue-500/30',
+  redstone: 'bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/30',
+  band: 'bg-purple-500/20 text-purple-600 dark:text-purple-400 border-purple-500/30',
+  reflector: 'bg-cyan-500/20 text-cyan-600 dark:text-cyan-400 border-cyan-500/30',
 }
 
 interface PriceCardProps {
@@ -21,28 +21,28 @@ export const PriceCard = memo(function PriceCard({ price, onClick, isLive }: Pri
   return (
     <button
       onClick={onClick}
-      className="w-full text-left bg-gray-900 border border-gray-800 rounded-xl p-5 hover:border-gray-700 hover:bg-gray-900/80 transition-all shadow-lg shadow-black/20"
+      className="w-full text-left bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-5 hover:border-gray-300 dark:hover:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900/80 transition-all shadow-sm dark:shadow-lg dark:shadow-black/20"
       aria-label={`View details for ${price.assetPair}`}
     >
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-lg font-semibold text-gray-100">{price.assetPair}</h3>
+        <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">{price.assetPair}</h3>
         {isLive && <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" role="status" aria-label="Live data" />}
       </div>
 
-      <div className="text-3xl font-bold text-white mb-3 font-mono tracking-tight">
+      <div className="text-3xl font-bold text-gray-900 dark:text-white mb-3 font-mono tracking-tight">
         ${formatPrice(price.price)}
       </div>
 
-      <div className="flex items-center justify-between text-xs text-gray-500 mb-3">
+      <div className="flex items-center justify-between text-xs text-gray-400 dark:text-gray-500 mb-3">
         <span>Updated {timeAgo(price.timestamp)}</span>
-        <span className="text-cyan-400">{confidencePct}% confidence</span>
+        <span className="text-cyan-600 dark:text-cyan-400">{confidencePct}% confidence</span>
       </div>
 
       <div className="flex flex-wrap gap-1.5">
         {price.sources.map((src) => (
           <span
             key={src}
-            className={`px-2 py-0.5 rounded text-xs font-medium border ${SOURCE_COLORS[src] ?? 'bg-gray-800 text-gray-400 border-gray-700'}`}
+            className={`px-2 py-0.5 rounded text-xs font-medium border ${SOURCE_COLORS[src] ?? 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700'}`}
           >
             {src}
           </span>

--- a/src/components/PriceCardSkeleton.tsx
+++ b/src/components/PriceCardSkeleton.tsx
@@ -1,18 +1,18 @@
 export function PriceCardSkeleton() {
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl p-5 animate-pulse" aria-hidden="true">
+    <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-5 animate-pulse" aria-hidden="true">
       <div className="flex items-center justify-between mb-3">
-        <div className="h-5 w-28 bg-gray-800 rounded" />
-        <div className="h-2 w-2 rounded-full bg-gray-800" />
+        <div className="h-5 w-28 bg-gray-200 dark:bg-gray-800 rounded" />
+        <div className="h-2 w-2 rounded-full bg-gray-200 dark:bg-gray-800" />
       </div>
-      <div className="h-9 w-36 bg-gray-800 rounded mb-3" />
+      <div className="h-9 w-36 bg-gray-200 dark:bg-gray-800 rounded mb-3" />
       <div className="flex items-center justify-between mb-3">
-        <div className="h-3 w-20 bg-gray-800 rounded" />
-        <div className="h-3 w-24 bg-gray-800 rounded" />
+        <div className="h-3 w-20 bg-gray-200 dark:bg-gray-800 rounded" />
+        <div className="h-3 w-24 bg-gray-200 dark:bg-gray-800 rounded" />
       </div>
       <div className="flex gap-1.5">
-        <div className="h-5 w-16 bg-gray-800 rounded" />
-        <div className="h-5 w-16 bg-gray-800 rounded" />
+        <div className="h-5 w-16 bg-gray-200 dark:bg-gray-800 rounded" />
+        <div className="h-5 w-16 bg-gray-200 dark:bg-gray-800 rounded" />
       </div>
     </div>
   )

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -17,10 +17,26 @@ interface PriceChartProps {
   loading?: boolean
 }
 
+// Detect current theme from the html element class
+function isDarkMode() {
+  return document.documentElement.classList.contains('dark')
+}
+
 export const PriceChart = memo(function PriceChart({ data, pair, loading }: PriceChartProps) {
+  const dark = isDarkMode()
+
+  const colors = {
+    gridStroke: dark ? '#1f2937' : '#e5e7eb',
+    tickFill: dark ? '#6b7280' : '#9ca3af',
+    axisLine: dark ? '#1f2937' : '#e5e7eb',
+    tooltipBg: dark ? '#111827' : '#ffffff',
+    tooltipBorder: dark ? '#1f2937' : '#e5e7eb',
+    tooltipLabel: dark ? '#9ca3af' : '#6b7280',
+  }
+
   if (loading) {
     return (
-      <div className="h-80 bg-gray-900/50 border border-gray-800 rounded-xl flex items-center justify-center" role="status" aria-label="Loading chart">
+      <div className="h-80 bg-gray-100 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-800 rounded-xl flex items-center justify-center" role="status" aria-label="Loading chart">
         <div className="animate-spin w-8 h-8 border-2 border-cyan-400 border-t-transparent rounded-full" />
       </div>
     )
@@ -28,7 +44,7 @@ export const PriceChart = memo(function PriceChart({ data, pair, loading }: Pric
 
   if (!data.length) {
     return (
-      <div className="h-80 bg-gray-900/50 border border-gray-800 rounded-xl flex items-center justify-center text-gray-500">
+      <div className="h-80 bg-gray-100 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-800 rounded-xl flex items-center justify-center text-gray-400 dark:text-gray-500">
         No historical data available
       </div>
     )
@@ -45,8 +61,8 @@ export const PriceChart = memo(function PriceChart({ data, pair, loading }: Pric
   const pad = (maxP - minP) * 0.1 || maxP * 0.05
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
-      <h3 className="text-sm font-medium text-gray-400 mb-4">{pair} Price History</h3>
+    <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-4">
+      <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-4">{pair} Price History</h3>
       <div className="h-80">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={chartData}>
@@ -56,16 +72,16 @@ export const PriceChart = memo(function PriceChart({ data, pair, loading }: Pric
                 <stop offset="100%" stopColor="#22d3ee" stopOpacity={0} />
               </linearGradient>
             </defs>
-            <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+            <CartesianGrid strokeDasharray="3 3" stroke={colors.gridStroke} />
             <XAxis
               dataKey="time"
-              tick={{ fill: '#6b7280', fontSize: 11 }}
-              axisLine={{ stroke: '#1f2937' }}
+              tick={{ fill: colors.tickFill, fontSize: 11 }}
+              axisLine={{ stroke: colors.axisLine }}
               tickLine={false}
             />
             <YAxis
               domain={[minP - pad, maxP + pad]}
-              tick={{ fill: '#6b7280', fontSize: 11 }}
+              tick={{ fill: colors.tickFill, fontSize: 11 }}
               axisLine={false}
               tickLine={false}
               tickFormatter={formatPriceShort}
@@ -73,12 +89,12 @@ export const PriceChart = memo(function PriceChart({ data, pair, loading }: Pric
             />
             <Tooltip
               contentStyle={{
-                background: '#111827',
-                border: '1px solid #1f2937',
+                background: colors.tooltipBg,
+                border: `1px solid ${colors.tooltipBorder}`,
                 borderRadius: '8px',
                 fontSize: '13px',
               }}
-              labelStyle={{ color: '#9ca3af' }}
+              labelStyle={{ color: colors.tooltipLabel }}
               formatter={(value: number) => [`$${formatPriceShort(value)}`, pair]}
               labelFormatter={(label) => `Time: ${label}`}
             />

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useState, useEffect } from 'react'
 import {
   AreaChart,
   Area,
@@ -17,13 +17,18 @@ interface PriceChartProps {
   loading?: boolean
 }
 
-// Detect current theme from the html element class
-function isDarkMode() {
-  return document.documentElement.classList.contains('dark')
-}
-
 export const PriceChart = memo(function PriceChart({ data, pair, loading }: PriceChartProps) {
-  const dark = isDarkMode()
+  const [dark, setDark] = useState(() =>
+    document.documentElement.classList.contains('dark'),
+  )
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setDark(document.documentElement.classList.contains('dark'))
+    })
+    observer.observe(document.documentElement, { attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
 
   const colors = {
     gridStroke: dark ? '#1f2937' : '#e5e7eb',

--- a/src/components/SourceHealthBadge.tsx
+++ b/src/components/SourceHealthBadge.tsx
@@ -11,7 +11,7 @@ interface SourceHealthProps {
 
 export function SourceHealthBadge({ sources }: SourceHealthProps) {
   if (!sources.length) {
-    return <span className="text-xs text-gray-500">No sources</span>
+    return <span className="text-xs text-gray-400 dark:text-gray-500">No sources</span>
   }
 
   return (
@@ -22,7 +22,7 @@ export function SourceHealthBadge({ sources }: SourceHealthProps) {
         return (
           <span
             key={src}
-            className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium border border-gray-700 text-gray-300 bg-gray-800"
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-800"
           >
             <span className={`w-1.5 h-1.5 rounded-full ${info.color}`} />
             {info.label}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react'
+
+export type Theme = 'dark' | 'light'
+
+const STORAGE_KEY = 'stellar-oracle-theme'
+
+function getInitialTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null
+    if (stored === 'dark' || stored === 'light') return stored
+  } catch {
+    // localStorage unavailable
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme)
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (theme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, theme)
+    } catch {
+      // localStorage unavailable
+    }
+  }, [theme])
+
+  const toggleTheme = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'))
+
+  return { theme, toggleTheme }
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -11,7 +11,11 @@ function getInitialTheme(): Theme {
   } catch {
     // localStorage unavailable
   }
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  try {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  } catch {
+    return 'dark'
+  }
 }
 
 export function useTheme() {

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@variant dark (&:where(.dark, .dark *));
 
 :root {
   font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
@@ -9,6 +10,11 @@
 body {
   margin: 0;
   min-height: 100vh;
+  background-color: #ffffff;
+  color: #111827;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
 }
 
 * {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -39,8 +39,8 @@ export function Dashboard() {
       <NetworkStatusBanner />
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-2xl font-bold text-white">Price Oracle Dashboard</h1>
-          <p className="text-sm text-gray-500 mt-1">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Price Oracle Dashboard</h1>
+          <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">
             Aggregated from Chainlink, Redstone, Band &amp; Reflector
           </p>
         </div>
@@ -48,7 +48,7 @@ export function Dashboard() {
       </div>
 
       {error && (
-        <div className="mb-6 p-4 bg-red-900/30 border border-red-800 rounded-xl text-sm text-red-400" role="alert">
+        <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-xl text-sm text-red-600 dark:text-red-400" role="alert">
           {error}
         </div>
       )}
@@ -73,7 +73,7 @@ export function Dashboard() {
       )}
 
       {!loading && merged.length === 0 && (
-        <div className="text-center py-32 text-gray-500">
+        <div className="text-center py-32 text-gray-400 dark:text-gray-500">
           <p className="text-lg mb-2">No price feeds available</p>
           <p className="text-sm">Connect to the aggregator API to see price data.</p>
         </div>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -3,11 +3,11 @@ import { Link } from 'react-router-dom'
 export function NotFound() {
   return (
     <div className="flex flex-col items-center justify-center py-32 text-center">
-      <h1 className="text-6xl font-bold text-gray-800 mb-4">404</h1>
-      <p className="text-lg text-gray-500 mb-8">Page not found</p>
+      <h1 className="text-6xl font-bold text-gray-200 dark:text-gray-800 mb-4">404</h1>
+      <p className="text-lg text-gray-400 dark:text-gray-500 mb-8">Page not found</p>
       <Link
         to="/"
-        className="px-6 py-2.5 bg-cyan-500/10 border border-cyan-500/30 text-cyan-400 rounded-lg text-sm font-medium hover:bg-cyan-500/20 transition-colors"
+        className="px-6 py-2.5 bg-cyan-500/10 border border-cyan-500/30 text-cyan-600 dark:text-cyan-400 rounded-lg text-sm font-medium hover:bg-cyan-500/20 transition-colors"
       >
         Back to Dashboard
       </Link>

--- a/src/pages/PriceDetail.tsx
+++ b/src/pages/PriceDetail.tsx
@@ -34,7 +34,7 @@ export function PriceDetail() {
     <div>
       <button
         onClick={() => navigate('/')}
-        className="mb-6 text-sm text-gray-500 hover:text-gray-300 transition-colors flex items-center gap-1 cursor-pointer"
+        className="mb-6 text-sm text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors flex items-center gap-1 cursor-pointer"
         type="button"
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -44,40 +44,40 @@ export function PriceDetail() {
       </button>
 
       {priceData && (
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6 mb-8">
+        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6 mb-8">
           <div className="flex items-start justify-between mb-6">
             <div>
               <div className="flex items-center gap-3 mb-1">
-                <h1 className="text-2xl font-bold text-white">{decodedPair}</h1>
+                <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{decodedPair}</h1>
                 {livePrices.has(decodedPair) && (
                   <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
                 )}
               </div>
-              <p className="text-sm text-gray-500">
+              <p className="text-sm text-gray-400 dark:text-gray-500">
                 Last updated: {formatTimestamp(priceData.timestamp)}
               </p>
             </div>
             <div className="flex items-center gap-3">
-              <span className="text-sm text-cyan-400">
+              <span className="text-sm text-cyan-600 dark:text-cyan-400">
                 {(priceData.confidence * 100).toFixed(1)}% confidence
               </span>
               <ConnectionBadge status={status} />
             </div>
           </div>
 
-          <div className="text-5xl font-bold text-white mb-4 font-mono tracking-tight">
+          <div className="text-5xl font-bold text-gray-900 dark:text-white mb-4 font-mono tracking-tight">
             ${formatPrice(priceData.price)}
           </div>
 
           <div>
-            <p className="text-xs text-gray-500 mb-2">Oracle Sources</p>
+            <p className="text-xs text-gray-400 dark:text-gray-500 mb-2">Oracle Sources</p>
             <SourceHealthBadge sources={priceData.sources} />
           </div>
         </div>
       )}
 
       {!priceData && (
-        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6 mb-8 flex items-center justify-center text-gray-500">
+        <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl p-6 mb-8 flex items-center justify-center text-gray-400 dark:text-gray-500">
           {historyLoading ? (
             <div className="animate-spin w-8 h-8 border-2 border-cyan-400 border-t-transparent rounded-full" role="status" aria-label="Loading" />
           ) : (

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -7,3 +7,18 @@ class ResizeObserverMock {
 }
 
 window.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver
+
+// matchMedia is not implemented in jsdom
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+})


### PR DESCRIPTION
Closes #4

---

- Add useTheme hook with localStorage persistence and prefers-color-scheme fallback
- Add sun/moon toggle button in nav bar (desktop + mobile)
- Configure Tailwind 4 class-based dark mode via @variant dark
- Add anti-flash inline script in index.html to apply theme before React mounts
- Update all components with dark: variant classes for both themes
- Add smooth 200ms transition on theme switch
- Update color-scheme meta tag to support dark light