### PR TITLE
feat: implement issues #49, #50, #51, #52

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { Layout } from './components/Layout'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { Dashboard } from './pages/Dashboard'
 import { NotFound } from './pages/NotFound'
-import { AlertsProvider } from './hooks/useAlerts'
 import { useWebVitals } from './hooks/useWebVitals'
 import { PreferencesProvider } from './preferences/PreferencesContext'
 

--- a/src/api/rest.ts
+++ b/src/api/rest.ts
@@ -1,5 +1,6 @@
 import { config } from '../config'
 import type { PriceData, PriceHistoryResponse } from '../types'
+import { idbCache } from '../hooks/useIndexedDB'
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const url = `${config.apiUrl}${path}`
@@ -16,11 +17,29 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 
 export async function fetchAllPrices(pairs?: string[]): Promise<PriceData[]> {
   const params = pairs?.length ? `?pairs=${pairs.join(',')}` : ''
-  return request<PriceData[]>(`/api/prices${params}`)
+  const cacheKey = `all${params}`
+  try {
+    const data = await request<PriceData[]>(`/api/prices${params}`)
+    idbCache.set('prices', cacheKey, data)
+    return data
+  } catch (err) {
+    // Serve stale cache on network failure (offline support)
+    const cached = await idbCache.get<PriceData[]>('prices', cacheKey, Infinity)
+    if (cached) return cached
+    throw err
+  }
 }
 
 export async function fetchPrice(pair: string): Promise<PriceData> {
-  return request<PriceData>(`/api/prices/${encodeURIComponent(pair)}`)
+  try {
+    const data = await request<PriceData>(`/api/prices/${encodeURIComponent(pair)}`)
+    idbCache.set('prices', pair, data)
+    return data
+  } catch (err) {
+    const cached = await idbCache.get<PriceData>('prices', pair, Infinity)
+    if (cached) return cached
+    throw err
+  }
 }
 
 export async function fetchPriceHistory(
@@ -28,9 +47,18 @@ export async function fetchPriceHistory(
   limit = 100,
   offset = 0
 ): Promise<PriceHistoryResponse> {
-  return request<PriceHistoryResponse>(
-    `/api/prices/${encodeURIComponent(pair)}/history?limit=${limit}&offset=${offset}`
-  )
+  const cacheKey = `${pair}:${limit}:${offset}`
+  try {
+    const data = await request<PriceHistoryResponse>(
+      `/api/prices/${encodeURIComponent(pair)}/history?limit=${limit}&offset=${offset}`
+    )
+    idbCache.set('history', cacheKey, data)
+    return data
+  } catch (err) {
+    const cached = await idbCache.get<PriceHistoryResponse>('history', cacheKey, Infinity)
+    if (cached) return cached
+    throw err
+  }
 }
 
 export async function fetchHealth(): Promise<{ status: string; uptime: number }> {

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -6,6 +6,31 @@ type StatusHandler = (status: ConnectionStatus) => void
 
 export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'reconnecting'
 
+// Detect browser support for DecompressionStream (gzip/deflate)
+const supportsDecompression = typeof DecompressionStream !== 'undefined'
+
+async function decompress(data: Blob): Promise<string> {
+  try {
+    const ds = new DecompressionStream('gzip')
+    const decompressed = data.stream().pipeThrough(ds)
+    const reader = decompressed.getReader()
+    const chunks: Uint8Array[] = []
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+    }
+    const total = chunks.reduce((n, c) => n + c.length, 0)
+    const merged = new Uint8Array(total)
+    let offset = 0
+    for (const c of chunks) { merged.set(c, offset); offset += c.length }
+    return new TextDecoder().decode(merged)
+  } catch {
+    // Fallback: try reading as plain text
+    return data.text()
+  }
+}
+
 export class WebSocketClient {
   private ws: WebSocket | null = null
   private messageHandlers = new Set<MessageHandler>()
@@ -13,6 +38,8 @@ export class WebSocketClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private destroyed = false
   private subscribedPairs = new Set<string>()
+  /** Whether the server negotiated compressed binary frames */
+  private useCompression = false
 
   private _status: ConnectionStatus = 'disconnected'
   get status(): ConnectionStatus {
@@ -27,7 +54,15 @@ export class WebSocketClient {
   connect() {
     if (this.destroyed) return
     this.setStatus('connecting')
-    this.ws = new WebSocket(config.wsUrl)
+
+    // Append ?compress=1 to signal compression support to the server
+    const url = supportsDecompression
+      ? `${config.wsUrl}${config.wsUrl.includes('?') ? '&' : '?'}compress=1`
+      : config.wsUrl
+
+    this.ws = new WebSocket(url)
+    // Request binary for potential compressed frames
+    this.ws.binaryType = 'blob'
 
     this.ws.onopen = () => {
       this.setStatus('connected')
@@ -39,9 +74,17 @@ export class WebSocketClient {
       }
     }
 
-    this.ws.onmessage = (e) => {
+    this.ws.onmessage = async (e) => {
       try {
-        const msg = JSON.parse(e.data) as WsMessage
+        let text: string
+        if (e.data instanceof Blob) {
+          // Binary frame — attempt gzip decompression, fall back to plain text
+          text = supportsDecompression ? await decompress(e.data) : await e.data.text()
+          this.useCompression = true
+        } else {
+          text = e.data as string
+        }
+        const msg = JSON.parse(text) as WsMessage
         this.messageHandlers.forEach((h) => h(msg))
       } catch {
         // ignore malformed messages
@@ -49,6 +92,7 @@ export class WebSocketClient {
     }
 
     this.ws.onclose = () => {
+      this.useCompression = false
       this.setStatus('disconnected')
       this.scheduleReconnect()
     }
@@ -101,5 +145,10 @@ export class WebSocketClient {
   onStatusChange(handler: StatusHandler): () => void {
     this.statusHandlers.add(handler)
     return () => this.statusHandlers.delete(handler)
+  }
+
+  /** Returns true if the last received frame was compressed */
+  get isCompressed(): boolean {
+    return this.useCompression
   }
 }

--- a/src/components/PriceCard.tsx
+++ b/src/components/PriceCard.tsx
@@ -26,9 +26,11 @@ interface PriceCardProps {
   onAlertClick?: (e: React.MouseEvent) => void
   dragHandleProps?: DragHandleProps
   isDragOver?: boolean
+  selectMode?: boolean
+  isSelected?: boolean
 }
 
-export const PriceCard = memo(function PriceCard({ price, onClick, isLive, isStale, hasAlert, onAlertClick, dragHandleProps, isDragOver }: PriceCardProps) {
+export const PriceCard = memo(function PriceCard({ price, onClick, isLive, isStale, hasAlert, onAlertClick, dragHandleProps, isDragOver, selectMode, isSelected }: PriceCardProps) {
   const confidencePct = (price.confidence * 100).toFixed(1)
 
   return (
@@ -42,12 +44,24 @@ export const PriceCard = memo(function PriceCard({ price, onClick, isLive, isSta
       }}
       role="button"
       tabIndex={0}
-      className={`w-full text-left bg-gray-900 border rounded-xl p-5 hover:border-gray-700 hover:bg-gray-900/80 transition-all shadow-lg shadow-black/20 cursor-pointer ${isStale ? 'opacity-60' : ''} ${isDragOver ? 'border-cyan-500 ring-1 ring-cyan-500/40' : 'border-gray-800'}`}
+      className={`w-full text-left bg-gray-900 border rounded-xl p-5 hover:border-gray-700 hover:bg-gray-900/80 transition-all shadow-lg shadow-black/20 cursor-pointer ${isStale ? 'opacity-60' : ''} ${isSelected ? 'border-cyan-500 ring-2 ring-cyan-500/40' : isDragOver ? 'border-cyan-500 ring-1 ring-cyan-500/40' : 'border-gray-800'}`}
       aria-label={`View details for ${price.assetPair}`}
+      aria-selected={selectMode ? isSelected : undefined}
     >
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          {dragHandleProps && (
+          {selectMode ? (
+            <span
+              className={`w-4 h-4 flex items-center justify-center rounded border ${isSelected ? 'bg-cyan-600 border-cyan-500' : 'border-gray-600'}`}
+              aria-hidden="true"
+            >
+              {isSelected && (
+                <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </span>
+          ) : dragHandleProps ? (
             <button
               type="button"
               aria-label={`Drag handle for ${price.assetPair}`}
@@ -65,7 +79,7 @@ export const PriceCard = memo(function PriceCard({ price, onClick, isLive, isSta
                 <circle cx="11" cy="12" r="1.2" />
               </svg>
             </button>
-          )}
+          ) : null}
           <h3 className="text-lg font-semibold text-gray-100">{price.assetPair}</h3>
         </div>
         <div className="flex items-center gap-2">

--- a/src/components/PriceTableView.tsx
+++ b/src/components/PriceTableView.tsx
@@ -12,6 +12,9 @@ interface PriceTableViewProps {
   onRowClick: (pair: string) => void
   onAlertClick: (e: React.MouseEvent, pair: string) => void
   hasAlertFn: (pair: string) => boolean
+  selectMode?: boolean
+  selected?: Set<string>
+  onToggleSelect?: (pair: string) => void
 }
 
 const COLUMNS: { key: SortKey; label: string }[] = [
@@ -29,6 +32,9 @@ export const PriceTableView = memo(function PriceTableView({
   onRowClick,
   onAlertClick,
   hasAlertFn,
+  selectMode,
+  selected,
+  onToggleSelect,
 }: PriceTableViewProps) {
   const [sortKey, setSortKey] = useState<SortKey>('assetPair')
   const [sortDir, setSortDir] = useState<SortDir>('asc')
@@ -60,6 +66,11 @@ export const PriceTableView = memo(function PriceTableView({
       <table className="min-w-full text-sm" aria-label="Price feeds table">
         <thead>
           <tr className="sticky top-0 bg-gray-900 border-b border-gray-800">
+            {selectMode && (
+              <th scope="col" className="px-4 py-3 w-10">
+                <span className="sr-only">Select</span>
+              </th>
+            )}
             {COLUMNS.map(({ key, label }) => (
               <th
                 key={key}
@@ -87,21 +98,37 @@ export const PriceTableView = memo(function PriceTableView({
           {sorted.map((p) => {
             const isLive = livePairs.has(p.assetPair)
             const hasAlert = hasAlertFn(p.assetPair)
+            const isSelected = selected?.has(p.assetPair) ?? false
             return (
               <tr
                 key={p.assetPair}
-                onClick={() => onRowClick(p.assetPair)}
+                onClick={() => selectMode ? onToggleSelect?.(p.assetPair) : onRowClick(p.assetPair)}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault()
-                    onRowClick(p.assetPair)
+                    selectMode ? onToggleSelect?.(p.assetPair) : onRowClick(p.assetPair)
                   }
                 }}
                 role="button"
                 tabIndex={0}
-                className={`border-b border-gray-800 hover:bg-gray-800/50 cursor-pointer transition-colors ${isStale ? 'opacity-60' : ''}`}
+                className={`border-b border-gray-800 hover:bg-gray-800/50 cursor-pointer transition-colors ${isStale ? 'opacity-60' : ''} ${isSelected ? 'bg-cyan-900/20' : ''}`}
                 aria-label={`View details for ${p.assetPair}`}
+                aria-selected={selectMode ? isSelected : undefined}
               >
+                {selectMode && (
+                  <td className="px-4 py-3 w-10">
+                    <span
+                      className={`inline-flex w-4 h-4 items-center justify-center rounded border ${isSelected ? 'bg-cyan-600 border-cyan-500' : 'border-gray-600'}`}
+                      aria-hidden="true"
+                    >
+                      {isSelected && (
+                        <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                        </svg>
+                      )}
+                    </span>
+                  </td>
+                )}
                 <td className="px-4 py-3 font-semibold text-gray-100 whitespace-nowrap">
                   <span className="flex items-center gap-2">
                     {p.assetPair}

--- a/src/components/PriceTableView.tsx
+++ b/src/components/PriceTableView.tsx
@@ -102,11 +102,11 @@ export const PriceTableView = memo(function PriceTableView({
             return (
               <tr
                 key={p.assetPair}
-                onClick={() => selectMode ? onToggleSelect?.(p.assetPair) : onRowClick(p.assetPair)}
+                onClick={() => { if (selectMode) { onToggleSelect?.(p.assetPair) } else { onRowClick(p.assetPair) } }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault()
-                    selectMode ? onToggleSelect?.(p.assetPair) : onRowClick(p.assetPair)
+                    if (selectMode) { onToggleSelect?.(p.assetPair) } else { onRowClick(p.assetPair) }
                   }
                 }}
                 role="button"

--- a/src/components/__snapshots__/Layout.test.tsx.snap
+++ b/src/components/__snapshots__/Layout.test.tsx.snap
@@ -30,80 +30,109 @@ exports[`snapshots > default 1`] = `
           </span>
         </a>
         <div
-          class="hidden sm:flex items-center gap-1"
+          class="flex items-center gap-2 sm:gap-4"
         >
-          <a
-            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-100 dark:bg-gray-800 text-cyan-600 dark:text-cyan-400"
-            data-discover="true"
-            href="/"
+          <div
+            class="hidden sm:flex items-center gap-1"
           >
-            Dashboard
-          </a>
-        </div>
-        <div
-          class="flex items-center gap-2"
-        >
-          <button
-            aria-label="Open settings"
-            class="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-          >
-            <svg
-              class="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+            <a
+              class="px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-100 dark:bg-gray-800 text-cyan-600 dark:text-cyan-400"
+              data-discover="true"
+              href="/"
             >
-              <path
-                d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-          <button
-            aria-label="Switch to dark theme"
-            class="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-          >
-            <svg
-              aria-hidden="true"
-              class="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+              Dashboard
+            </a>
+            <a
+              class="px-4 py-2 rounded-lg text-sm font-medium transition-colors text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800/50"
+              data-discover="true"
+              href="/sources"
             >
-              <path
-                d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-          <button
-            aria-label="Toggle menu"
-            class="sm:hidden p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+              Source Health
+            </a>
+          </div>
+          <div
+            class="flex items-center gap-2"
           >
-            <svg
-              class="w-6 h-6"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+            <button
+              aria-label="Toggle price alerts"
+              class="relative p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
             >
-              <path
-                d="M4 6h16M4 12h16M4 18h16"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
+              <svg
+                class="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Open settings"
+              class="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            >
+              <svg
+                class="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Switch to dark theme"
+              class="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            >
+              <svg
+                aria-hidden="true"
+                class="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Toggle menu"
+              class="sm:hidden p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+            >
+              <svg
+                class="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M4 6h16M4 12h16M4 18h16"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/hooks/useCopyShareLink.ts
+++ b/src/hooks/useCopyShareLink.ts
@@ -1,0 +1,34 @@
+import { useState, useCallback } from 'react'
+
+/**
+ * Returns a function that copies the current URL to clipboard.
+ * Provides a "copied" state that resets after 2 seconds.
+ * The current URL already encodes all view state via URL search params (#50).
+ */
+export function useCopyShareLink() {
+  const [copied, setCopied] = useState(false)
+
+  const copy = useCallback(() => {
+    const url = window.location.href
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(url).then(() => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }).catch(() => {})
+    } else {
+      // Fallback for browsers without clipboard API
+      const el = document.createElement('textarea')
+      el.value = url
+      el.style.position = 'fixed'
+      el.style.opacity = '0'
+      document.body.appendChild(el)
+      el.select()
+      document.execCommand('copy')
+      document.body.removeChild(el)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }, [])
+
+  return { copy, copied }
+}

--- a/src/hooks/useIndexedDB.ts
+++ b/src/hooks/useIndexedDB.ts
@@ -1,0 +1,143 @@
+/**
+ * Lightweight IndexedDB cache layer (no external deps).
+ * Stores prices, price history, and preferences with TTL + LRU eviction.
+ * Max cache size: 50 MB (enforced by evicting oldest entries).
+ */
+
+const DB_NAME = 'stellar-oracle'
+const DB_VERSION = 1
+const TTL_MS = 5 * 60 * 1000 // 5 minutes default
+const MAX_BYTES = 50 * 1024 * 1024 // 50 MB
+
+interface CacheEntry<T> {
+  key: string
+  value: T
+  size: number       // approximate byte size
+  storedAt: number   // epoch ms
+  accessedAt: number // for LRU
+}
+
+type StoreName = 'prices' | 'history' | 'preferences'
+
+let dbPromise: Promise<IDBDatabase> | null = null
+
+function openDB(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise
+  dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      for (const store of ['prices', 'history', 'preferences'] as StoreName[]) {
+        if (!db.objectStoreNames.contains(store)) {
+          db.createObjectStore(store, { keyPath: 'key' })
+        }
+      }
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+  return dbPromise
+}
+
+function byteSize(value: unknown): number {
+  try { return new TextEncoder().encode(JSON.stringify(value)).length } catch { return 0 }
+}
+
+function tx(db: IDBDatabase, store: StoreName, mode: IDBTransactionMode) {
+  return db.transaction(store, mode).objectStore(store)
+}
+
+function idbGet<T>(db: IDBDatabase, store: StoreName, key: string): Promise<CacheEntry<T> | undefined> {
+  return new Promise((resolve, reject) => {
+    const req = tx(db, store, 'readonly').get(key)
+    req.onsuccess = () => resolve(req.result as CacheEntry<T> | undefined)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+function idbPut(db: IDBDatabase, store: StoreName, entry: CacheEntry<unknown>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = tx(db, store, 'readwrite').put(entry)
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+  })
+}
+
+function idbDelete(db: IDBDatabase, store: StoreName, key: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = tx(db, store, 'readwrite').delete(key)
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+  })
+}
+
+function idbGetAll<T>(db: IDBDatabase, store: StoreName): Promise<CacheEntry<T>[]> {
+  return new Promise((resolve, reject) => {
+    const req = tx(db, store, 'readonly').getAll()
+    req.onsuccess = () => resolve(req.result as CacheEntry<T>[])
+    req.onerror = () => reject(req.error)
+  })
+}
+
+/** Evict LRU entries until total size is under MAX_BYTES */
+async function evict(db: IDBDatabase, store: StoreName) {
+  const all = await idbGetAll(db, store)
+  let total = all.reduce((s, e) => s + e.size, 0)
+  if (total <= MAX_BYTES) return
+  // Sort by LRU (oldest access first)
+  all.sort((a, b) => a.accessedAt - b.accessedAt)
+  for (const entry of all) {
+    if (total <= MAX_BYTES) break
+    await idbDelete(db, store, entry.key)
+    total -= entry.size
+  }
+}
+
+export const idbCache = {
+  async get<T>(store: StoreName, key: string, ttl = TTL_MS): Promise<T | null> {
+    try {
+      const db = await openDB()
+      const entry = await idbGet<T>(db, store, key)
+      if (!entry) return null
+      if (Date.now() - entry.storedAt > ttl) {
+        await idbDelete(db, store, key)
+        return null
+      }
+      // Update access time for LRU (fire-and-forget)
+      idbPut(db, store, { ...entry, accessedAt: Date.now() }).catch(() => {})
+      return entry.value
+    } catch {
+      return null
+    }
+  },
+
+  async set<T>(store: StoreName, key: string, value: T): Promise<void> {
+    try {
+      const db = await openDB()
+      const size = byteSize(value)
+      const now = Date.now()
+      await idbPut(db, store, { key, value, size, storedAt: now, accessedAt: now })
+      await evict(db, store)
+    } catch {
+      // Cache write failure is non-fatal
+    }
+  },
+
+  async delete(store: StoreName, key: string): Promise<void> {
+    try {
+      const db = await openDB()
+      await idbDelete(db, store, key)
+    } catch {}
+  },
+
+  async clear(store: StoreName): Promise<void> {
+    try {
+      const db = await openDB()
+      await new Promise<void>((resolve, reject) => {
+        const req = tx(db, store, 'readwrite').clear()
+        req.onsuccess = () => resolve()
+        req.onerror = () => reject(req.error)
+      })
+    } catch {}
+  },
+}

--- a/src/hooks/useIndexedDB.ts
+++ b/src/hooks/useIndexedDB.ts
@@ -127,7 +127,7 @@ export const idbCache = {
     try {
       const db = await openDB()
       await idbDelete(db, store, key)
-    } catch {}
+    } catch { /* cache delete failure is non-fatal */ }
   },
 
   async clear(store: StoreName): Promise<void> {
@@ -138,6 +138,6 @@ export const idbCache = {
         req.onsuccess = () => resolve()
         req.onerror = () => reject(req.error)
       })
-    } catch {}
+    } catch { /* cache clear failure is non-fatal */ }
   },
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ import { useAlerts } from '../hooks/useAlerts'
 import { useColumnCount } from '../hooks/useColumnCount'
 import { useDragOrder } from '../hooks/useDragOrder'
 import { usePreferences } from '../preferences/PreferencesContext'
+import { useCopyShareLink } from '../hooks/useCopyShareLink'
 import { PriceCard } from '../components/PriceCard'
 import { PriceCardSkeleton } from '../components/PriceCardSkeleton'
 import { PriceTableView } from '../components/PriceTableView'
@@ -14,14 +15,14 @@ import { AlertBadge } from '../components/AlertBadge'
 import { ConnectionBadge } from '../components/ConnectionBadge'
 import { NetworkStatusBanner } from '../components/NetworkStatusBanner'
 import { FilterBar } from '../components/FilterBar'
-import type { AlertFormData } from '../types'
+import type { AlertFormData, PriceData } from '../types'
 
 const ROW_HEIGHT = 200
 const SKELETON_COUNT = 8
 
 function mergePrices(
-  restPrices: { assetPair: string; price: number; timestamp: number; confidence: number; sources: string[] }[],
-  livePrices: Map<string, { assetPair: string; price: number; timestamp: number; confidence: number; sources: string[] }>,
+  restPrices: PriceData[],
+  livePrices: Map<string, PriceData>,
 ) {
   return restPrices.map((p) => {
     const live = livePrices.get(p.assetPair)
@@ -32,15 +33,40 @@ function mergePrices(
   })
 }
 
+function exportCSV(items: PriceData[]) {
+  const header = 'Asset Pair,Price,Confidence,Sources,Updated'
+  const rows = items.map((p) =>
+    [
+      p.assetPair,
+      p.price,
+      (p.confidence * 100).toFixed(2) + '%',
+      p.sources.join(';'),
+      new Date(p.timestamp).toISOString(),
+    ].join(',')
+  )
+  const blob = new Blob([[header, ...rows].join('\n')], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `oracle-prices-${Date.now()}.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
 export function Dashboard() {
   const { prices, pricesLoading, pricesError, pricesValidating, livePrices, wsStatus } = usePriceContext()
   const navigate = useNavigate()
   const { alerts, addAlert, removeAlert, hasAlertsForPair, activeCount } = useAlerts()
   const [searchParams] = useSearchParams()
   const { preferences, updatePreference } = usePreferences()
+  const { copy: copyShareLink, copied: linkCopied } = useCopyShareLink()
 
   const [modalOpen, setModalOpen] = useState(false)
   const [modalPair, setModalPair] = useState('')
+
+  // #49 — bulk selection state
+  const [selectMode, setSelectMode] = useState(false)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
 
   const search = searchParams.get('search') || ''
   const confidence = searchParams.get('confidence') || 'all'
@@ -52,7 +78,6 @@ export function Dashboard() {
 
   const merged = mergePrices(prices, livePrices)
 
-  // Apply saved card order (card view only)
   const orderedMerged = useMemo(() => {
     const order = preferences.cardOrder
     if (!order || order.length === 0) return merged
@@ -66,36 +91,21 @@ export function Dashboard() {
 
   const filtered = useMemo(() => {
     let result = orderedMerged
-
-    if (search) {
-      result = result.filter((p) => p.assetPair.toLowerCase().includes(search.toLowerCase()))
-    }
-    if (confidence === 'high') {
-      result = result.filter((p) => p.confidence > 80)
-    } else if (confidence === 'medium') {
-      result = result.filter((p) => p.confidence > 50)
-    }
-    if (source !== 'all') {
-      result = result.filter((p) => p.sources.some((s) => s.toLowerCase() === source.toLowerCase()))
-    }
-    if (sort === 'price-high') {
-      result = [...result].sort((a, b) => b.price - a.price)
-    } else if (sort === 'price-low') {
-      result = [...result].sort((a, b) => a.price - b.price)
-    } else if (sort === 'confidence') {
-      result = [...result].sort((a, b) => b.confidence - a.confidence)
-    } else if (sort === 'recent') {
-      result = [...result].sort((a, b) => b.timestamp - a.timestamp)
-    }
-
+    if (search) result = result.filter((p) => p.assetPair.toLowerCase().includes(search.toLowerCase()))
+    if (confidence === 'high') result = result.filter((p) => p.confidence > 80)
+    else if (confidence === 'medium') result = result.filter((p) => p.confidence > 50)
+    if (source !== 'all') result = result.filter((p) => p.sources.some((s) => s.toLowerCase() === source.toLowerCase()))
+    if (sort === 'price-high') result = [...result].sort((a, b) => b.price - a.price)
+    else if (sort === 'price-low') result = [...result].sort((a, b) => a.price - b.price)
+    else if (sort === 'confidence') result = [...result].sort((a, b) => b.confidence - a.confidence)
+    else if (sort === 'recent') result = [...result].sort((a, b) => b.timestamp - a.timestamp)
     return result
   }, [orderedMerged, search, confidence, source, sort])
 
-  // Drag-and-drop for card order
   const filteredPairs = useMemo(() => filtered.map((p) => p.assetPair), [filtered])
+
   const handleOrderChange = useCallback(
     (newPairs: string[]) => {
-      // Rebuild full order: new filtered order + unchanged unfiltered pairs appended
       const filteredSet = new Set(newPairs)
       const unfiltered = (preferences.cardOrder.length > 0 ? preferences.cardOrder : orderedMerged.map((p) => p.assetPair)).filter(
         (pair) => !filteredSet.has(pair),
@@ -116,8 +126,18 @@ export function Dashboard() {
   })
 
   const handleCardClick = useCallback(
-    (pair: string) => navigate(`/price/${encodeURIComponent(pair)}`),
-    [navigate],
+    (pair: string) => {
+      if (selectMode) {
+        setSelected((prev) => {
+          const next = new Set(prev)
+          next.has(pair) ? next.delete(pair) : next.add(pair)
+          return next
+        })
+      } else {
+        navigate(`/price/${encodeURIComponent(pair)}`)
+      }
+    },
+    [navigate, selectMode],
   )
 
   const handleAlertClick = useCallback((e: React.MouseEvent, pair: string) => {
@@ -140,6 +160,30 @@ export function Dashboard() {
     [addAlert],
   )
 
+  // #49 — bulk action handlers
+  const toggleSelectMode = useCallback(() => {
+    setSelectMode((m) => !m)
+    setSelected(new Set())
+  }, [])
+
+  const selectAll = useCallback(() => setSelected(new Set(filteredPairs)), [filteredPairs])
+  const deselectAll = useCallback(() => setSelected(new Set()), [])
+
+  const handleBulkExportCSV = useCallback(() => {
+    const items = filtered.filter((p) => selected.has(p.assetPair))
+    exportCSV(items)
+  }, [filtered, selected])
+
+  const handleBulkCreateAlerts = useCallback(() => {
+    for (const pair of selected) {
+      if (!hasAlertsForPair(pair)) {
+        setModalPair(pair)
+        setModalOpen(true)
+        break // open modal for first un-alerted pair
+      }
+    }
+  }, [selected, hasAlertsForPair])
+
   const dashboardView = preferences.dashboardView ?? 'card'
 
   return (
@@ -153,6 +197,50 @@ export function Dashboard() {
           </p>
         </div>
         <div className="flex items-center gap-3">
+          {/* #50 — Share link button */}
+          <button
+            type="button"
+            onClick={copyShareLink}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-gray-700 text-gray-400 hover:text-gray-200 hover:border-gray-600 transition-colors"
+            aria-label="Copy shareable link"
+          >
+            {linkCopied ? (
+              <>
+                <svg className="w-4 h-4 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                <span className="text-green-400">Copied!</span>
+              </>
+            ) : (
+              <>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                </svg>
+                Share
+              </>
+            )}
+          </button>
+
+          {/* #49 — Select mode toggle */}
+          {!pricesLoading && prices.length > 0 && (
+            <button
+              type="button"
+              onClick={toggleSelectMode}
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+                selectMode
+                  ? 'bg-cyan-600 border-cyan-500 text-white'
+                  : 'border-gray-700 text-gray-400 hover:text-gray-200 hover:border-gray-600'
+              }`}
+              aria-pressed={selectMode}
+              aria-label="Toggle selection mode"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+              </svg>
+              {selectMode ? `Select (${selected.size})` : 'Select'}
+            </button>
+          )}
+
           {!pricesLoading && prices.length > 0 && (
             <div className="flex items-center rounded-lg border border-gray-700 overflow-hidden" role="group" aria-label="View toggle">
               <button
@@ -189,6 +277,52 @@ export function Dashboard() {
         </div>
       </div>
 
+      {/* #49 — Bulk action bar */}
+      {selectMode && (
+        <div className="mb-4 p-3 bg-gray-900 border border-cyan-800 rounded-xl flex flex-wrap items-center gap-3">
+          <span className="text-sm text-gray-300 font-medium">
+            {selected.size} selected
+          </span>
+          <button
+            type="button"
+            onClick={selectAll}
+            className="text-xs px-2 py-1 rounded bg-gray-800 text-gray-300 hover:bg-gray-700 transition-colors"
+          >
+            Select all
+          </button>
+          <button
+            type="button"
+            onClick={deselectAll}
+            className="text-xs px-2 py-1 rounded bg-gray-800 text-gray-300 hover:bg-gray-700 transition-colors"
+          >
+            Deselect all
+          </button>
+          <div className="flex-1" />
+          <button
+            type="button"
+            disabled={selected.size === 0}
+            onClick={handleBulkExportCSV}
+            className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-gray-800 text-gray-300 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors border border-gray-700"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            Export CSV
+          </button>
+          <button
+            type="button"
+            disabled={selected.size === 0}
+            onClick={handleBulkCreateAlerts}
+            className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-amber-900/40 text-amber-400 hover:bg-amber-900/60 disabled:opacity-40 disabled:cursor-not-allowed transition-colors border border-amber-800/50"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+            </svg>
+            Set Alerts
+          </button>
+        </div>
+      )}
+
       {pricesError && (
         <div className="mb-6 p-4 bg-red-900/30 border border-red-800 rounded-xl text-sm text-red-400" role="alert">
           {pricesError}
@@ -211,6 +345,15 @@ export function Dashboard() {
           onRowClick={handleCardClick}
           onAlertClick={handleAlertClick}
           hasAlertFn={hasAlertsForPair}
+          selectMode={selectMode}
+          selected={selected}
+          onToggleSelect={(pair) => {
+            setSelected((prev) => {
+              const next = new Set(prev)
+              next.has(pair) ? next.delete(pair) : next.add(pair)
+              return next
+            })
+          }}
         />
       ) : (
         <div
@@ -251,8 +394,10 @@ export function Dashboard() {
                         hasAlert={hasAlertsForPair(p.assetPair)}
                         onClick={() => handleCardClick(p.assetPair)}
                         onAlertClick={(e) => handleAlertClick(e, p.assetPair)}
-                        dragHandleProps={getHandleProps(globalIdx)}
-                        isDragOver={dragOverIndex === globalIdx}
+                        dragHandleProps={selectMode ? undefined : getHandleProps(globalIdx)}
+                        isDragOver={!selectMode && dragOverIndex === globalIdx}
+                        selectMode={selectMode}
+                        isSelected={selected.has(p.assetPair)}
                       />
                     )
                   })}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -130,7 +130,7 @@ export function Dashboard() {
       if (selectMode) {
         setSelected((prev) => {
           const next = new Set(prev)
-          next.has(pair) ? next.delete(pair) : next.add(pair)
+          if (next.has(pair)) { next.delete(pair) } else { next.add(pair) }
           return next
         })
       } else {
@@ -350,7 +350,7 @@ export function Dashboard() {
           onToggleSelect={(pair) => {
             setSelected((prev) => {
               const next = new Set(prev)
-              next.has(pair) ? next.delete(pair) : next.add(pair)
+              if (next.has(pair)) { next.delete(pair) } else { next.add(pair) }
               return next
             })
           }}

--- a/src/pages/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/pages/__snapshots__/Dashboard.test.tsx.snap
@@ -20,6 +20,27 @@ exports[`snapshots > empty 1`] = `
     <div
       class="flex items-center gap-3"
     >
+      <button
+        aria-label="Copy shareable link"
+        class="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-gray-700 text-gray-400 hover:text-gray-200 hover:border-gray-600 transition-colors"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+        Share
+      </button>
       <span
         aria-label="WebSocket Offline"
         class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
@@ -74,6 +95,27 @@ exports[`snapshots > error 1`] = `
     <div
       class="flex items-center gap-3"
     >
+      <button
+        aria-label="Copy shareable link"
+        class="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-gray-700 text-gray-400 hover:text-gray-200 hover:border-gray-600 transition-colors"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+        Share
+      </button>
       <span
         aria-label="WebSocket Offline"
         class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
@@ -134,6 +176,27 @@ exports[`snapshots > loading 1`] = `
     <div
       class="flex items-center gap-3"
     >
+      <button
+        aria-label="Copy shareable link"
+        class="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-gray-700 text-gray-400 hover:text-gray-200 hover:border-gray-600 transition-colors"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+        Share
+      </button>
       <span
         aria-label="WebSocket Offline"
         class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
@@ -479,6 +542,49 @@ exports[`snapshots > with data 1`] = `
     <div
       class="flex items-center gap-3"
     >
+      <button
+        aria-label="Copy shareable link"
+        class="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-gray-700 text-gray-400 hover:text-gray-200 hover:border-gray-600 transition-colors"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+        Share
+      </button>
+      <button
+        aria-label="Toggle selection mode"
+        aria-pressed="false"
+        class="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border transition-colors border-gray-700 text-gray-400 hover:text-gray-200 hover:border-gray-600"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+        Select
+      </button>
       <div
         aria-label="View toggle"
         class="flex items-center rounded-lg border border-gray-700 overflow-hidden"

--- a/src/preferences/PreferencesContext.tsx
+++ b/src/preferences/PreferencesContext.tsx
@@ -1,8 +1,11 @@
-import { createContext, useContext, useCallback, useEffect, useRef, type ReactNode } from 'react'
+import { createContext, useContext, useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useUndoRedo, type Command } from '../hooks/useUndoRedo'
 import { DEFAULT_PREFERENCES, MAX_UNDO_DEPTH } from './constants'
+import { idbCache } from '../hooks/useIndexedDB'
 import type { Preferences } from './types'
+
+const PREFS_IDB_KEY = 'user-preferences'
 
 interface PreferencesContextValue {
   preferences: Preferences
@@ -19,6 +22,16 @@ const PreferencesContext = createContext<PreferencesContextValue | null>(null)
 export function PreferencesProvider({ children }: { children: ReactNode }) {
   const location = useLocation()
   const prevPathRef = useRef(location.pathname)
+  const [initialPrefs, setInitialPrefs] = useState<Preferences>(DEFAULT_PREFERENCES)
+  const [idbLoaded, setIdbLoaded] = useState(false)
+
+  // Load persisted preferences from IndexedDB on mount
+  useEffect(() => {
+    idbCache.get<Preferences>('preferences', PREFS_IDB_KEY, Infinity).then((saved) => {
+      if (saved) setInitialPrefs({ ...DEFAULT_PREFERENCES, ...saved })
+      setIdbLoaded(true)
+    })
+  }, [])
 
   const {
     state: preferences,
@@ -28,7 +41,14 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
     canUndo,
     canRedo,
     clear,
-  } = useUndoRedo<Preferences>(DEFAULT_PREFERENCES, MAX_UNDO_DEPTH)
+  } = useUndoRedo<Preferences>(initialPrefs, MAX_UNDO_DEPTH)
+
+  // Persist to IndexedDB whenever preferences change
+  useEffect(() => {
+    if (idbLoaded) {
+      idbCache.set('preferences', PREFS_IDB_KEY, preferences)
+    }
+  }, [preferences, idbLoaded])
 
   const updatePreference = useCallback(
     <K extends keyof Preferences>(key: K, value: Preferences[K]) => {


### PR DESCRIPTION
## Issue #52 — WebSocket compression (src/api/websocket.ts)

Problem: WebSocket messages carrying many asset pairs can be large, wasting bandwidth.

How it was solved:
- Detect browser support for the native DecompressionStream API at module load time (no external dependency).
- When supported, append ?compress=1 to the WebSocket URL so the server can opt-in to sending gzip-compressed binary frames.
- Set ws.binaryType = 'blob' so binary frames arrive as Blobs.
- On each message, branch on whether the frame is a Blob (binary/compressed) or a string (plain text). Binary frames are piped through DecompressionStream('gzip'), chunks are merged into a Uint8Array, decoded with TextDecoder, then JSON-parsed normally.
- If decompression throws (malformed data or deflate instead of gzip), the code falls back to reading the Blob as plain text.
- When compression is not supported, the URL is unchanged and all frames continue as plain text — full backward compatibility.
- Exposed an isCompressed getter so callers can observe whether the active connection is using compression.

Closes #52

---

## Issue #51 — IndexedDB offline cache (src/hooks/useIndexedDB.ts, src/api/rest.ts, src/preferences/PreferencesContext.tsx)

Problem: On page refresh while offline, all price data and preferences are lost.

How it was solved:

useIndexedDB.ts — new idbCache utility (no external library, zero bundle overhead):
- Opens a single versioned IndexedDB database 'stellar-oracle' with three object stores: 'prices', 'history', 'preferences'.
- Each entry is stored as { key, value, size, storedAt, accessedAt } where size is the approximate byte length of the JSON-serialised value.
- idbCache.get(store, key, ttl) returns the cached value if it exists and has not expired (storedAt + ttl > now), otherwise deletes the stale entry and returns null. Passing Infinity as the TTL serves stale data unconditionally (used for offline fallback).
- idbCache.set(store, key, value) writes the entry then runs LRU eviction: sorts all entries in the store by accessedAt ascending and deletes oldest entries until the total serialised byte size is under 50 MB.
- All IDB operations are promisified; any failure is silently swallowed so cache errors never surface to the user.

rest.ts — cache integration:
- fetchAllPrices, fetchPrice, fetchPriceHistory each attempt the network request first. On success the response is written to the appropriate IDB store with the default TTL.
- On network failure (offline or server error), the same key is fetched from IDB with TTL=Infinity (serve stale). If a stale entry exists it is returned; otherwise the original error is re-thrown so the UI can display it.

PreferencesContext.tsx — preferences persistence:
- On mount, reads 'user-preferences' from the 'preferences' IDB store with TTL=Infinity and merges it over DEFAULT_PREFERENCES as the initial state.
- After the IDB load completes (idbLoaded flag), any change to preferences triggers a fire-and-forget write to IDB so settings survive page reloads.

Closes #51

---

## Issue #50 — Shareable URL state (src/hooks/useCopyShareLink.ts, src/pages/Dashboard.tsx)

Problem: Users cannot share a specific filtered/sorted dashboard view because the state only lives in memory.

How it was solved:
- The existing FilterBar already encodes all filter and sort state (search, confidence, source, sort) as URL search params via useSearchParams, so the URL is already the single source of truth for view state.
- Added useCopyShareLink hook: calls navigator.clipboard.writeText with window.location.href. Includes a textarea fallback (document.execCommand) for browsers without the Clipboard API. Returns { copy, copied } where copied resets to false after 2 seconds.
- Dashboard renders a 'Share' button in the header that calls copy(). While copied is true the button shows a green checkmark and 'Copied!' text so the user gets immediate feedback.
- No serialisation logic was needed because URL params already capture the complete view state. Sharing the URL is sufficient to restore filters, sort order, and view mode (card/table, which is persisted via preferences + IDB).

Closes #50

---

## Issue #49 — Bulk selection (src/pages/Dashboard.tsx, src/components/PriceCard.tsx, src/components/PriceTableView.tsx)

Problem: Every action (alert, navigate) only targets a single asset pair. There is no way to operate on multiple pairs at once.

How it was solved:

Dashboard:
- Added selectMode (boolean) and selected (Set<string>) state.
- 'Select' toggle button in the dashboard header activates selection mode. The button shows the current selection count as 'Select (N)' and turns cyan when active. Deactivating clears the selection.
- In selection mode, clicking a PriceCard or table row toggles the pair in the selected Set instead of navigating to the detail page.
- Bulk action bar appears below the header when selectMode is true. It contains: selection count label, 'Select all' (sets selected to all filteredPairs), 'Deselect all', 'Export CSV', and 'Set Alerts' buttons. Export and alert buttons are disabled when nothing is selected.
- exportCSV: builds a CSV string with columns Asset Pair, Price, Confidence, Sources, Updated; creates a Blob URL; triggers a programmatic <a> click; revokes the object URL. File is named oracle-prices-<timestamp>.csv.
- handleBulkCreateAlerts: iterates selected pairs, finds the first one without an existing alert, sets it as modalPair, and opens the AlertModal. (One-at-a time alert creation reuses the existing modal without new UI complexity.)

PriceCard:
- Added selectMode?: boolean and isSelected?: boolean props.
- When selectMode is true, the drag handle is replaced with a small visual checkbox (cyan filled + checkmark when selected, grey border otherwise).
- The card border switches to ring-2 ring-cyan-500/40 when selected.
- aria-selected is set to the isSelected value in select mode for accessibility.

PriceTableView:
- Added selectMode?, selected?, onToggleSelect? props.
- When selectMode is true, a leading checkbox column is rendered in both header and each data row.
- Row click handler dispatches onToggleSelect in select mode and onRowClick otherwise.
- Selected rows get a subtle bg-cyan-900/20 background highlight.
- aria-selected is set for accessibility.

Closes #49