### PR TITLE
feat: add search and filter bar for asset pairs (resolves #1)

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,0 +1,136 @@
+import { useSearchParams } from 'react-router-dom'
+import { useCallback } from 'react'
+
+export function FilterBar() {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const search = searchParams.get('search') || ''
+  const confidence = searchParams.get('confidence') || 'all'
+  const source = searchParams.get('source') || 'all'
+
+  const handleSearchChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        if (e.target.value) {
+          next.set('search', e.target.value)
+        } else {
+          next.delete('search')
+        }
+        return next
+      })
+    },
+    [setSearchParams]
+  )
+
+  const handleConfidenceChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        if (e.target.value !== 'all') {
+          next.set('confidence', e.target.value)
+        } else {
+          next.delete('confidence')
+        }
+        return next
+      })
+    },
+    [setSearchParams]
+  )
+
+  const handleSourceChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev)
+        if (e.target.value !== 'all') {
+          next.set('source', e.target.value)
+        } else {
+          next.delete('source')
+        }
+        return next
+      })
+    },
+    [setSearchParams]
+  )
+
+  const handleClearFilters = useCallback(() => {
+    setSearchParams(new URLSearchParams())
+  }, [setSearchParams])
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-4 mb-6 shadow-lg shadow-black/20 flex flex-col md:flex-row gap-4 items-end md:items-center">
+      <div className="flex-1 w-full relative">
+        <label htmlFor="search" className="block text-sm font-medium text-gray-400 mb-1.5">
+          Search Asset Pair
+        </label>
+        <div className="relative">
+          <input
+            id="search"
+            type="text"
+            value={search}
+            onChange={handleSearchChange}
+            placeholder="e.g. XLM"
+            className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-2 focus:outline-none focus:border-cyan-500 focus:ring-1 focus:ring-cyan-500 transition-colors pl-10"
+          />
+          <svg
+            className="absolute left-3 top-2.5 h-5 w-5 text-gray-500"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </div>
+      </div>
+
+      <div className="w-full md:w-48">
+        <label htmlFor="confidence" className="block text-sm font-medium text-gray-400 mb-1.5">
+          Confidence
+        </label>
+        <select
+          id="confidence"
+          value={confidence}
+          onChange={handleConfidenceChange}
+          className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-3 py-2 focus:outline-none focus:border-cyan-500 focus:ring-1 focus:ring-cyan-500 transition-colors appearance-none"
+        >
+          <option value="all">All Confidence</option>
+          <option value="high">High (&gt;80%)</option>
+          <option value="medium">Medium (&gt;50%)</option>
+        </select>
+      </div>
+
+      <div className="w-full md:w-48">
+        <label htmlFor="source" className="block text-sm font-medium text-gray-400 mb-1.5">
+          Oracle Source
+        </label>
+        <select
+          id="source"
+          value={source}
+          onChange={handleSourceChange}
+          className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-3 py-2 focus:outline-none focus:border-cyan-500 focus:ring-1 focus:ring-cyan-500 transition-colors appearance-none capitalize"
+        >
+          <option value="all">All Sources</option>
+          <option value="chainlink">Chainlink</option>
+          <option value="redstone">Redstone</option>
+          <option value="band">Band</option>
+          <option value="reflector">Reflector</option>
+        </select>
+      </div>
+
+      <div className="w-full md:w-auto">
+        <button
+          onClick={handleClearFilters}
+          className="w-full mt-6 md:w-auto px-4 py-2 bg-gray-800 hover:bg-gray-700 border border-gray-700 text-gray-300 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-gray-600"
+          aria-label="Clear all filters"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,11 +1,12 @@
 import { useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { usePrices } from '../hooks/usePrices'
 import { useWebSocket } from '../hooks/useWebSocket'
 import { PriceCard } from '../components/PriceCard'
 import { PriceCardSkeleton } from '../components/PriceCardSkeleton'
 import { ConnectionBadge } from '../components/ConnectionBadge'
 import { NetworkStatusBanner } from '../components/NetworkStatusBanner'
+import { FilterBar } from '../components/FilterBar'
 
 function mergePrices(
   restPrices: { assetPair: string; price: number; timestamp: number; confidence: number; sources: string[] }[],
@@ -24,8 +25,25 @@ export function Dashboard() {
   const { prices, loading, error } = usePrices()
   const { livePrices, status } = useWebSocket(prices.map((p) => p.assetPair))
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
 
-  const merged = mergePrices(prices, livePrices)
+  const search = searchParams.get('search') || ''
+  const confidence = searchParams.get('confidence') || 'all'
+  const source = searchParams.get('source') || 'all'
+
+  let merged = mergePrices(prices, livePrices)
+
+  if (search) {
+    merged = merged.filter((p) => p.assetPair.toLowerCase().includes(search.toLowerCase()))
+  }
+  if (confidence === 'high') {
+    merged = merged.filter((p) => p.confidence >= 0.8)
+  } else if (confidence === 'medium') {
+    merged = merged.filter((p) => p.confidence >= 0.5)
+  }
+  if (source !== 'all') {
+    merged = merged.filter((p) => p.sources.some((s) => s.toLowerCase() === source.toLowerCase()))
+  }
 
   const handleCardClick = useCallback(
     (pair: string) => navigate(`/price/${encodeURIComponent(pair)}`),
@@ -46,6 +64,8 @@ export function Dashboard() {
         </div>
         <ConnectionBadge status={status} />
       </div>
+
+      <FilterBar />
 
       {error && (
         <div className="mb-6 p-4 bg-red-900/30 border border-red-800 rounded-xl text-sm text-red-400" role="alert">


### PR DESCRIPTION
# Description

This PR resolves issue #1 by introducing a comprehensive Search and Filter Bar to the price oracle dashboard. It allows users to quickly locate specific asset pairs, filter out low-confidence prices, and narrow down feeds by their respective oracle sources.

closes #1 

## Changes Made
- **FilterBar Component**: Added a new responsive `FilterBar` component to the dashboard to handle all filtering logic.
- **Search by Name**: Added a text input that filters the asset pair name based on a case-insensitive match.
- **Confidence Filter**: Added a dropdown to filter prices based on their confidence score (High `>80%`, Medium `>50%`, or All).
- **Source Filter**: Added a dropdown to filter pairs by the data source (Chainlink, Redstone, Band, Reflector).
- **URL Synchronization**: Leveraged `useSearchParams` from `react-router-dom` to tie the filter state to the URL. This allows users to bookmark and share specific filtered views (e.g., `?search=XLM&source=chainlink`).
- **Clear Filters**: Included a quick "Clear" button to easily revert the dashboard back to its default state.

## Verification
- Verified text search, confidence boundaries, and source matching logic.
- Ensured the UI seamlessly matches the existing dark-theme aesthetic and remains responsive on mobile devices using Tailwind CSS flex utilities.
- Tested URL behavior when reloading the page to confirm that the dashboard automatically loads the correct filtered view.
