### PR TITLE
Virtualized dashboard + Core Web Vitals reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_API_URL=http://localhost:3000
 VITE_WS_URL=ws://localhost:3000
+VITE_ANALYTICS_URL=

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "stellar-oracle-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.14.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.5.0",
-        "recharts": "^2.15.3"
+        "recharts": "^2.15.3",
+        "web-vitals": "^4.2.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.24.0",
@@ -1813,6 +1815,33 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -6043,6 +6072,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "prepare": "husky || true"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.14.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.5.0",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "web-vitals": "^4.2.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Layout } from './components/Layout'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { Dashboard } from './pages/Dashboard'
 import { NotFound } from './pages/NotFound'
+import { useWebVitals } from './hooks/useWebVitals'
 
 const PriceDetail = lazy(() =>
   import('./pages/PriceDetail').then((m) => ({ default: m.PriceDetail })),
@@ -18,6 +19,8 @@ function PriceDetailLoader() {
 }
 
 export default function App() {
+  useWebVitals()
+
   return (
     <BrowserRouter>
       <ErrorBoundary>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Layout } from './components/Layout'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { Dashboard } from './pages/Dashboard'
 import { NotFound } from './pages/NotFound'
+import { useWebVitals } from './hooks/useWebVitals'
 import { PreferencesProvider } from './preferences/PreferencesContext'
 
 const PriceDetail = lazy(() =>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,4 +4,5 @@ export const config = {
   refreshInterval: 10_000,
   wsReconnectDelay: 3_000,
   wsBroadcastInterval: 5_000,
+  analyticsEndpoint: import.meta.env.VITE_ANALYTICS_URL ?? '',
 } as const

--- a/src/hooks/useColumnCount.ts
+++ b/src/hooks/useColumnCount.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react'
+
+const BREAKPOINTS = [
+  { minWidth: 1280, columns: 4 },
+  { minWidth: 1024, columns: 3 },
+  { minWidth: 640, columns: 2 },
+  { minWidth: 0, columns: 1 },
+] as const
+
+export function useColumnCount(ref: React.RefObject<HTMLDivElement | null>): number {
+  const [columns, setColumns] = useState(4)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? 0
+      const match = BREAKPOINTS.find((bp) => width >= bp.minWidth)
+      setColumns(match?.columns ?? 1)
+    })
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [ref])
+
+  return columns
+}

--- a/src/hooks/useWebVitals.test.tsx
+++ b/src/hooks/useWebVitals.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { useWebVitals } from './useWebVitals'
+
+let mockAnalyticsEndpoint = ''
+
+vi.mock('../config', () => ({
+  config: {
+    apiUrl: '',
+    wsUrl: '',
+    refreshInterval: 10_000,
+    wsReconnectDelay: 3_000,
+    wsBroadcastInterval: 5_000,
+    get analyticsEndpoint() {
+      return mockAnalyticsEndpoint
+    },
+  },
+}))
+
+const mocks = {
+  onLCP: vi.fn(),
+  onFID: vi.fn(),
+  onCLS: vi.fn(),
+  onINP: vi.fn(),
+  onFCP: vi.fn(),
+  onTTFB: vi.fn(),
+  sendBeacon: vi.fn().mockReturnValue(true),
+  ric: vi.fn().mockImplementation((cb: () => void) => cb()),
+}
+
+vi.mock('web-vitals', () => ({
+  onLCP: (...args: unknown[]) => mocks.onLCP(...args),
+  onFID: (...args: unknown[]) => mocks.onFID(...args),
+  onCLS: (...args: unknown[]) => mocks.onCLS(...args),
+  onINP: (...args: unknown[]) => mocks.onINP(...args),
+  onFCP: (...args: unknown[]) => mocks.onFCP(...args),
+  onTTFB: (...args: unknown[]) => mocks.onTTFB(...args),
+}))
+
+function TestComponent() {
+  useWebVitals()
+  return null
+}
+
+function createMetric(overrides: Partial<{ name: string; value: number; rating: string; delta: number; id: string }> = {}) {
+  return {
+    name: 'LCP',
+    value: 1500,
+    rating: 'good',
+    delta: 0,
+    id: 'v1',
+    entries: [],
+    navigationType: 'navigate' as const,
+    ...overrides,
+  }
+}
+
+function readBlobText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = reject
+    reader.readAsText(blob)
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockAnalyticsEndpoint = ''
+  vi.stubGlobal('navigator', {
+    doNotTrack: undefined,
+    sendBeacon: mocks.sendBeacon,
+    connection: { effectiveType: '4g' },
+  })
+  vi.stubGlobal('requestIdleCallback', mocks.ric)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('useWebVitals', () => {
+  it('registers all web-vital observers on mount', () => {
+    render(<TestComponent />)
+    expect(mocks.onLCP).toHaveBeenCalledTimes(1)
+    expect(mocks.onFID).toHaveBeenCalledTimes(1)
+    expect(mocks.onCLS).toHaveBeenCalledTimes(1)
+    expect(mocks.onINP).toHaveBeenCalledTimes(1)
+    expect(mocks.onFCP).toHaveBeenCalledTimes(1)
+    expect(mocks.onTTFB).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends report via sendBeacon when analytics endpoint is configured', async () => {
+    mockAnalyticsEndpoint = 'https://analytics.example.com/vitals'
+
+    render(<TestComponent />)
+
+    const callback = mocks.onLCP.mock.calls[0][0]
+    callback(createMetric({ name: 'LCP', value: 2500, rating: 'needs-improvement' }))
+
+    expect(mocks.sendBeacon).toHaveBeenCalledTimes(1)
+    const [url, blob] = mocks.sendBeacon.mock.calls[0]
+    expect(url).toBe('https://analytics.example.com/vitals')
+    const body = JSON.parse(await readBlobText(blob as Blob))
+    expect(body.name).toBe('LCP')
+    expect(body.value).toBe(2500)
+    expect(body.rating).toBe('needs-improvement')
+    expect(body.route).toBe('/')
+    expect(body.viewport).toBe('1024x768')
+    expect(body.connection).toBe('4g')
+  })
+
+  it('does not call sendBeacon when analytics endpoint is empty', () => {
+    render(<TestComponent />)
+
+    const callback = mocks.onLCP.mock.calls[0][0]
+    callback(createMetric())
+
+    expect(mocks.sendBeacon).not.toHaveBeenCalled()
+  })
+
+  it('respects Do Not Track', () => {
+    vi.stubGlobal('navigator', {
+      doNotTrack: '1',
+      sendBeacon: mocks.sendBeacon,
+    })
+
+    render(<TestComponent />)
+
+    expect(mocks.onLCP).not.toHaveBeenCalled()
+    expect(mocks.sendBeacon).not.toHaveBeenCalled()
+  })
+
+  it('respects Global Privacy Control', () => {
+    vi.stubGlobal('navigator', {
+      doNotTrack: undefined,
+      globalPrivacyControl: true,
+      sendBeacon: mocks.sendBeacon,
+    })
+
+    render(<TestComponent />)
+
+    expect(mocks.onLCP).not.toHaveBeenCalled()
+    expect(mocks.sendBeacon).not.toHaveBeenCalled()
+  })
+
+  it('handles missing connection API gracefully', () => {
+    vi.stubGlobal('navigator', {
+      doNotTrack: undefined,
+      sendBeacon: mocks.sendBeacon,
+      connection: undefined,
+    })
+
+    render(<TestComponent />)
+
+    const callback = mocks.onLCP.mock.calls[0][0]
+    expect(() => callback(createMetric())).not.toThrow()
+  })
+
+  it('falls back to setTimeout when requestIdleCallback is unavailable', () => {
+    vi.stubGlobal('requestIdleCallback', undefined)
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
+
+    render(<TestComponent />)
+
+    const callback = mocks.onLCP.mock.calls[0][0]
+    callback(createMetric())
+
+    expect(setTimeoutSpy).toHaveBeenCalled()
+    setTimeoutSpy.mockRestore()
+  })
+})

--- a/src/hooks/useWebVitals.ts
+++ b/src/hooks/useWebVitals.ts
@@ -1,0 +1,85 @@
+import { useEffect } from 'react'
+import { onLCP, onFID, onCLS, onINP, onFCP, onTTFB } from 'web-vitals'
+import type { Metric } from 'web-vitals'
+import { config } from '../config'
+
+interface WebVitalReport {
+  name: string
+  value: number
+  rating: string
+  delta: number
+  id: string
+  route: string
+  viewport: string
+  connection: string | null
+}
+
+function shouldTrack(): boolean {
+  if (navigator.doNotTrack === '1') return false
+  if ((navigator as Navigator & { globalPrivacyControl?: boolean }).globalPrivacyControl) return false
+  return true
+}
+
+function getConnectionType(): string | null {
+  const conn = (navigator as Navigator & { connection?: { effectiveType?: string } }).connection
+  return conn?.effectiveType ?? null
+}
+
+function sendToAnalytics(report: WebVitalReport) {
+  const body = JSON.stringify(report)
+
+  if (config.analyticsEndpoint) {
+    const blob = new Blob([body], { type: 'application/json' })
+    navigator.sendBeacon(config.analyticsEndpoint, blob)
+  }
+
+  if (import.meta.env.DEV) {
+    const ratingColor =
+      report.rating === 'good' ? '#4caf50' : report.rating === 'needs-improvement' ? '#ff9800' : '#f44336'
+
+    console.log(
+      `%c[Web Vitals]%c ${report.name} %c${report.rating} %c${report.value.toFixed(2)}`,
+      'color:#888',
+      'color:#fff;font-weight:bold',
+      `color:${ratingColor}`,
+      'color:#64b5f6',
+      report,
+    )
+  }
+}
+
+export function useWebVitals() {
+  useEffect(() => {
+    if (!shouldTrack()) return
+
+    const reportMetric = (metric: Metric) => {
+      const task = () => {
+        sendToAnalytics({
+          name: metric.name,
+          value: metric.value,
+          rating: metric.rating,
+          delta: metric.delta,
+          id: metric.id,
+          route: window.location.pathname,
+          viewport: `${window.innerWidth}x${window.innerHeight}`,
+          connection: getConnectionType(),
+        })
+      }
+
+      if (typeof requestIdleCallback === 'function') {
+        requestIdleCallback(task)
+      } else {
+        setTimeout(task, 0)
+      }
+    }
+
+    onLCP(reportMetric)
+    onFID(reportMetric)
+    onCLS(reportMetric)
+    onINP(reportMetric)
+    onFCP(reportMetric)
+    onTTFB(reportMetric)
+  }, [])
+}
+
+export type { WebVitalReport }

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -3,6 +3,21 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { Dashboard } from './Dashboard'
 
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count, estimateSize }: { count: number; estimateSize: (i: number) => number }) => {
+    const items = Array.from({ length: count }, (_, i) => {
+      const size = estimateSize(i)
+      const start = i * size
+      return { key: i, index: i, start, end: start + size, size, lane: 0 }
+    })
+    return {
+      getVirtualItems: () => items,
+      getTotalSize: () => items.reduce((total, item) => total + item.size, 0),
+      measure: () => {},
+    }
+  },
+}))
+
 afterEach(cleanup)
 
 vi.mock('../hooks/usePrices', () => ({

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { usePriceContext } from '../context/PriceContext'
 import { useAlerts } from '../hooks/useAlerts'
+import { useColumnCount } from '../hooks/useColumnCount'
 import { PriceCard } from '../components/PriceCard'
 import { PriceCardSkeleton } from '../components/PriceCardSkeleton'
 import { AlertModal } from '../components/AlertModal'
@@ -47,6 +49,14 @@ export function Dashboard() {
     [merged, searchQuery],
   )
 
+  const rowCount = Math.ceil(filtered.length / columns)
+  const virtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: useCallback(() => document.documentElement, []),
+    estimateSize: useCallback(() => ROW_HEIGHT, []),
+    overscan: 5,
+  })
+
   const handleCardClick = useCallback(
     (pair: string) => navigate(`/price/${encodeURIComponent(pair)}`),
     [navigate],
@@ -71,8 +81,6 @@ export function Dashboard() {
     },
     [addAlert],
   )
-
-  const SKELETON_COUNT = 8
 
   return (
     <div>
@@ -116,18 +124,48 @@ export function Dashboard() {
           ))}
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4" role="list" aria-label="Price feeds">
-          {filtered.map((p) => (
-            <PriceCard
-              key={p.assetPair}
-              price={p}
-              isLive={livePrices.has(p.assetPair)}
-              isStale={pricesValidating}
-              hasAlert={hasAlertsForPair(p.assetPair)}
-              onClick={() => handleCardClick(p.assetPair)}
-              onAlertClick={(e) => handleAlertClick(e, p.assetPair)}
-            />
-          ))}
+        <div
+          ref={containerRef}
+          style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }}
+          aria-label="Price feeds"
+        >
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const startIdx = virtualRow.index * columns
+            const rowItems = filtered.slice(startIdx, startIdx + columns)
+            return (
+              <div
+                key={virtualRow.key}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: `repeat(${columns}, 1fr)`,
+                    gap: '1rem',
+                  }}
+                  role="list"
+                >
+                  {rowItems.map((p) => (
+                    <PriceCard
+                      key={p.assetPair}
+                      price={p}
+                      isLive={livePrices.has(p.assetPair)}
+                      isStale={pricesValidating}
+                      hasAlert={hasAlertsForPair(p.assetPair)}
+                      onClick={() => handleCardClick(p.assetPair)}
+                      onAlertClick={(e) => handleAlertClick(e, p.assetPair)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )
+          })}
         </div>
       )}
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,11 +1,16 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { usePrices } from '../hooks/usePrices'
 import { useWebSocket } from '../hooks/useWebSocket'
+import { useColumnCount } from '../hooks/useColumnCount'
 import { PriceCard } from '../components/PriceCard'
 import { PriceCardSkeleton } from '../components/PriceCardSkeleton'
 import { ConnectionBadge } from '../components/ConnectionBadge'
 import { NetworkStatusBanner } from '../components/NetworkStatusBanner'
+
+const ROW_HEIGHT = 200
+const SKELETON_COUNT = 8
 
 function mergePrices(
   restPrices: { assetPair: string; price: number; timestamp: number; confidence: number; sources: string[] }[],
@@ -25,14 +30,23 @@ export function Dashboard() {
   const { livePrices, status } = useWebSocket(prices.map((p) => p.assetPair))
   const navigate = useNavigate()
 
+  const containerRef = useRef<HTMLDivElement>(null)
+  const columns = useColumnCount(containerRef)
+
   const merged = mergePrices(prices, livePrices)
+  const rowCount = Math.ceil(merged.length / columns)
+
+  const virtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: useCallback(() => window, []),
+    estimateSize: useCallback(() => ROW_HEIGHT, []),
+    overscan: 5,
+  })
 
   const handleCardClick = useCallback(
     (pair: string) => navigate(`/price/${encodeURIComponent(pair)}`),
     [navigate],
   )
-
-  const SKELETON_COUNT = 8
 
   return (
     <div>
@@ -59,20 +73,48 @@ export function Dashboard() {
             <PriceCardSkeleton key={i} />
           ))}
         </div>
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4" role="list" aria-label="Price feeds">
-          {merged.map((p) => (
-            <PriceCard
-              key={p.assetPair}
-              price={p}
-              isLive={livePrices.has(p.assetPair)}
-              onClick={() => handleCardClick(p.assetPair)}
-            />
-          ))}
+      ) : merged.length > 0 ? (
+        <div
+          ref={containerRef}
+          style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }}
+          aria-label="Price feeds"
+        >
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const startIdx = virtualRow.index * columns
+            const rowItems = merged.slice(startIdx, startIdx + columns)
+            return (
+              <div
+                key={virtualRow.key}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: `repeat(${columns}, 1fr)`,
+                    gap: '1rem',
+                  }}
+                  role="list"
+                >
+                  {rowItems.map((p) => (
+                    <PriceCard
+                      key={p.assetPair}
+                      price={p}
+                      isLive={livePrices.has(p.assetPair)}
+                      onClick={() => handleCardClick(p.assetPair)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )
+          })}
         </div>
-      )}
-
-      {!loading && merged.length === 0 && (
+      ) : (
         <div className="text-center py-32 text-gray-500">
           <p className="text-lg mb-2">No price feeds available</p>
           <p className="text-sm">Connect to the aggregator API to see price data.</p>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -38,7 +38,7 @@ export function Dashboard() {
 
   const virtualizer = useVirtualizer({
     count: rowCount,
-    getScrollElement: useCallback(() => window, []),
+    getScrollElement: useCallback(() => document.documentElement, []),
     estimateSize: useCallback(() => ROW_HEIGHT, []),
     overscan: 5,
   })

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_URL: string
   readonly VITE_WS_URL: string
+  readonly VITE_ANALYTICS_URL: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Closes #8 
Closes #16 
Closes #17 

## Changes

### Virtualized rendering
* Replace plain CSS grid with @tanstack/react-virtual for the asset pair grid
* Only visible rows (plus 5 overscan) are rendered as DOM nodes
* Dynamic column count via ResizeObserver matching existing Tailwind breakpoints
* New hook: useColumnCount

### Core Web Vitals reporting
* Measure LCP, FID, CLS, INP, FCP, TTFB via web-vitals v4
* Report includes route, viewport, connection type
* Respects Do Not Track / Global Privacy Control
* Sends to configurable VITE_ANALYTICS_URL endpoint via sendBeacon
* Uses requestIdleCallback to avoid runtime performance impact
* Logs to console in development
* New hook: useWebVitals, integrated at App root

### Verification
* All 85 tests pass (17 test files)
* TypeScript compiles with zero errors