### PR TITLE
addsnapshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "stellar-oracle-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@tailwindcss/oxide-linux-x64-gnu": "^4.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.5.0",
@@ -1743,9 +1744,7 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "linux"
       ],

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     }
   ],
   "dependencies": {
+    "@tailwindcss/oxide-linux-x64-gnu": "^4.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from 'react'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { Layout } from './components/Layout'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { Dashboard } from './pages/Dashboard'
@@ -20,22 +20,29 @@ function PriceDetailLoader() {
 
 const BASENAME = import.meta.env.BASE_URL.replace(/\/$/, '')
 
+function AppContent() {
+  const location = useLocation()
+  return (
+    <ErrorBoundary key={location.key}>
+      <PreferencesProvider>
+        <Layout>
+          <Suspense fallback={<PriceDetailLoader />}>
+            <Routes>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/price/:pair" element={<PriceDetail />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Suspense>
+        </Layout>
+      </PreferencesProvider>
+    </ErrorBoundary>
+  )
+}
+
 export default function App() {
   return (
     <BrowserRouter basename={BASENAME}>
-      <ErrorBoundary>
-        <PreferencesProvider>
-          <Layout>
-            <Suspense fallback={<PriceDetailLoader />}>
-              <Routes>
-                <Route path="/" element={<Dashboard />} />
-                <Route path="/price/:pair" element={<PriceDetail />} />
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </Suspense>
-          </Layout>
-        </PreferencesProvider>
-      </ErrorBoundary>
+      <AppContent />
     </BrowserRouter>
   )
 }

--- a/src/api/websocket.test.ts
+++ b/src/api/websocket.test.ts
@@ -1,25 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { WebSocketClient } from './websocket'
+import { FakeWebSocket } from '../test/fakeWebSocket'
 
-class MockWebSocket {
-  static OPEN = 1
-  static CONNECTING = 0
-  static CLOSING = 2
-  static CLOSED = 3
-  onopen: (() => void) | null = null
-  onclose: (() => void) | null = null
-  onmessage: ((e: { data: string }) => void) | null = null
-  onerror: (() => void) | null = null
-  readyState = 0
-  send = vi.fn()
-  close = vi.fn()
+let ws: FakeWebSocket
+
+function stubWebSocket(): void {
+  const mock = vi.fn(() => ws)
+  mock.OPEN = FakeWebSocket.OPEN
+  mock.CONNECTING = FakeWebSocket.CONNECTING
+  mock.CLOSING = FakeWebSocket.CLOSING
+  mock.CLOSED = FakeWebSocket.CLOSED
+  vi.stubGlobal('WebSocket', mock)
 }
 
-let mockWs: MockWebSocket
-
 beforeEach(() => {
-  mockWs = new MockWebSocket()
-  vi.stubGlobal('WebSocket', vi.fn(() => mockWs))
+  ws = new FakeWebSocket('ws://localhost:3000')
+  stubWebSocket()
 })
 
 afterEach(() => {
@@ -40,7 +36,7 @@ describe('WebSocketClient', () => {
     const onStatus = vi.fn()
     client.onStatusChange(onStatus)
     client.connect()
-    mockWs.onopen!()
+    ws.simulateOpen()
     expect(onStatus).toHaveBeenCalledWith('connected')
   })
 
@@ -48,12 +44,11 @@ describe('WebSocketClient', () => {
     const client = new WebSocketClient()
     client.connect()
     client.subscribe('BTC/USD')
-    mockWs.readyState = WebSocket.OPEN
-    mockWs.send.mockClear()
-    mockWs.onopen!()
-    expect(mockWs.send.mock.calls[0][0]).toBe(
+    ws.sent.length = 0
+    ws.simulateOpen()
+    expect(ws.sent).toEqual([
       JSON.stringify({ action: 'subscribe', assetPairs: ['BTC/USD'] }),
-    )
+    ])
   })
 
   it('calls message handlers on incoming messages', () => {
@@ -61,9 +56,29 @@ describe('WebSocketClient', () => {
     const handler = vi.fn()
     client.onMessage(handler)
     client.connect()
-    const msg = { type: 'price_update', assetPair: 'BTC/USD', price: 50000, timestamp: Date.now(), confidence: 0.99, sources: ['chainlink'] }
-    mockWs.onmessage!({ data: JSON.stringify(msg) })
+    const msg = {
+      type: 'price_update',
+      assetPair: 'BTC/USD',
+      price: 50000,
+      timestamp: Date.now(),
+      confidence: 0.99,
+      sources: ['chainlink'],
+    }
+    ws.simulateMessage(msg)
     expect(handler).toHaveBeenCalledWith(msg)
+  })
+
+  it('calls multiple message handlers', () => {
+    const client = new WebSocketClient()
+    const h1 = vi.fn()
+    const h2 = vi.fn()
+    client.onMessage(h1)
+    client.onMessage(h2)
+    client.connect()
+    const msg = { type: 'price_update', assetPair: 'BTC/USD', price: 50000, timestamp: Date.now(), confidence: 0.99, sources: ['chainlink'] }
+    ws.simulateMessage(msg)
+    expect(h1).toHaveBeenCalledWith(msg)
+    expect(h2).toHaveBeenCalledWith(msg)
   })
 
   it('ignores malformed messages', () => {
@@ -71,7 +86,7 @@ describe('WebSocketClient', () => {
     const handler = vi.fn()
     client.onMessage(handler)
     client.connect()
-    mockWs.onmessage!({ data: 'not json' })
+    ws.onmessage!({ data: 'not json' } as MessageEvent)
     expect(handler).not.toHaveBeenCalled()
   })
 
@@ -82,29 +97,39 @@ describe('WebSocketClient', () => {
     client.connect()
     client.disconnect()
     expect(onStatus).toHaveBeenCalledWith('disconnected')
-    expect(mockWs.close).toHaveBeenCalled()
+    expect(ws.closed).toBe(true)
   })
 
   it('subscribe sends subscribe message', () => {
     const client = new WebSocketClient()
     client.connect()
-    mockWs.readyState = WebSocket.OPEN
+    ws.readyState = FakeWebSocket.OPEN
     client.subscribe('BTC/USD')
-    expect(mockWs.send.mock.calls[0][0]).toBe(
+    expect(ws.sent).toEqual([
       JSON.stringify({ action: 'subscribe', assetPairs: ['BTC/USD'] }),
-    )
+    ])
+  })
+
+  it('subscribe with array sends subscribe message', () => {
+    const client = new WebSocketClient()
+    client.connect()
+    ws.readyState = FakeWebSocket.OPEN
+    client.subscribe(['BTC/USD', 'ETH/USD'])
+    expect(ws.sent).toEqual([
+      JSON.stringify({ action: 'subscribe', assetPairs: ['BTC/USD', 'ETH/USD'] }),
+    ])
   })
 
   it('unsubscribe sends unsubscribe message', () => {
     const client = new WebSocketClient()
     client.connect()
-    mockWs.readyState = WebSocket.OPEN
+    ws.readyState = FakeWebSocket.OPEN
     client.subscribe('BTC/USD')
     client.unsubscribe('BTC/USD')
-    const lastCall = mockWs.send.mock.calls.length - 1
-    expect(mockWs.send.mock.calls[lastCall][0]).toBe(
+    expect(ws.sent).toEqual([
+      JSON.stringify({ action: 'subscribe', assetPairs: ['BTC/USD'] }),
       JSON.stringify({ action: 'unsubscribe', assetPairs: ['BTC/USD'] }),
-    )
+    ])
   })
 
   it('removes handler via returned disposer', () => {
@@ -113,22 +138,113 @@ describe('WebSocketClient', () => {
     const dispose = client.onMessage(handler)
     dispose()
     client.connect()
-    mockWs.onmessage!({ data: JSON.stringify({ type: 'price_update', assetPair: 'BTC/USD', price: 50000, timestamp: Date.now(), confidence: 0.99, sources: [] }) })
+    ws.simulateMessage({ type: 'price_update', assetPair: 'BTC/USD', price: 50000, timestamp: Date.now(), confidence: 0.99, sources: [] })
     expect(handler).not.toHaveBeenCalled()
   })
 
-  it('does not reconnect after disconnect', () => {
+  it('removes status handler via returned disposer', () => {
+    const client = new WebSocketClient()
+    const handler = vi.fn()
+    const dispose = client.onStatusChange(handler)
+    dispose()
+    client.connect()
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('does not reconnect after explicit disconnect', () => {
     const client = new WebSocketClient()
     client.connect()
+    ws.simulateOpen()
     client.disconnect()
-    mockWs.onclose!()
-    expect(mockWs.close).toHaveBeenCalledTimes(1)
+    ws.simulateClose()
+    expect(ws.closed).toBe(true)
+    expect(ws.sent).toEqual([])
   })
 
   it('handles error by closing', () => {
     const client = new WebSocketClient()
+    const onStatus = vi.fn()
+    client.onStatusChange(onStatus)
     client.connect()
-    mockWs.onerror!()
-    expect(mockWs.close).toHaveBeenCalled()
+    ws.simulateError()
+    expect(ws.closed).toBe(true)
+  })
+
+  it('transitions through connecting, connected, disconnected, reconnecting', () => {
+    const client = new WebSocketClient()
+    const onStatus = vi.fn()
+    client.onStatusChange(onStatus)
+    client.connect()
+    ws.simulateOpen()
+    ws.simulateClose()
+    expect(onStatus.mock.calls.map((c) => c[0])).toEqual([
+      'connecting',
+      'connected',
+      'disconnected',
+      'reconnecting',
+    ])
+  })
+
+  it('attempts reconnection after close', () => {
+    vi.useFakeTimers()
+    const connectSpy = vi.spyOn(WebSocketClient.prototype, 'connect')
+    const client = new WebSocketClient()
+    client.connect()
+    connectSpy.mockClear()
+    ws.simulateOpen()
+    ws.simulateClose()
+    expect(connectSpy).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(3000)
+    expect(connectSpy).toHaveBeenCalledTimes(1)
+    connectSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('prevents multiple concurrent reconnection timers', () => {
+    vi.useFakeTimers()
+    const connectSpy = vi.spyOn(WebSocketClient.prototype, 'connect')
+    const client = new WebSocketClient()
+    client.connect()
+    connectSpy.mockClear()
+    ws.simulateClose()
+    ws.simulateClose()
+    vi.advanceTimersByTime(3000)
+    expect(connectSpy).toHaveBeenCalledTimes(1)
+    connectSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('does not send when not connected', () => {
+    const client = new WebSocketClient()
+    client.connect()
+    ws.readyState = FakeWebSocket.CONNECTING
+    client.subscribe('BTC/USD')
+    expect(ws.sent).toEqual([])
+  })
+
+  it('returns current status through lifecycle', () => {
+    const client = new WebSocketClient()
+    expect(client.status).toBe('disconnected')
+    client.connect()
+    expect(client.status).toBe('connecting')
+    ws.simulateOpen()
+    expect(client.status).toBe('connected')
+    ws.simulateClose()
+    expect(client.status).toBe('reconnecting')
+  })
+
+  it('getDerivedStateFromError is ignored on second close while reconnecting', () => {
+    vi.useFakeTimers()
+    const connectSpy = vi.spyOn(WebSocketClient.prototype, 'connect')
+    const client = new WebSocketClient()
+    client.connect()
+    connectSpy.mockClear()
+    ws.simulateClose()
+    ws.simulateClose()
+    expect(connectSpy).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(3000)
+    expect(connectSpy).toHaveBeenCalledTimes(1)
+    connectSpy.mockRestore()
+    vi.useRealTimers()
   })
 })

--- a/src/components/AlertBadge.test.tsx
+++ b/src/components/AlertBadge.test.tsx
@@ -77,3 +77,36 @@ describe('AlertBadge', () => {
     expect(screen.getByText('↕')).toBeInTheDocument()
   })
 })
+
+describe('snapshots', () => {
+  it('count 1', () => {
+    const { container } = render(<AlertBadge count={1} alerts={[baseAlert()]} />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('count > 1', () => {
+    const { container } = render(<AlertBadge count={2} alerts={[baseAlert(), baseAlert({ id: '2' })]} />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('upper only threshold', () => {
+    const { container } = render(
+      <AlertBadge count={1} alerts={[baseAlert({ lowerThreshold: null, upperThreshold: 60000 })]} />,
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('lower only threshold', () => {
+    const { container } = render(
+      <AlertBadge count={1} alerts={[baseAlert({ upperThreshold: null, lowerThreshold: 30000 })]} />,
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('both thresholds', () => {
+    const { container } = render(
+      <AlertBadge count={1} alerts={[baseAlert({ upperThreshold: 60000, lowerThreshold: 30000 })]} />,
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/components/AlertModal.test.tsx
+++ b/src/components/AlertModal.test.tsx
@@ -193,3 +193,20 @@ describe('AlertModal', () => {
     expect(screen.getByLabelText('Close modal')).toBeInTheDocument()
   })
 })
+
+describe('snapshots', () => {
+  it('create mode', () => {
+    const { container } = render(<AlertModal {...defaultProps} />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('edit mode', () => {
+    const { container } = render(<AlertModal {...defaultProps} alert={mockAlert} onDelete={vi.fn()} />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('with suggestions', () => {
+    const { container } = render(<AlertModal {...defaultProps} currentPrice={50000} />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/components/ConnectionBadge.test.tsx
+++ b/src/components/ConnectionBadge.test.tsx
@@ -24,3 +24,25 @@ describe('ConnectionBadge', () => {
     expect(screen.getByText('Offline')).toBeInTheDocument()
   })
 })
+
+describe('snapshots', () => {
+  it('connected', () => {
+    const { container } = render(<ConnectionBadge status="connected" />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('connecting', () => {
+    const { container } = render(<ConnectionBadge status="connecting" />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('reconnecting', () => {
+    const { container } = render(<ConnectionBadge status="reconnecting" />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('disconnected', () => {
+    const { container } = render(<ConnectionBadge status="disconnected" />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
 import { ErrorBoundary } from './ErrorBoundary'
+
+afterEach(cleanup)
 
 const Bomb = ({ shouldThrow }: { shouldThrow: boolean }) => {
   if (shouldThrow) throw new Error('💥')
@@ -38,6 +40,81 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>,
     )
     expect(screen.getByText('Custom Error')).toBeInTheDocument()
+    spy.mockRestore()
+  })
+
+  it('calls onError callback when error is caught', () => {
+    const onError = vi.fn()
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <ErrorBoundary onError={onError}>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    )
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ componentStack: expect.any(String) }))
+    spy.mockRestore()
+  })
+
+  it('logs error to console.error in componentDidCatch', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    )
+    expect(spy).toHaveBeenCalledWith('ErrorBoundary caught:', expect.any(Error), expect.any(String))
+    spy.mockRestore()
+  })
+
+  it('resets error state when key prop changes (navigation)', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { rerender } = render(
+      <ErrorBoundary key="1">
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+
+    rerender(
+      <ErrorBoundary key="2">
+        <div>Navigated</div>
+      </ErrorBoundary>,
+    )
+    expect(screen.getByText('Navigated')).toBeInTheDocument()
+    spy.mockRestore()
+  })
+})
+
+describe('snapshots', () => {
+  it('children', () => {
+    const { container } = render(
+      <ErrorBoundary>
+        <div>Safe</div>
+      </ErrorBoundary>,
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('error fallback', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { container } = render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    )
+    expect(container.firstChild).toMatchSnapshot()
+    spy.mockRestore()
+  })
+
+  it('custom fallback', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { container } = render(
+      <ErrorBoundary fallback={<div>Custom Error</div>}>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    )
+    expect(container.firstChild).toMatchSnapshot()
     spy.mockRestore()
   })
 })

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import { Component, type ErrorInfo, type ReactNode } from 'react'
 interface ErrorBoundaryProps {
   children: ReactNode
   fallback?: ReactNode
+  onError?: (error: Error, info: ErrorInfo) => void
 }
 
 interface ErrorBoundaryState {
@@ -22,6 +23,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error('ErrorBoundary caught:', error, info.componentStack)
+    this.props.onError?.(error, info)
   }
 
   render() {

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -63,3 +63,16 @@ describe('Layout', () => {
     expect(buttons.length).toBeGreaterThanOrEqual(1)
   })
 })
+
+describe('snapshots', () => {
+  it('default', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      </MemoryRouter>,
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/components/NetworkStatusBanner.test.tsx
+++ b/src/components/NetworkStatusBanner.test.tsx
@@ -33,3 +33,12 @@ describe('NetworkStatusBanner', () => {
     expect(container.querySelector('[role="alert"]')).not.toBeInTheDocument()
   })
 })
+
+describe('snapshots', () => {
+  it('offline', () => {
+    vi.stubGlobal('navigator', { onLine: false })
+    const { container } = render(<NetworkStatusBanner />)
+    expect(container.firstChild).toMatchSnapshot()
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/components/PriceCard.test.tsx
+++ b/src/components/PriceCard.test.tsx
@@ -122,3 +122,33 @@ describe('PriceCard', () => {
     expect(card?.className).not.toContain('opacity-60')
   })
 })
+
+describe('snapshots', () => {
+  const fixedPrice = {
+    assetPair: 'BTC/USD',
+    price: 50000.1234,
+    timestamp: 1700000000000,
+    confidence: 0.9876,
+    sources: ['chainlink', 'redstone'],
+  }
+
+  it('default', () => {
+    const { container } = render(<PriceCard price={fixedPrice} />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('isLive', () => {
+    const { container } = render(<PriceCard price={fixedPrice} isLive />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('isStale', () => {
+    const { container } = render(<PriceCard price={fixedPrice} isStale />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('hasAlert', () => {
+    const { container } = render(<PriceCard price={fixedPrice} hasAlert />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/components/PriceCardSkeleton.test.tsx
+++ b/src/components/PriceCardSkeleton.test.tsx
@@ -13,3 +13,10 @@ describe('PriceCardSkeleton', () => {
     expect(container.querySelector('[aria-hidden="true"]')).toBeInTheDocument()
   })
 })
+
+describe('snapshots', () => {
+  it('default', () => {
+    const { container } = render(<PriceCardSkeleton />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/components/PriceChart.test.tsx
+++ b/src/components/PriceChart.test.tsx
@@ -24,3 +24,25 @@ describe('PriceChart', () => {
     expect(screen.getByText('BTC/USD Price History')).toBeInTheDocument()
   })
 })
+
+describe('snapshots', () => {
+  const fixedData = [
+    { price: 50000, timestamp: 1700000000000, confidence: 0.99, sources: ['chainlink'] },
+    { price: 50100, timestamp: 1700000060000, confidence: 0.99, sources: ['chainlink'] },
+  ]
+
+  it('loading', () => {
+    const { container } = render(<PriceChart data={[]} pair="BTC/USD" loading />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('empty', () => {
+    const { container } = render(<PriceChart data={[]} pair="BTC/USD" loading={false} />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('with data', () => {
+    const { container } = render(<PriceChart data={fixedData} pair="BTC/USD" loading={false} />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/components/SourceHealthBadge.test.tsx
+++ b/src/components/SourceHealthBadge.test.tsx
@@ -29,3 +29,15 @@ describe('SourceHealthBadge', () => {
     expect(screen.getAllByText('Reflector')).toHaveLength(1)
   })
 })
+
+describe('snapshots', () => {
+  it('with sources', () => {
+    const { container } = render(<SourceHealthBadge sources={['chainlink', 'redstone', 'band', 'reflector']} />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('empty', () => {
+    const { container } = render(<SourceHealthBadge sources={[]} />)
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/hooks/useWebSocket.test.ts
+++ b/src/hooks/useWebSocket.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useWebSocket } from './useWebSocket'
+import { FakeWebSocket } from '../test/fakeWebSocket'
+
+let ws: FakeWebSocket
+
+function stubWebSocket(): void {
+  const mock = vi.fn(() => ws)
+  mock.OPEN = FakeWebSocket.OPEN
+  mock.CONNECTING = FakeWebSocket.CONNECTING
+  mock.CLOSING = FakeWebSocket.CLOSING
+  mock.CLOSED = FakeWebSocket.CLOSED
+  vi.stubGlobal('WebSocket', mock)
+}
+
+beforeEach(() => {
+  ws = new FakeWebSocket('ws://localhost:3000')
+  stubWebSocket()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function makePriceUpdate(overrides: Partial<{
+  assetPair: string
+  price: number
+  timestamp: number
+  confidence: number
+  sources: string[]
+}> = {}) {
+  return {
+    type: 'price_update' as const,
+    assetPair: 'BTC/USD',
+    price: 50000,
+    timestamp: Date.now(),
+    confidence: 0.99,
+    sources: ['chainlink'],
+    ...overrides,
+  }
+}
+
+describe('useWebSocket', () => {
+  it('starts connecting and has empty livePrices initially', () => {
+    const { result } = renderHook(() => useWebSocket())
+    expect(result.current.status).toBe('connecting')
+    expect(result.current.livePrices.size).toBe(0)
+  })
+
+  it('transitions to connecting then connected on open', async () => {
+    const { result } = renderHook(() => useWebSocket())
+    await waitFor(() => expect(result.current.status).toBe('connecting'))
+
+    act(() => { ws.simulateOpen() })
+    await waitFor(() => expect(result.current.status).toBe('connected'))
+  })
+
+  it('updates livePrices on price_update message', async () => {
+    const { result } = renderHook(() => useWebSocket())
+    act(() => { ws.simulateOpen() })
+    await waitFor(() => expect(result.current.status).toBe('connected'))
+
+    act(() => { ws.simulateMessage(makePriceUpdate()) })
+    await waitFor(() => {
+      expect(result.current.livePrices.size).toBe(1)
+      expect(result.current.livePrices.get('BTC/USD')!.price).toBe(50000)
+    })
+  })
+
+  it('replaces existing price on subsequent updates for same pair', async () => {
+    const { result } = renderHook(() => useWebSocket())
+    act(() => { ws.simulateOpen() })
+    await waitFor(() => expect(result.current.status).toBe('connected'))
+
+    act(() => { ws.simulateMessage(makePriceUpdate({ price: 50000 })) })
+    await waitFor(() => {
+      expect(result.current.livePrices.get('BTC/USD')!.price).toBe(50000)
+    })
+
+    act(() => { ws.simulateMessage(makePriceUpdate({ price: 51000 })) })
+    await waitFor(() => {
+      expect(result.current.livePrices.size).toBe(1)
+      expect(result.current.livePrices.get('BTC/USD')!.price).toBe(51000)
+    })
+  })
+
+  it('tracks multiple asset pairs', async () => {
+    const { result } = renderHook(() => useWebSocket())
+    act(() => { ws.simulateOpen() })
+    await waitFor(() => expect(result.current.status).toBe('connected'))
+
+    act(() => { ws.simulateMessage(makePriceUpdate({ assetPair: 'BTC/USD', price: 50000 })) })
+    act(() => { ws.simulateMessage(makePriceUpdate({ assetPair: 'ETH/USD', price: 3000 })) })
+    await waitFor(() => {
+      expect(result.current.livePrices.size).toBe(2)
+    })
+    expect(result.current.livePrices.get('BTC/USD')!.price).toBe(50000)
+    expect(result.current.livePrices.get('ETH/USD')!.price).toBe(3000)
+  })
+
+  it('updates status to reconnecting on close', async () => {
+    const { result } = renderHook(() => useWebSocket())
+    act(() => { ws.simulateOpen() })
+    await waitFor(() => expect(result.current.status).toBe('connected'))
+
+    act(() => { ws.simulateClose() })
+    await waitFor(() => expect(result.current.status).toBe('reconnecting'))
+  })
+
+  it('provides subscribe function that sends messages', async () => {
+    const { result } = renderHook(() => useWebSocket())
+    act(() => { ws.simulateOpen() })
+    await waitFor(() => expect(result.current.status).toBe('connected'))
+
+    act(() => { result.current.subscribe(['BTC/USD']) })
+    expect(ws.sent).toContain(JSON.stringify({ action: 'subscribe', assetPairs: ['BTC/USD'] }))
+  })
+
+  it('provides unsubscribe function that sends messages', async () => {
+    const { result } = renderHook(() => useWebSocket())
+    act(() => { ws.simulateOpen() })
+    await waitFor(() => expect(result.current.status).toBe('connected'))
+
+    act(() => { result.current.subscribe(['BTC/USD']) })
+    act(() => { result.current.unsubscribe(['BTC/USD']) })
+    expect(ws.sent).toContain(JSON.stringify({ action: 'unsubscribe', assetPairs: ['BTC/USD'] }))
+  })
+
+  it('subscribes to pairs passed to the hook', async () => {
+    renderHook(() => useWebSocket(['BTC/USD', 'ETH/USD']))
+    act(() => { ws.simulateOpen() })
+    await waitFor(() => {
+      expect(ws.sent).toContain(
+        JSON.stringify({ action: 'subscribe', assetPairs: ['BTC/USD', 'ETH/USD'] }),
+      )
+    })
+  })
+
+  it('ignores non price_update messages', async () => {
+    const { result } = renderHook(() => useWebSocket())
+    act(() => { ws.simulateOpen() })
+    await waitFor(() => expect(result.current.status).toBe('connected'))
+
+    act(() => { ws.simulateMessage({ type: 'unknown', data: 'test' }) })
+    expect(result.current.livePrices.size).toBe(0)
+  })
+
+  it('cleans up WebSocketClient on unmount', () => {
+    const { unmount } = renderHook(() => useWebSocket())
+    unmount()
+    expect(ws.closed).toBe(true)
+  })
+})

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -296,3 +296,77 @@ describe('Dashboard', () => {
     expect(badge).toBeInTheDocument()
   })
 })
+
+describe('snapshots', () => {
+  it('loading', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>,
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('error', async () => {
+    const { usePriceContext } = await import('../context/PriceContext')
+    vi.mocked(usePriceContext).mockReturnValue({
+      prices: [],
+      pricesLoading: false,
+      pricesError: 'Failed to fetch prices',
+      pricesValidating: false,
+      livePrices: new Map(),
+      wsStatus: 'disconnected',
+      refetchPrices: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    })
+    const { container } = render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>,
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('empty', async () => {
+    const { usePriceContext } = await import('../context/PriceContext')
+    vi.mocked(usePriceContext).mockReturnValue({
+      prices: [],
+      pricesLoading: false,
+      pricesError: null,
+      pricesValidating: false,
+      livePrices: new Map(),
+      wsStatus: 'disconnected',
+      refetchPrices: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    })
+    const { container } = render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>,
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+
+  it('with data', async () => {
+    const { usePriceContext } = await import('../context/PriceContext')
+    vi.mocked(usePriceContext).mockReturnValue({
+      prices: mockPrices,
+      pricesLoading: false,
+      pricesError: null,
+      pricesValidating: false,
+      livePrices: new Map(),
+      wsStatus: 'disconnected',
+      refetchPrices: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    })
+    const { container } = render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>,
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/pages/NotFound.test.tsx
+++ b/src/pages/NotFound.test.tsx
@@ -27,3 +27,14 @@ describe('NotFound', () => {
     expect(links[0].closest('a')).toHaveAttribute('href', '/')
   })
 })
+
+describe('snapshots', () => {
+  it('default', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>,
+    )
+    expect(container.firstChild).toMatchSnapshot()
+  })
+})

--- a/src/test/fakeWebSocket.test.ts
+++ b/src/test/fakeWebSocket.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { FakeWebSocket } from './fakeWebSocket'
+
+describe('FakeWebSocket', () => {
+  let ws: FakeWebSocket
+
+  beforeEach(() => {
+    ws = new FakeWebSocket('ws://test.com')
+  })
+
+  it('sets url and initial readyState', () => {
+    expect(ws.url).toBe('ws://test.com')
+    expect(ws.readyState).toBe(FakeWebSocket.CONNECTING)
+  })
+
+  it('has correct static constants', () => {
+    expect(FakeWebSocket.CONNECTING).toBe(0)
+    expect(FakeWebSocket.OPEN).toBe(1)
+    expect(FakeWebSocket.CLOSING).toBe(2)
+    expect(FakeWebSocket.CLOSED).toBe(3)
+  })
+
+  describe('simulateOpen', () => {
+    it('triggers onopen and sets readyState to OPEN', () => {
+      const onopen = vi.fn()
+      ws.onopen = onopen
+      ws.simulateOpen()
+      expect(ws.readyState).toBe(FakeWebSocket.OPEN)
+      expect(onopen).toHaveBeenCalledTimes(1)
+      expect(onopen).toHaveBeenCalledWith(expect.any(Event))
+    })
+
+    it('does nothing when onopen is null', () => {
+      ws.simulateOpen()
+      expect(ws.readyState).toBe(FakeWebSocket.OPEN)
+    })
+  })
+
+  describe('simulateMessage', () => {
+    it('triggers onmessage with stringified data', () => {
+      const onmessage = vi.fn()
+      ws.onmessage = onmessage
+      const payload = { type: 'price_update', assetPair: 'BTC/USD', price: 50000 }
+      ws.simulateMessage(payload)
+      expect(onmessage).toHaveBeenCalledTimes(1)
+      const event = onmessage.mock.calls[0][0] as MessageEvent
+      expect(event.data).toBe(JSON.stringify(payload))
+    })
+
+    it('does nothing when onmessage is null', () => {
+      ws.simulateMessage({ key: 'value' })
+    })
+
+    it('respects messageLatency option', async () => {
+      vi.useFakeTimers()
+      ws = new FakeWebSocket('ws://test.com', { messageLatency: 100 })
+      const onmessage = vi.fn()
+      ws.onmessage = onmessage
+      ws.simulateMessage({ data: 'delayed' })
+      expect(onmessage).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(100)
+      expect(onmessage).toHaveBeenCalledTimes(1)
+      vi.useRealTimers()
+    })
+  })
+
+  describe('simulateClose', () => {
+    it('triggers onclose and sets readyState to CLOSED', () => {
+      const onclose = vi.fn()
+      ws.onclose = onclose
+      ws.simulateClose(1000, 'normal')
+      expect(ws.readyState).toBe(FakeWebSocket.CLOSED)
+      expect(onclose).toHaveBeenCalledTimes(1)
+      const event = onclose.mock.calls[0][0] as CloseEvent
+      expect(event.code).toBe(1000)
+      expect(event.reason).toBe('normal')
+    })
+
+    it('does nothing when onclose is null', () => {
+      ws.simulateClose()
+      expect(ws.readyState).toBe(FakeWebSocket.CLOSED)
+    })
+  })
+
+  describe('simulateError', () => {
+    it('triggers onerror', () => {
+      const onerror = vi.fn()
+      ws.onerror = onerror
+      ws.simulateError()
+      expect(onerror).toHaveBeenCalledTimes(1)
+      expect(onerror).toHaveBeenCalledWith(expect.any(Event))
+    })
+
+    it('does nothing when onerror is null', () => {
+      ws.simulateError()
+    })
+  })
+
+  describe('send', () => {
+    it('appends to sent array', () => {
+      ws.send('message1')
+      ws.send('message2')
+      expect(ws.sent).toEqual(['message1', 'message2'])
+    })
+  })
+
+  describe('close', () => {
+    it('sets closed flag and readyState to CLOSING then CLOSED', () => {
+      ws.close(1001, 'going away')
+      expect(ws.closed).toBe(true)
+      expect(ws.closeCode).toBe(1001)
+      expect(ws.closeReason).toBe('going away')
+      expect(ws.readyState).toBe(FakeWebSocket.CLOSED)
+    })
+
+    it('triggers onclose', () => {
+      const onclose = vi.fn()
+      ws.onclose = onclose
+      ws.close()
+      expect(onclose).toHaveBeenCalledTimes(1)
+      expect(onclose).toHaveBeenCalledWith(expect.any(CloseEvent))
+    })
+  })
+
+  describe('openDelay option', () => {
+    it('auto-opens after specified delay', () => {
+      vi.useFakeTimers()
+      const onopen = vi.fn()
+      ws = new FakeWebSocket('ws://test.com', { openDelay: 200 })
+      ws.onopen = onopen
+      vi.advanceTimersByTime(200)
+      expect(ws.readyState).toBe(FakeWebSocket.OPEN)
+      expect(onopen).toHaveBeenCalledTimes(1)
+      vi.useRealTimers()
+    })
+
+    it('does not auto-open before delay elapses', () => {
+      vi.useFakeTimers()
+      ws = new FakeWebSocket('ws://test.com', { openDelay: 200 })
+      ws.onopen = vi.fn()
+      vi.advanceTimersByTime(100)
+      expect(ws.readyState).toBe(FakeWebSocket.CONNECTING)
+      vi.useRealTimers()
+    })
+  })
+
+  describe('closeDelay option', () => {
+    it('defers close event', () => {
+      vi.useFakeTimers()
+      const onclose = vi.fn()
+      ws = new FakeWebSocket('ws://test.com', { closeDelay: 100 })
+      ws.onclose = onclose
+      ws.close()
+      expect(ws.readyState).toBe(FakeWebSocket.CLOSING)
+      expect(onclose).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(100)
+      expect(ws.readyState).toBe(FakeWebSocket.CLOSED)
+      expect(onclose).toHaveBeenCalledTimes(1)
+      vi.useRealTimers()
+    })
+  })
+
+  describe('reset', () => {
+    it('resets all state and clears handlers', () => {
+      ws.onopen = vi.fn()
+      ws.simulateOpen()
+      ws.send('test')
+      ws.reset()
+      expect(ws.readyState).toBe(FakeWebSocket.CONNECTING)
+      expect(ws.sent).toEqual([])
+      expect(ws.closed).toBe(false)
+      expect(ws.closeCode).toBeUndefined()
+      expect(ws.closeReason).toBeUndefined()
+      expect(ws.onopen).toBeNull()
+      expect(ws.onclose).toBeNull()
+      expect(ws.onmessage).toBeNull()
+      expect(ws.onerror).toBeNull()
+    })
+
+    it('cancels pending auto-open timer', () => {
+      vi.useFakeTimers()
+      ws = new FakeWebSocket('ws://test.com', { openDelay: 100 })
+      ws.onopen = vi.fn()
+      ws.reset()
+      vi.advanceTimersByTime(100)
+      expect(ws.readyState).toBe(FakeWebSocket.CONNECTING)
+      vi.useRealTimers()
+    })
+  })
+})

--- a/src/test/fakeWebSocket.ts
+++ b/src/test/fakeWebSocket.ts
@@ -1,0 +1,124 @@
+export interface FakeWebSocketOptions {
+  openDelay?: number
+  messageLatency?: number
+  closeDelay?: number
+}
+
+export class FakeWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  readonly CONNECTING = 0
+  readonly OPEN = 1
+  readonly CLOSING = 2
+  readonly CLOSED = 3
+
+  url: string
+  readyState: number = FakeWebSocket.CONNECTING
+  bufferedAmount = 0
+  extensions = ''
+  protocol = ''
+  binaryType: BinaryType = 'blob'
+
+  onopen: ((event: Event) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+
+  sent: string[] = []
+  closed = false
+  closeCode: number | undefined
+  closeReason: string | undefined
+
+  private options: FakeWebSocketOptions
+  private autoOpenTimer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(url: string, options: FakeWebSocketOptions = {}) {
+    this.url = url
+    this.options = options
+
+    if (options.openDelay != null) {
+      this.autoOpenTimer = setTimeout(() => this.simulateOpen(), options.openDelay)
+    }
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closed = true
+    this.closeCode = code
+    this.closeReason = reason
+    this.readyState = FakeWebSocket.CLOSING
+
+    const delay = this.options.closeDelay ?? 0
+    if (delay > 0) {
+      setTimeout(() => {
+        this.readyState = FakeWebSocket.CLOSED
+        this.onclose?.(new CloseEvent('close', { code, reason }))
+      }, delay)
+    } else {
+      this.readyState = FakeWebSocket.CLOSED
+      this.onclose?.(new CloseEvent('close', { code, reason }))
+    }
+  }
+
+  addEventListener(): void {
+    // stub - not used by current codebase
+  }
+
+  removeEventListener(): void {
+    // stub - not used by current codebase
+  }
+
+  dispatchEvent(): boolean {
+    return true
+  }
+
+  simulateOpen(): void {
+    if (this.autoOpenTimer) {
+      clearTimeout(this.autoOpenTimer)
+      this.autoOpenTimer = null
+    }
+    this.readyState = FakeWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: unknown): void {
+    const event = new MessageEvent('message', { data: JSON.stringify(data) })
+
+    if (this.options.messageLatency != null && this.options.messageLatency > 0) {
+      setTimeout(() => this.onmessage?.(event), this.options.messageLatency)
+    } else {
+      this.onmessage?.(event)
+    }
+  }
+
+  simulateClose(code?: number, reason?: string): void {
+    this.readyState = FakeWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close', { code, reason }))
+  }
+
+  simulateError(): void {
+    this.onerror?.(new Event('error'))
+  }
+
+  reset(): void {
+    if (this.autoOpenTimer) {
+      clearTimeout(this.autoOpenTimer)
+      this.autoOpenTimer = null
+    }
+    this.readyState = FakeWebSocket.CONNECTING
+    this.sent = []
+    this.closed = false
+    this.closeCode = undefined
+    this.closeReason = undefined
+    this.onopen = null
+    this.onclose = null
+    this.onmessage = null
+    this.onerror = null
+  }
+}


### PR DESCRIPTION
Closes #27 
Closes #28 
Closes #29 
Closes #30 

test: expand test suite with snapshots, benchmarks, and mocks

- Add snapshot testing for all components
- Add performance benchmark tests
- Add WebSocket mocking utility for tests
- Add error boundary tests for each page