### PR TITLE
feat: implement issues #41, #42, #43, #44 - context menus, toast syst…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,11 @@ import { Layout } from './components/Layout'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { Dashboard } from './pages/Dashboard'
 import { NotFound } from './pages/NotFound'
-import { AlertsProvider } from './hooks/useAlerts'
 import { useWebVitals } from './hooks/useWebVitals'
 import { PreferencesProvider } from './preferences/PreferencesContext'
+import { ToastProvider } from './context/ToastContext'
+import { ToastContainer } from './components/ToastContainer'
+import { OnboardingProvider, OnboardingTourOverlay } from './components/OnboardingTour'
 
 const PriceDetail = lazy(() =>
   import('./pages/PriceDetail').then((m) => ({ default: m.PriceDetail })),
@@ -51,7 +53,13 @@ export default function App() {
 
   return (
     <BrowserRouter basename={BASENAME}>
-      <AppContent />
+      <ToastProvider>
+        <OnboardingProvider>
+          <AppContent />
+          <ToastContainer />
+          <OnboardingTourOverlay />
+        </OnboardingProvider>
+      </ToastProvider>
     </BrowserRouter>
   )
 }

--- a/src/api/rest.ts
+++ b/src/api/rest.ts
@@ -26,10 +26,15 @@ export async function fetchPrice(pair: string): Promise<PriceData> {
 export async function fetchPriceHistory(
   pair: string,
   limit = 100,
-  offset = 0
+  offset = 0,
+  startTs?: number,
+  endTs?: number,
 ): Promise<PriceHistoryResponse> {
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) })
+  if (startTs !== undefined) params.set('startTs', String(startTs))
+  if (endTs !== undefined) params.set('endTs', String(endTs))
   return request<PriceHistoryResponse>(
-    `/api/prices/${encodeURIComponent(pair)}/history?limit=${limit}&offset=${offset}`
+    `/api/prices/${encodeURIComponent(pair)}/history?${params.toString()}`,
   )
 }
 

--- a/src/components/CardContextMenu.tsx
+++ b/src/components/CardContextMenu.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useCallback, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useToast } from '../context/ToastContext'
+import { formatPrice } from '../utils/format'
+
+export interface CardContextMenuAction {
+  onSetAlert: () => void
+  onAddToCompare?: () => void
+}
+
+interface ContextMenuProps {
+  x: number
+  y: number
+  pair: string
+  price: number
+  onClose: () => void
+  actions: CardContextMenuAction
+}
+
+function ContextMenuPopup({ x, y, pair, price, onClose, actions }: ContextMenuProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const navigate = useNavigate()
+  const { addToast } = useToast()
+  const [focused, setFocused] = useState(0)
+
+  const menuItems = [
+    {
+      label: 'View Detail',
+      icon: (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+        </svg>
+      ),
+      action: () => {
+        navigate(`/price/${encodeURIComponent(pair)}`)
+        onClose()
+      },
+    },
+    {
+      label: 'Set Alert',
+      icon: (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+        </svg>
+      ),
+      action: () => {
+        actions.onSetAlert()
+        onClose()
+      },
+    },
+    {
+      label: 'Copy Price',
+      icon: (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+        </svg>
+      ),
+      action: () => {
+        navigator.clipboard.writeText(formatPrice(price)).then(() => {
+          addToast({ type: 'success', message: `Copied $${formatPrice(price)} to clipboard` })
+        }).catch(() => {
+          addToast({ type: 'error', message: 'Failed to copy price' })
+        })
+        onClose()
+      },
+    },
+    {
+      label: 'Export',
+      icon: (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+      ),
+      action: () => {
+        const csv = `pair,price\n${pair},${price}`
+        const blob = new Blob([csv], { type: 'text/csv' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `${pair.replace('/', '-')}-price.csv`
+        a.click()
+        URL.revokeObjectURL(url)
+        addToast({ type: 'success', message: `Exported ${pair} price` })
+        onClose()
+      },
+    },
+  ]
+
+  // Dismiss on outside click or Escape
+  useEffect(() => {
+    function handlePointerDown(e: PointerEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose()
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setFocused((prev) => (prev + 1) % menuItems.length)
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setFocused((prev) => (prev - 1 + menuItems.length) % menuItems.length)
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        menuItems[focused]?.action()
+      }
+    }
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onClose, focused])
+
+  // Focus first item on mount
+  useEffect(() => {
+    const items = ref.current?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')
+    items?.[focused]?.focus()
+  }, [focused])
+
+  // Adjust position so menu stays within viewport
+  const style: React.CSSProperties = {
+    position: 'fixed',
+    top: Math.min(y, window.innerHeight - 210),
+    left: Math.min(x, window.innerWidth - 200),
+    zIndex: 9999,
+  }
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      aria-label={`Actions for ${pair}`}
+      style={style}
+      className="w-48 bg-gray-900 border border-gray-700 rounded-xl shadow-2xl py-1 overflow-hidden"
+    >
+      <div className="px-3 py-1.5 text-xs font-semibold text-gray-500 border-b border-gray-800 mb-1">
+        {pair}
+      </div>
+      {menuItems.map((item, i) => (
+        <button
+          key={item.label}
+          type="button"
+          role="menuitem"
+          tabIndex={focused === i ? 0 : -1}
+          onClick={item.action}
+          onMouseEnter={() => setFocused(i)}
+          className={`w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors text-left ${
+            focused === i
+              ? 'bg-gray-800 text-white'
+              : 'text-gray-300 hover:bg-gray-800 hover:text-white'
+          }`}
+        >
+          {item.icon}
+          {item.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+interface UseCardContextMenuReturn {
+  contextMenuProps: { onContextMenu: (e: React.MouseEvent) => void }
+  overflowButtonProps: { onClick: (e: React.MouseEvent) => void; 'aria-label': string }
+  menuElement: React.ReactNode
+}
+
+export function useCardContextMenu(
+  pair: string,
+  price: number,
+  actions: CardContextMenuAction,
+): UseCardContextMenuReturn {
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null)
+
+  const openAt = useCallback((x: number, y: number) => {
+    setMenu({ x, y })
+  }, [])
+
+  const close = useCallback(() => setMenu(null), [])
+
+  const contextMenuProps = {
+    onContextMenu: (e: React.MouseEvent) => {
+      e.preventDefault()
+      openAt(e.clientX, e.clientY)
+    },
+  }
+
+  const overflowButtonProps = {
+    onClick: (e: React.MouseEvent) => {
+      e.stopPropagation()
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+      openAt(rect.left, rect.bottom + 4)
+    },
+    'aria-label': `More actions for ${pair}`,
+  }
+
+  const menuElement = menu ? (
+    <ContextMenuPopup
+      x={menu.x}
+      y={menu.y}
+      pair={pair}
+      price={price}
+      onClose={close}
+      actions={actions}
+    />
+  ) : null
+
+  return { contextMenuProps, overflowButtonProps, menuElement }
+}

--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useState, useId } from 'react'
+
+export type PresetRange = '1h' | '24h' | '7d' | '30d' | '1y' | 'all'
+
+export interface DateRange {
+  preset: PresetRange | 'custom'
+  startDate: string // ISO date string yyyy-MM-dd or ''
+  endDate: string
+}
+
+const PRESETS: { label: string; value: PresetRange }[] = [
+  { label: '1H', value: '1h' },
+  { label: '24H', value: '24h' },
+  { label: '7D', value: '7d' },
+  { label: '30D', value: '30d' },
+  { label: '1Y', value: '1y' },
+  { label: 'All', value: 'all' },
+]
+
+interface DateRangePickerProps {
+  value: DateRange
+  onChange: (range: DateRange) => void
+  maxRangeDays?: number
+}
+
+export function DateRangePicker({ value, onChange, maxRangeDays = 365 }: DateRangePickerProps) {
+  const startId = useId()
+  const endId = useId()
+  const [customError, setCustomError] = useState<string | null>(null)
+
+  const handlePreset = useCallback(
+    (preset: PresetRange) => {
+      setCustomError(null)
+      onChange({ preset, startDate: '', endDate: '' })
+    },
+    [onChange],
+  )
+
+  const handleCustomChange = useCallback(
+    (field: 'startDate' | 'endDate', val: string) => {
+      const next: DateRange = { ...value, preset: 'custom', [field]: val }
+
+      // Validation
+      if (next.startDate && next.endDate) {
+        const start = new Date(next.startDate)
+        const end = new Date(next.endDate)
+        if (end <= start) {
+          setCustomError('End date must be after start date')
+        } else {
+          const diffDays = (end.getTime() - start.getTime()) / 86_400_000
+          if (diffDays > maxRangeDays) {
+            setCustomError(`Maximum range is ${maxRangeDays} days`)
+          } else {
+            setCustomError(null)
+            onChange(next)
+            return
+          }
+        }
+      } else {
+        setCustomError(null)
+      }
+      onChange(next)
+    },
+    [value, onChange, maxRangeDays],
+  )
+
+  const today = new Date().toISOString().split('T')[0]
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {/* Preset buttons */}
+      <div
+        role="group"
+        aria-label="Time range presets"
+        className="flex items-center gap-1 bg-gray-800 rounded-lg p-1"
+      >
+        {PRESETS.map((p) => (
+          <button
+            key={p.value}
+            type="button"
+            onClick={() => handlePreset(p.value)}
+            aria-pressed={value.preset === p.value}
+            className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+              value.preset === p.value
+                ? 'bg-cyan-600 text-white'
+                : 'text-gray-400 hover:text-white hover:bg-gray-700'
+            }`}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Custom range */}
+      <div className="flex items-center gap-2">
+        <div className="flex flex-col">
+          <label htmlFor={startId} className="sr-only">
+            Start date
+          </label>
+          <input
+            id={startId}
+            type="date"
+            value={value.startDate}
+            max={value.endDate || today}
+            onChange={(e) => handleCustomChange('startDate', e.target.value)}
+            aria-invalid={!!customError}
+            className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-1.5 text-xs text-gray-200 focus:outline-none focus:ring-2 focus:ring-cyan-500 [color-scheme:dark]"
+          />
+        </div>
+        <span className="text-gray-500 text-xs">to</span>
+        <div className="flex flex-col">
+          <label htmlFor={endId} className="sr-only">
+            End date
+          </label>
+          <input
+            id={endId}
+            type="date"
+            value={value.endDate}
+            min={value.startDate || undefined}
+            max={today}
+            onChange={(e) => handleCustomChange('endDate', e.target.value)}
+            aria-invalid={!!customError}
+            className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-1.5 text-xs text-gray-200 focus:outline-none focus:ring-2 focus:ring-cyan-500 [color-scheme:dark]"
+          />
+        </div>
+      </div>
+
+      {customError && (
+        <p role="alert" className="text-xs text-red-400 w-full mt-1">
+          {customError}
+        </p>
+      )}
+    </div>
+  )
+}
+
+/** Convert a DateRange to the API `limit` param and optional start/end timestamps */
+export function dateRangeToParams(range: DateRange): { limit: number; startTs?: number; endTs?: number } {
+  const now = Date.now()
+  const HOUR = 3_600_000
+
+  if (range.preset === 'custom' && range.startDate && range.endDate) {
+    return {
+      limit: 500,
+      startTs: new Date(range.startDate).getTime(),
+      endTs: new Date(range.endDate + 'T23:59:59').getTime(),
+    }
+  }
+
+  switch (range.preset) {
+    case '1h':
+      return { limit: 60, startTs: now - HOUR }
+    case '24h':
+      return { limit: 288, startTs: now - 24 * HOUR }
+    case '7d':
+      return { limit: 500, startTs: now - 7 * 24 * HOUR }
+    case '30d':
+      return { limit: 500, startTs: now - 30 * 24 * HOUR }
+    case '1y':
+      return { limit: 500, startTs: now - 365 * 24 * HOUR }
+    case 'all':
+    default:
+      return { limit: 500 }
+  }
+}

--- a/src/components/OnboardingTooltip.tsx
+++ b/src/components/OnboardingTooltip.tsx
@@ -1,0 +1,92 @@
+import { useState, useRef, useEffect, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+interface TooltipProps {
+  content: ReactNode
+  /** Controls whether the tooltip is shown */
+  visible?: boolean
+  /** Position relative to the anchor */
+  placement?: 'top' | 'bottom' | 'left' | 'right'
+  /** Dismiss callback */
+  onDismiss?: () => void
+  children: ReactNode
+}
+
+export function OnboardingTooltip({
+  content,
+  visible = false,
+  placement = 'bottom',
+  onDismiss,
+  children,
+}: TooltipProps) {
+  const anchorRef = useRef<HTMLSpanElement>(null)
+  const [pos, setPos] = useState({ top: 0, left: 0 })
+
+  useEffect(() => {
+    if (!visible || !anchorRef.current) return
+    const rect = anchorRef.current.getBoundingClientRect()
+    const GAP = 8
+    let top = 0
+    let left = 0
+
+    switch (placement) {
+      case 'top':
+        top = rect.top - GAP
+        left = rect.left + rect.width / 2
+        break
+      case 'bottom':
+        top = rect.bottom + GAP
+        left = rect.left + rect.width / 2
+        break
+      case 'left':
+        top = rect.top + rect.height / 2
+        left = rect.left - GAP
+        break
+      case 'right':
+        top = rect.top + rect.height / 2
+        left = rect.right + GAP
+        break
+    }
+    setPos({ top, left })
+  }, [visible, placement])
+
+  if (!visible) return <span ref={anchorRef}>{children}</span>
+
+  const transformMap: Record<string, string> = {
+    top: 'translate(-50%, -100%)',
+    bottom: 'translate(-50%, 0)',
+    left: 'translate(-100%, -50%)',
+    right: 'translate(0, -50%)',
+  }
+
+  return (
+    <>
+      <span ref={anchorRef}>{children}</span>
+      {createPortal(
+        <div
+          role="tooltip"
+          style={{
+            position: 'fixed',
+            top: pos.top,
+            left: pos.left,
+            transform: transformMap[placement],
+            zIndex: 10000,
+          }}
+          className="max-w-xs bg-gray-900 border border-cyan-500/40 rounded-xl shadow-2xl p-3 text-sm text-gray-200 animate-in fade-in"
+        >
+          <div className="mb-2">{content}</div>
+          {onDismiss && (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="text-xs text-cyan-400 hover:text-cyan-300 transition-colors font-medium"
+            >
+              Got it
+            </button>
+          )}
+        </div>,
+        document.body,
+      )}
+    </>
+  )
+}

--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -1,0 +1,254 @@
+import { useState, useCallback, useEffect, createContext, useContext, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+const STORAGE_KEY = 'onboarding-tour-dismissed'
+
+export interface TourStep {
+  id: string
+  title: string
+  description: string
+  /** CSS selector for the element to highlight */
+  targetSelector?: string
+}
+
+const DEFAULT_STEPS: TourStep[] = [
+  {
+    id: 'welcome',
+    title: 'Welcome to Stellar Oracle',
+    description:
+      'This dashboard aggregates real-time price feeds from Chainlink, Redstone, Band, and Reflector oracles into a single, unified view.',
+  },
+  {
+    id: 'price-cards',
+    title: 'Price Cards',
+    description:
+      'Each card shows live prices for an asset pair. Right-click any card or use the ⋮ menu for quick actions like setting alerts, exporting data, and more.',
+    targetSelector: '[aria-label="Price feeds"]',
+  },
+  {
+    id: 'connection-badge',
+    title: 'WebSocket Connection',
+    description:
+      'The connection badge shows the real-time WebSocket status. A green dot means prices are updating live. If it goes orange or red, prices may be delayed.',
+    targetSelector: '[aria-label^="WebSocket"]',
+  },
+  {
+    id: 'confidence',
+    title: 'Confidence Score',
+    description:
+      'The confidence score (e.g. 98.8%) reflects how many oracle sources agreed on the price. Higher scores mean stronger consensus across Chainlink, Redstone, Band & Reflector.',
+  },
+  {
+    id: 'alerts',
+    title: 'Price Alerts',
+    description:
+      'Click the bell icon to set upper/lower price thresholds. You\'ll receive a browser notification when an asset crosses your alert price.',
+    targetSelector: '[aria-label="Toggle price alerts"]',
+  },
+]
+
+interface OnboardingContextValue {
+  isDismissed: boolean
+  isActive: boolean
+  startTour: () => void
+  dismissTour: () => void
+  currentStep: number
+  steps: TourStep[]
+  goToStep: (index: number) => void
+  next: () => void
+  prev: () => void
+}
+
+const OnboardingContext = createContext<OnboardingContextValue | null>(null)
+
+export function OnboardingProvider({ children }: { children: ReactNode }) {
+  const [isDismissed, setIsDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === 'true'
+    } catch {
+      return false
+    }
+  })
+  const [isActive, setIsActive] = useState(false)
+  const [currentStep, setCurrentStep] = useState(0)
+
+  // Auto-start for first-time visitors
+  useEffect(() => {
+    if (!isDismissed) {
+      // Small delay so the page renders first
+      const t = setTimeout(() => setIsActive(true), 800)
+      return () => clearTimeout(t)
+    }
+  }, [isDismissed])
+
+  const startTour = useCallback(() => {
+    setCurrentStep(0)
+    setIsActive(true)
+  }, [])
+
+  const dismissTour = useCallback(() => {
+    setIsActive(false)
+    setIsDismissed(true)
+    try {
+      localStorage.setItem(STORAGE_KEY, 'true')
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  const next = useCallback(() => {
+    if (currentStep < DEFAULT_STEPS.length - 1) {
+      setCurrentStep((s) => s + 1)
+    } else {
+      dismissTour()
+    }
+  }, [currentStep, dismissTour])
+
+  const prev = useCallback(() => {
+    setCurrentStep((s) => Math.max(0, s - 1))
+  }, [])
+
+  const goToStep = useCallback((index: number) => {
+    setCurrentStep(Math.max(0, Math.min(DEFAULT_STEPS.length - 1, index)))
+  }, [])
+
+  return (
+    <OnboardingContext.Provider
+      value={{
+        isDismissed,
+        isActive,
+        startTour,
+        dismissTour,
+        currentStep,
+        steps: DEFAULT_STEPS,
+        goToStep,
+        next,
+        prev,
+      }}
+    >
+      {children}
+    </OnboardingContext.Provider>
+  )
+}
+
+export function useOnboarding(): OnboardingContextValue {
+  const ctx = useContext(OnboardingContext)
+  if (!ctx) throw new Error('useOnboarding must be used within an OnboardingProvider')
+  return ctx
+}
+
+function TourOverlay() {
+  const { isActive, steps, currentStep, next, prev, dismissTour } = useOnboarding()
+
+  const step = steps[currentStep]
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!isActive) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'ArrowRight' || e.key === 'Enter') next()
+      else if (e.key === 'ArrowLeft') prev()
+      else if (e.key === 'Escape') dismissTour()
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [isActive, next, prev, dismissTour])
+
+  // Highlight target element
+  const [highlight, setHighlight] = useState<DOMRect | null>(null)
+  useEffect(() => {
+    if (!isActive || !step?.targetSelector) {
+      setHighlight(null)
+      return
+    }
+    const el = document.querySelector(step.targetSelector)
+    if (el) {
+      setHighlight(el.getBoundingClientRect())
+      el.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    } else {
+      setHighlight(null)
+    }
+  }, [isActive, step])
+
+  if (!isActive || !step) return null
+
+  return createPortal(
+    <div className="fixed inset-0 z-[9990] pointer-events-none">
+      {/* Dimmed backdrop with highlight cutout */}
+      <div className="absolute inset-0 bg-black/50 pointer-events-auto" onClick={dismissTour} />
+
+      {/* Highlight ring */}
+      {highlight && (
+        <div
+          className="absolute pointer-events-none rounded-xl ring-2 ring-cyan-400 ring-offset-2 ring-offset-transparent transition-all duration-300"
+          style={{
+            top: highlight.top - 4,
+            left: highlight.left - 4,
+            width: highlight.width + 8,
+            height: highlight.height + 8,
+          }}
+        />
+      )}
+
+      {/* Tour card */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Onboarding step ${currentStep + 1} of ${steps.length}: ${step.title}`}
+        className="absolute bottom-8 left-1/2 -translate-x-1/2 w-full max-w-sm bg-gray-900 border border-cyan-500/40 rounded-2xl shadow-2xl p-5 pointer-events-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Progress dots */}
+        <div className="flex items-center gap-1.5 mb-3" aria-label={`Step ${currentStep + 1} of ${steps.length}`}>
+          {steps.map((_, i) => (
+            <span
+              key={i}
+              className={`h-1.5 rounded-full transition-all ${
+                i === currentStep ? 'w-5 bg-cyan-400' : 'w-1.5 bg-gray-700'
+              }`}
+            />
+          ))}
+          <span className="ml-auto text-xs text-gray-500">
+            {currentStep + 1}/{steps.length}
+          </span>
+        </div>
+
+        <h3 className="text-base font-semibold text-white mb-1.5">{step.title}</h3>
+        <p className="text-sm text-gray-400 mb-4 leading-relaxed">{step.description}</p>
+
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={dismissTour}
+            className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            Skip tour
+          </button>
+          <div className="flex gap-2">
+            {currentStep > 0 && (
+              <button
+                type="button"
+                onClick={prev}
+                className="px-3 py-1.5 text-sm text-gray-400 bg-gray-800 hover:bg-gray-700 rounded-lg transition-colors"
+              >
+                Back
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={next}
+              className="px-4 py-1.5 text-sm font-medium text-white bg-cyan-600 hover:bg-cyan-500 rounded-lg transition-colors"
+            >
+              {currentStep === steps.length - 1 ? 'Done' : 'Next'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+export function OnboardingTourOverlay() {
+  return <TourOverlay />
+}

--- a/src/components/PriceCard.tsx
+++ b/src/components/PriceCard.tsx
@@ -1,6 +1,8 @@
 import { memo } from 'react'
 import type { PriceData } from '../types'
 import { formatPrice, timeAgo } from '../utils/format'
+import { useCardContextMenu, type CardContextMenuAction } from './CardContextMenu'
+
 const SOURCE_COLORS: Record<string, string> = {
   chainlink: 'bg-blue-500/20 text-blue-600 dark:text-blue-400 border-blue-500/30',
   redstone: 'bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/30',
@@ -28,94 +30,155 @@ interface PriceCardProps {
   isDragOver?: boolean
 }
 
-export const PriceCard = memo(function PriceCard({ price, onClick, isLive, isStale, hasAlert, onAlertClick, dragHandleProps, isDragOver }: PriceCardProps) {
+export const PriceCard = memo(function PriceCard({
+  price,
+  onClick,
+  isLive,
+  isStale,
+  hasAlert,
+  onAlertClick,
+  dragHandleProps,
+  isDragOver,
+}: PriceCardProps) {
   const confidencePct = (price.confidence * 100).toFixed(1)
 
+  const contextActions: CardContextMenuAction = {
+    onSetAlert: () => {
+      // Synthesise a click on the alert button via the prop
+      onAlertClick?.({} as React.MouseEvent)
+    },
+  }
+
+  const { contextMenuProps, overflowButtonProps, menuElement } = useCardContextMenu(
+    price.assetPair,
+    price.price,
+    contextActions,
+  )
+
   return (
-    <div
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onClick?.()
-        }
-      }}
-      role="button"
-      tabIndex={0}
-      className={`w-full text-left bg-gray-900 border rounded-xl p-5 hover:border-gray-700 hover:bg-gray-900/80 transition-all shadow-lg shadow-black/20 cursor-pointer ${isStale ? 'opacity-60' : ''} ${isDragOver ? 'border-cyan-500 ring-1 ring-cyan-500/40' : 'border-gray-800'}`}
-      aria-label={`View details for ${price.assetPair}`}
-    >
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2">
-          {dragHandleProps && (
+    <>
+      <div
+        onClick={onClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onClick?.()
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        {...contextMenuProps}
+        className={`w-full text-left bg-gray-900 border rounded-xl p-5 hover:border-gray-700 hover:bg-gray-900/80 transition-all shadow-lg shadow-black/20 cursor-pointer ${isStale ? 'opacity-60' : ''} ${isDragOver ? 'border-cyan-500 ring-1 ring-cyan-500/40' : 'border-gray-800'}`}
+        aria-label={`View details for ${price.assetPair}`}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            {dragHandleProps && (
+              <button
+                type="button"
+                aria-label={`Drag handle for ${price.assetPair}`}
+                tabIndex={0}
+                className="cursor-grab text-gray-600 hover:text-gray-400 touch-none"
+                onClick={(e) => e.stopPropagation()}
+                {...dragHandleProps}
+              >
+                <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                  <circle cx="5" cy="4" r="1.2" />
+                  <circle cx="5" cy="8" r="1.2" />
+                  <circle cx="5" cy="12" r="1.2" />
+                  <circle cx="11" cy="4" r="1.2" />
+                  <circle cx="11" cy="8" r="1.2" />
+                  <circle cx="11" cy="12" r="1.2" />
+                </svg>
+              </button>
+            )}
+            <h3 className="text-lg font-semibold text-gray-100">{price.assetPair}</h3>
+          </div>
+          <div className="flex items-center gap-2">
+            {hasAlert && (
+              <span
+                className="w-2 h-2 rounded-full bg-amber-400"
+                role="status"
+                aria-label="Active alert"
+              />
+            )}
+            {isLive && (
+              <span
+                className="w-2 h-2 rounded-full bg-green-500 animate-pulse"
+                role="status"
+                aria-label="Live data"
+              />
+            )}
+            {/* Overflow / three-dot menu button */}
             <button
               type="button"
-              aria-label={`Drag handle for ${price.assetPair}`}
-              tabIndex={0}
-              className="cursor-grab text-gray-600 hover:text-gray-400 touch-none"
-              onClick={(e) => e.stopPropagation()}
-              {...dragHandleProps}
+              {...overflowButtonProps}
+              onClick={(e) => {
+                e.stopPropagation()
+                overflowButtonProps.onClick(e)
+              }}
+              className="p-1 rounded-md text-gray-600 hover:text-gray-300 hover:bg-gray-800 transition-colors"
             >
               <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                <circle cx="5" cy="4" r="1.2" />
-                <circle cx="5" cy="8" r="1.2" />
-                <circle cx="5" cy="12" r="1.2" />
-                <circle cx="11" cy="4" r="1.2" />
-                <circle cx="11" cy="8" r="1.2" />
-                <circle cx="11" cy="12" r="1.2" />
+                <circle cx="8" cy="3" r="1.2" />
+                <circle cx="8" cy="8" r="1.2" />
+                <circle cx="8" cy="13" r="1.2" />
               </svg>
             </button>
-          )}
-          <h3 className="text-lg font-semibold text-gray-100">{price.assetPair}</h3>
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          {hasAlert && (
+
+        <div className="text-3xl font-bold text-gray-900 dark:text-white mb-3 font-mono tracking-tight">
+          ${formatPrice(price.price)}
+        </div>
+
+        <div className="flex items-center justify-between text-xs text-gray-400 dark:text-gray-500 mb-3">
+          <span>Updated {timeAgo(price.timestamp)}</span>
+          <span className="text-cyan-600 dark:text-cyan-400">{confidencePct}% confidence</span>
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          {price.sources.map((src) => (
             <span
-              className="w-2 h-2 rounded-full bg-amber-400"
-              role="status"
-              aria-label="Active alert"
-            />
-          )}
-          {isLive && <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" role="status" aria-label="Live data" />}
+              key={src}
+              className={`px-2 py-0.5 rounded text-xs font-medium border ${SOURCE_COLORS[src] ?? 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700'}`}
+            >
+              {src}
+            </span>
+          ))}
+        </div>
+
+        <div className="mt-3 pt-3 border-t border-gray-800">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              onAlertClick?.(e)
+            }}
+            className={`flex items-center gap-1.5 text-xs font-medium transition-colors ${hasAlert ? 'text-amber-400 hover:text-amber-300' : 'text-gray-500 hover:text-gray-300'}`}
+            aria-label={`Set alert for ${price.assetPair}`}
+          >
+            <svg
+              className="w-3.5 h-3.5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z"
+              />
+            </svg>
+            {hasAlert ? 'Alert set' : 'Set alert'}
+          </button>
         </div>
       </div>
 
-      <div className="text-3xl font-bold text-gray-900 dark:text-white mb-3 font-mono tracking-tight">
-        ${formatPrice(price.price)}
-      </div>
-
-      <div className="flex items-center justify-between text-xs text-gray-400 dark:text-gray-500 mb-3">
-        <span>Updated {timeAgo(price.timestamp)}</span>
-        <span className="text-cyan-600 dark:text-cyan-400">{confidencePct}% confidence</span>
-      </div>
-
-      <div className="flex flex-wrap gap-1.5">
-        {price.sources.map((src) => (
-          <span
-            key={src}
-            className={`px-2 py-0.5 rounded text-xs font-medium border ${SOURCE_COLORS[src] ?? 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700'}`}
-          >
-            {src}
-          </span>
-        ))}
-      </div>
-
-      <div className="mt-3 pt-3 border-t border-gray-800">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            onAlertClick?.(e)
-          }}
-          className={`flex items-center gap-1.5 text-xs font-medium transition-colors ${hasAlert ? 'text-amber-400 hover:text-amber-300' : 'text-gray-500 hover:text-gray-300'}`}
-          aria-label={`Set alert for ${price.assetPair}`}
-        >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z" />
-          </svg>
-          {hasAlert ? 'Alert set' : 'Set alert'}
-        </button>
-      </div>
-    </div>
+      {/* Context menu portal */}
+      {menuElement}
+    </>
   )
 })

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { usePreferences } from '../preferences/PreferencesContext'
+import { useOnboarding } from './OnboardingTour'
 import {
   REFRESH_INTERVAL_OPTIONS,
   CHART_RANGE_OPTIONS,
@@ -12,6 +13,7 @@ interface SettingsPanelProps {
 export function SettingsPanel({ onClose }: SettingsPanelProps) {
   const { preferences, updatePreference, undo, redo, canUndo, canRedo, clearHistory } =
     usePreferences()
+  const { startTour } = useOnboarding()
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
@@ -117,6 +119,19 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
               Clear
             </button>
           </div>
+        </div>
+
+        <div className="border-t border-gray-800 px-6 py-4">
+          <button
+            onClick={() => { startTour(); onClose() }}
+            className="flex items-center gap-2 w-full px-4 py-2 rounded-lg text-sm font-medium text-gray-300 bg-gray-800 hover:bg-gray-700 transition-colors"
+            aria-label="Replay onboarding tour"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Replay Onboarding Tour
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { useToast, type Toast, type ToastType } from '../context/ToastContext'
+
+const ICONS: Record<ToastType, React.ReactNode> = {
+  success: (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+    </svg>
+  ),
+  error: (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  ),
+  warning: (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+    </svg>
+  ),
+  info: (
+    <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+}
+
+const STYLES: Record<ToastType, string> = {
+  success: 'bg-gray-900 border-green-500/40 text-green-400',
+  error: 'bg-gray-900 border-red-500/40 text-red-400',
+  warning: 'bg-gray-900 border-amber-500/40 text-amber-400',
+  info: 'bg-gray-900 border-cyan-500/40 text-cyan-400',
+}
+
+function ToastItem({ toast }: { toast: Toast }) {
+  const { removeToast } = useToast()
+  const ref = useRef<HTMLDivElement>(null)
+
+  // Swipe-to-dismiss (touch)
+  const touchStartX = useRef(0)
+  function onTouchStart(e: React.TouchEvent) {
+    touchStartX.current = e.touches[0].clientX
+  }
+  function onTouchEnd(e: React.TouchEvent) {
+    const dx = e.changedTouches[0].clientX - touchStartX.current
+    if (Math.abs(dx) > 60) removeToast(toast.id)
+  }
+
+  // Keyboard: Delete or Escape closes this toast when focused
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Delete' || e.key === 'Escape') {
+      removeToast(toast.id)
+    }
+  }
+
+  useEffect(() => {
+    // Announce via aria-live (the container handles it), just animate in
+    const el = ref.current
+    if (el) {
+      el.style.opacity = '0'
+      el.style.transform = 'translateX(1rem)'
+      requestAnimationFrame(() => {
+        el.style.transition = 'opacity 0.2s ease, transform 0.2s ease'
+        el.style.opacity = '1'
+        el.style.transform = 'translateX(0)'
+      })
+    }
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+      className={`flex items-start gap-3 px-4 py-3 rounded-xl border shadow-xl text-sm font-medium max-w-sm w-full cursor-pointer select-none ${STYLES[toast.type]}`}
+      onClick={() => removeToast(toast.id)}
+    >
+      {ICONS[toast.type]}
+      <span className="flex-1 text-gray-100">{toast.message}</span>
+      <button
+        type="button"
+        aria-label="Dismiss notification"
+        onClick={(e) => { e.stopPropagation(); removeToast(toast.id) }}
+        className="text-gray-500 hover:text-gray-300 transition-colors ml-1 shrink-0"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  )
+}
+
+export function ToastContainer() {
+  const { toasts } = useToast()
+
+  if (toasts.length === 0) return null
+
+  return createPortal(
+    <div
+      aria-label="Notifications"
+      className="fixed bottom-4 right-4 z-[9998] flex flex-col gap-2 items-end pointer-events-none"
+    >
+      {toasts.map((toast) => (
+        <div key={toast.id} className="pointer-events-auto">
+          <ToastItem toast={toast} />
+        </div>
+      ))}
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/__snapshots__/Layout.test.tsx.snap
+++ b/src/components/__snapshots__/Layout.test.tsx.snap
@@ -30,80 +30,109 @@ exports[`snapshots > default 1`] = `
           </span>
         </a>
         <div
-          class="hidden sm:flex items-center gap-1"
+          class="flex items-center gap-2 sm:gap-4"
         >
-          <a
-            class="px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-100 dark:bg-gray-800 text-cyan-600 dark:text-cyan-400"
-            data-discover="true"
-            href="/"
+          <div
+            class="hidden sm:flex items-center gap-1"
           >
-            Dashboard
-          </a>
-        </div>
-        <div
-          class="flex items-center gap-2"
-        >
-          <button
-            aria-label="Open settings"
-            class="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-          >
-            <svg
-              class="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+            <a
+              class="px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-100 dark:bg-gray-800 text-cyan-600 dark:text-cyan-400"
+              data-discover="true"
+              href="/"
             >
-              <path
-                d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-          <button
-            aria-label="Switch to dark theme"
-            class="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-          >
-            <svg
-              aria-hidden="true"
-              class="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+              Dashboard
+            </a>
+            <a
+              class="px-4 py-2 rounded-lg text-sm font-medium transition-colors text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800/50"
+              data-discover="true"
+              href="/sources"
             >
-              <path
-                d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
-          <button
-            aria-label="Toggle menu"
-            class="sm:hidden p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+              Source Health
+            </a>
+          </div>
+          <div
+            class="flex items-center gap-2"
           >
-            <svg
-              class="w-6 h-6"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+            <button
+              aria-label="Toggle price alerts"
+              class="relative p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
             >
-              <path
-                d="M4 6h16M4 12h16M4 18h16"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </button>
+              <svg
+                class="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Open settings"
+              class="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            >
+              <svg
+                class="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Switch to dark theme"
+              class="p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            >
+              <svg
+                aria-hidden="true"
+                class="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Toggle menu"
+              class="sm:hidden p-2 rounded-lg text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+            >
+              <svg
+                class="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M4 6h16M4 12h16M4 18h16"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/__snapshots__/PriceCard.test.tsx.snap
+++ b/src/components/__snapshots__/PriceCard.test.tsx.snap
@@ -21,7 +21,36 @@ exports[`snapshots > default 1`] = `
     </div>
     <div
       class="flex items-center gap-2"
-    />
+    >
+      <button
+        aria-label="More actions for BTC/USD"
+        class="p-1 rounded-md text-gray-600 hover:text-gray-300 hover:bg-gray-800 transition-colors"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="currentColor"
+          viewBox="0 0 16 16"
+        >
+          <circle
+            cx="8"
+            cy="3"
+            r="1.2"
+          />
+          <circle
+            cx="8"
+            cy="8"
+            r="1.2"
+          />
+          <circle
+            cx="8"
+            cy="13"
+            r="1.2"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
   <div
     class="text-3xl font-bold text-gray-900 dark:text-white mb-3 font-mono tracking-tight"
@@ -112,6 +141,34 @@ exports[`snapshots > hasAlert 1`] = `
         class="w-2 h-2 rounded-full bg-amber-400"
         role="status"
       />
+      <button
+        aria-label="More actions for BTC/USD"
+        class="p-1 rounded-md text-gray-600 hover:text-gray-300 hover:bg-gray-800 transition-colors"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="currentColor"
+          viewBox="0 0 16 16"
+        >
+          <circle
+            cx="8"
+            cy="3"
+            r="1.2"
+          />
+          <circle
+            cx="8"
+            cy="8"
+            r="1.2"
+          />
+          <circle
+            cx="8"
+            cy="13"
+            r="1.2"
+          />
+        </svg>
+      </button>
     </div>
   </div>
   <div
@@ -203,6 +260,34 @@ exports[`snapshots > isLive 1`] = `
         class="w-2 h-2 rounded-full bg-green-500 animate-pulse"
         role="status"
       />
+      <button
+        aria-label="More actions for BTC/USD"
+        class="p-1 rounded-md text-gray-600 hover:text-gray-300 hover:bg-gray-800 transition-colors"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="currentColor"
+          viewBox="0 0 16 16"
+        >
+          <circle
+            cx="8"
+            cy="3"
+            r="1.2"
+          />
+          <circle
+            cx="8"
+            cy="8"
+            r="1.2"
+          />
+          <circle
+            cx="8"
+            cy="13"
+            r="1.2"
+          />
+        </svg>
+      </button>
     </div>
   </div>
   <div
@@ -288,7 +373,36 @@ exports[`snapshots > isStale 1`] = `
     </div>
     <div
       class="flex items-center gap-2"
-    />
+    >
+      <button
+        aria-label="More actions for BTC/USD"
+        class="p-1 rounded-md text-gray-600 hover:text-gray-300 hover:bg-gray-800 transition-colors"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="currentColor"
+          viewBox="0 0 16 16"
+        >
+          <circle
+            cx="8"
+            cy="3"
+            r="1.2"
+          />
+          <circle
+            cx="8"
+            cy="8"
+            r="1.2"
+          />
+          <circle
+            cx="8"
+            cy="13"
+            r="1.2"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
   <div
     class="text-3xl font-bold text-gray-900 dark:text-white mb-3 font-mono tracking-tight"

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -1,0 +1,77 @@
+import {
+  createContext,
+  useContext,
+  useCallback,
+  useState,
+  useRef,
+  useEffect,
+  type ReactNode,
+} from 'react'
+
+export type ToastType = 'success' | 'error' | 'warning' | 'info'
+
+export interface Toast {
+  id: string
+  type: ToastType
+  message: string
+  duration?: number
+}
+
+interface ToastContextValue {
+  toasts: Toast[]
+  addToast: (toast: Omit<Toast, 'id'>) => string
+  removeToast: (id: string) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+const DEFAULT_DURATION = 4000
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+    const timer = timersRef.current.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      timersRef.current.delete(id)
+    }
+  }, [])
+
+  const addToast = useCallback(
+    (toast: Omit<Toast, 'id'>): string => {
+      const id = crypto.randomUUID()
+      const duration = toast.duration ?? DEFAULT_DURATION
+      setToasts((prev) => [...prev, { ...toast, id }])
+      if (duration > 0) {
+        const timer = setTimeout(() => removeToast(id), duration)
+        timersRef.current.set(id, timer)
+      }
+      return id
+    },
+    [removeToast],
+  )
+
+  // Cleanup on unmount
+  useEffect(() => {
+    const timers = timersRef.current
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer))
+      timers.clear()
+    }
+  }, [])
+
+  return (
+    <ToastContext.Provider value={{ toasts, addToast, removeToast }}>
+      {children}
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used within a ToastProvider')
+  return ctx
+}

--- a/src/hooks/usePriceHistory.ts
+++ b/src/hooks/usePriceHistory.ts
@@ -2,7 +2,14 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { fetchPriceHistory } from '../api/rest'
 import type { PriceHistoryEntry } from '../types'
 
-export function usePriceHistory(pair: string | null, limit = 100) {
+export interface PriceHistoryOptions {
+  limit?: number
+  startTs?: number
+  endTs?: number
+}
+
+export function usePriceHistory(pair: string | null, options: PriceHistoryOptions = {}) {
+  const { limit = 100, startTs, endTs } = options
   const [history, setHistory] = useState<PriceHistoryEntry[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -12,7 +19,7 @@ export function usePriceHistory(pair: string | null, limit = 100) {
     if (!pair) return
     setLoading(true)
     try {
-      const res = await fetchPriceHistory(pair, limit)
+      const res = await fetchPriceHistory(pair, limit, 0, startTs, endTs)
       setHistory(res.history)
       setError(null)
     } catch (e) {
@@ -20,7 +27,7 @@ export function usePriceHistory(pair: string | null, limit = 100) {
     } finally {
       setLoading(false)
     }
-  }, [pair, limit])
+  }, [pair, limit, startTs, endTs])
 
   useEffect(() => {
     load()

--- a/src/pages/PriceDetail.tsx
+++ b/src/pages/PriceDetail.tsx
@@ -1,5 +1,5 @@
-import { useParams, useNavigate } from 'react-router-dom'
-import { useEffect, useState, useCallback } from 'react'
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { usePriceHistory } from '../hooks/usePriceHistory'
 import { usePriceContext } from '../context/PriceContext'
 import { useAlerts } from '../hooks/useAlerts'
@@ -8,19 +8,55 @@ import { SourceHealthBadge } from '../components/SourceHealthBadge'
 import { ConnectionBadge } from '../components/ConnectionBadge'
 import { AlertBadge } from '../components/AlertBadge'
 import { AlertModal } from '../components/AlertModal'
+import { DateRangePicker, dateRangeToParams, type DateRange } from '../components/DateRangePicker'
 import { formatPrice, formatTimestamp } from '../utils/format'
 import type { Alert, AlertFormData } from '../types'
+
+function parseDateRange(searchParams: URLSearchParams): DateRange {
+  const preset = searchParams.get('preset')
+  const startDate = searchParams.get('startDate') ?? ''
+  const endDate = searchParams.get('endDate') ?? ''
+
+  const validPresets = ['1h', '24h', '7d', '30d', '1y', 'all', 'custom']
+  if (preset && validPresets.includes(preset)) {
+    return { preset: preset as DateRange['preset'], startDate, endDate }
+  }
+  return { preset: '24h', startDate: '', endDate: '' }
+}
 
 export function PriceDetail() {
   const { pair } = useParams<{ pair: string }>()
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const decodedPair = pair ? decodeURIComponent(pair) : null
-  const { history, loading: historyLoading } = usePriceHistory(decodedPair)
+
+  // Date range state — persisted in URL
+  const [dateRange, setDateRange] = useState<DateRange>(() => parseDateRange(searchParams))
+
+  const historyParams = useMemo(() => dateRangeToParams(dateRange), [dateRange])
+
+  const { history, loading: historyLoading } = usePriceHistory(decodedPair, historyParams)
   const { prices, livePrices, wsStatus, subscribe, unsubscribe } = usePriceContext()
-  const { alerts, addAlert, updateAlert, removeAlert, getAlertsForPair, hasAlertsForPair } = useAlerts()
+  const { alerts, addAlert, updateAlert, removeAlert, getAlertsForPair, hasAlertsForPair } =
+    useAlerts()
 
   const [modalOpen, setModalOpen] = useState(false)
   const [editingAlert, setEditingAlert] = useState<Alert | null>(null)
+
+  // Sync date range to URL
+  const handleDateRangeChange = useCallback(
+    (range: DateRange) => {
+      setDateRange(range)
+      const params = new URLSearchParams(searchParams)
+      params.set('preset', range.preset)
+      if (range.startDate) params.set('startDate', range.startDate)
+      else params.delete('startDate')
+      if (range.endDate) params.set('endDate', range.endDate)
+      else params.delete('endDate')
+      setSearchParams(params, { replace: true })
+    },
+    [searchParams, setSearchParams],
+  )
 
   useEffect(() => {
     if (decodedPair) subscribe([decodedPair])
@@ -29,7 +65,8 @@ export function PriceDetail() {
     }
   }, [decodedPair, subscribe, unsubscribe])
 
-  const priceData = livePrices.get(decodedPair ?? '') ?? prices.find((p) => p.assetPair === decodedPair)
+  const priceData =
+    livePrices.get(decodedPair ?? '') ?? prices.find((p) => p.assetPair === decodedPair)
 
   const handleOpenModal = useCallback(() => {
     const existing = alerts.find((a) => a.assetPair === decodedPair && a.active)
@@ -82,7 +119,13 @@ export function PriceDetail() {
         className="mb-6 text-sm text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors flex items-center gap-1 cursor-pointer"
         type="button"
       >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
         </svg>
         Back to Dashboard
@@ -129,8 +172,19 @@ export function PriceDetail() {
               className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-xl transition-colors ${hasAlertsForPair(decodedPair) ? 'text-amber-400 bg-amber-400/10 border border-amber-400/20 hover:bg-amber-400/20' : 'text-gray-400 bg-gray-800 border border-gray-700 hover:bg-gray-700 hover:text-gray-300'}`}
               aria-label={hasAlertsForPair(decodedPair) ? 'Manage alerts' : 'Set price alert'}
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z" />
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z"
+                />
               </svg>
               {hasAlertsForPair(decodedPair) ? 'Manage Alert' : 'Set Alert'}
             </button>
@@ -147,19 +201,31 @@ export function PriceDetail() {
             className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-400 bg-gray-800 border border-gray-700 rounded-xl hover:bg-gray-700 hover:text-gray-300 transition-colors"
             aria-label="Set price alert"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z" />
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z"
+              />
             </svg>
             Set Alert
           </button>
         </div>
       )}
 
-      <PriceChart
-        data={history}
-        pair={decodedPair}
-        loading={historyLoading}
-      />
+      {/* Date range picker */}
+      <div className="mb-4">
+        <DateRangePicker value={dateRange} onChange={handleDateRangeChange} />
+      </div>
+
+      <PriceChart data={history} pair={decodedPair} loading={historyLoading} />
 
       <AlertModal
         isOpen={modalOpen}

--- a/src/pages/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/pages/__snapshots__/Dashboard.test.tsx.snap
@@ -809,7 +809,36 @@ exports[`snapshots > with data 1`] = `
             </div>
             <div
               class="flex items-center gap-2"
-            />
+            >
+              <button
+                aria-label="More actions for BTC/USD"
+                class="p-1 rounded-md text-gray-600 hover:text-gray-300 hover:bg-gray-800 transition-colors"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="w-4 h-4"
+                  fill="currentColor"
+                  viewBox="0 0 16 16"
+                >
+                  <circle
+                    cx="8"
+                    cy="3"
+                    r="1.2"
+                  />
+                  <circle
+                    cx="8"
+                    cy="8"
+                    r="1.2"
+                  />
+                  <circle
+                    cx="8"
+                    cy="13"
+                    r="1.2"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
           <div
             class="text-3xl font-bold text-gray-900 dark:text-white mb-3 font-mono tracking-tight"
@@ -931,7 +960,36 @@ exports[`snapshots > with data 1`] = `
             </div>
             <div
               class="flex items-center gap-2"
-            />
+            >
+              <button
+                aria-label="More actions for ETH/USD"
+                class="p-1 rounded-md text-gray-600 hover:text-gray-300 hover:bg-gray-800 transition-colors"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="w-4 h-4"
+                  fill="currentColor"
+                  viewBox="0 0 16 16"
+                >
+                  <circle
+                    cx="8"
+                    cy="3"
+                    r="1.2"
+                  />
+                  <circle
+                    cx="8"
+                    cy="8"
+                    r="1.2"
+                  />
+                  <circle
+                    cx="8"
+                    cy="13"
+                    r="1.2"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
           <div
             class="text-3xl font-bold text-gray-900 dark:text-white mb-3 font-mono tracking-tight"


### PR DESCRIPTION
…em, date range picker, onboarding tour

Close #43 - Contextual quick-actions menu per asset card ========================================================= Problem: Actions on a price card required navigating to the detail page first.

Solution:
- Added src/components/CardContextMenu.tsx with a reusable useCardContextMenu() hook that returns contextMenuProps (right-click) and overflowButtonProps (three-dot button), plus a menuElement portal to render the popup.
- Context menu supports: View Detail, Set Alert, Copy Price, Export (CSV).
- Menu dismisses on outside pointer-down or Escape key.
- Full keyboard navigation with ArrowUp/ArrowDown/Enter/Space using managed focus index (focused state) and role='menu' / role='menuitem' semantics.
- Updated PriceCard.tsx to spread contextMenuProps onto the card div (right- click) and render an overflow button (three vertical dots) in the card header.
- Copy Price uses navigator.clipboard and feeds back through the toast system.
- Export downloads a minimal CSV via Blob + object URL.

Close #42 - Centralized toast notification system
================================================== Problem: Feedback for actions (export, errors, alerts) was inconsistent.

Solution:
- Added src/context/ToastContext.tsx with ToastProvider and useToast() hook. Stores an array of Toast objects {id, type, message, duration}. addToast() auto-dismisses after configurable duration (default 4 s) using setTimeout stored in a ref-map to allow cleanup on unmount.
- Added src/components/ToastContainer.tsx rendered via createPortal to document.body, bottom-right fixed position, stacks multiple toasts vertically.
- Toast types: success (green), error (red), warning (amber), info (cyan), each with a distinct icon and border color.
- Each toast is dismissible by click, by the X button, or by swipe (touch dx>60).
- Keyboard: Delete or Escape while a toast is focused removes it.
- Accessibility: role='alert', aria-live='assertive', aria-atomic='true'.
- Wired ToastProvider and <ToastContainer /> into App.tsx above all other providers so any component can call useToast().

Close #44 - Date range picker for price history
================================================
Problem: Price history always loaded the last 100 points with no time-range selection.

Solution:
- Added src/components/DateRangePicker.tsx with:
  - Preset buttons (1H / 24H / 7D / 30D / 1Y / All) rendered as an aria group with aria-pressed state.
  - Custom date inputs (start/end) with native <input type='date'> and proper accessible labels (sr-only).
  - Validation: end > start, max range capped at maxRangeDays (default 365).
  - dateRangeToParams() helper converts a DateRange to { limit, startTs, endTs } ready to pass to the API.
- Updated src/api/rest.ts fetchPriceHistory() to accept optional startTs and endTs, appended to query string via URLSearchParams.
- Updated src/hooks/usePriceHistory.ts signature to accept a PriceHistoryOptions object { limit, startTs, endTs } instead of a plain limit number, so callers can pass time bounds without breaking the existing API.
- Updated src/pages/PriceDetail.tsx:
  - DateRange state initialised from URL search params (preset, startDate, endDate) so links are shareable.
  - handleDateRangeChange writes preset/startDate/endDate back to URL via setSearchParams({ replace: true }) for shareability.
  - Passes historyParams (from dateRangeToParams) to usePriceHistory.

Close #41 - Contextual onboarding hints and guided tour ======================================================== Problem: New users may not understand oracle sources, confidence scores, or WebSocket indicators.

Solution:
- Added src/components/OnboardingTour.tsx with:
  - OnboardingProvider: persists dismissed state to localStorage under the key 'onboarding-tour-dismissed'. Auto-starts tour 800 ms after first visit.
  - useOnboarding() hook exposing { isActive, startTour, dismissTour, currentStep, steps, next, prev, goToStep }.
  - 5 default tour steps covering: welcome, price cards, WebSocket badge, confidence score, and price alerts.
  - TourOverlay rendered via createPortal: highlights target DOM elements with a ring-2 ring-cyan-400 outline (via getBoundingClientRect), dims backdrop, scrolls target into view.
  - Progress indicator (animated pill dots + N/total counter).
  - Keyboard navigation: ArrowRight/Enter=next, ArrowLeft=prev, Escape=dismiss.
  - role='dialog' aria-modal='true' on the tour card.
- Added src/components/OnboardingTooltip.tsx: standalone portal tooltip component that positions itself relative to an anchor element, used for contextual inline hints (dismissible with 'Got it').
- Updated src/components/SettingsPanel.tsx:
  - Imports useOnboarding() and adds a 'Replay Onboarding Tour' button at the bottom of the panel so users can re-trigger the tour at any time.
- Wired OnboardingProvider and <OnboardingTourOverlay /> into App.tsx.

Other changes
=============
- Deleted stale snapshot for Layout.test.tsx (regenerated by test run) since the Layout component's existing nav structure was captured before the bell button was present; snapshot now reflects the actual current DOM.
- All 30 test files, 299 tests pass.
- TypeScript: 0 errors. ESLint: 0 errors.
- Bundle sizes well within CI budgets: main JS 88.7 kB brotli (limit 200 kB), total JS 188.9 kB brotli (limit 600 kB), CSS 6.6 kB brotli (limit 50 kB).