### PR TITLE
fix: prevent PriceCard double navigation by portaling context menu

### DIFF
--- a/src/components/CardContextMenu.tsx
+++ b/src/components/CardContextMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 import { useToast } from '../context/ToastContext'
 import { formatPrice } from '../utils/format'
@@ -137,6 +138,7 @@ function ContextMenuPopup({ x, y, pair, price, onClose, actions }: ContextMenuPr
       role="menu"
       aria-label={`Actions for ${pair}`}
       style={style}
+      onClick={(e) => e.stopPropagation()}
       className="w-48 bg-gray-900 border border-gray-700 rounded-xl shadow-2xl py-1 overflow-hidden"
     >
       <div className="px-3 py-1.5 text-xs font-semibold text-gray-500 border-b border-gray-800 mb-1">
@@ -199,16 +201,19 @@ export function useCardContextMenu(
     'aria-label': `More actions for ${pair}`,
   }
 
-  const menuElement = menu ? (
-    <ContextMenuPopup
-      x={menu.x}
-      y={menu.y}
-      pair={pair}
-      price={price}
-      onClose={close}
-      actions={actions}
-    />
-  ) : null
+  const menuElement = menu
+    ? createPortal(
+        <ContextMenuPopup
+          x={menu.x}
+          y={menu.y}
+          pair={pair}
+          price={price}
+          onClose={close}
+          actions={actions}
+        />,
+        document.body,
+      )
+    : null
 
   return { contextMenuProps, overflowButtonProps, menuElement }
 }


### PR DESCRIPTION
## Problem
PriceCard click triggers both card click and context menu actions (e.g., navigating to detail page AND opening the context menu simultaneously).

## Root Cause
The ContextMenuPopup was rendered as a DOM sibling of the card div. Native pointerdown events on the menu could trigger the card's onClick handler during the dismissal sequence, causing the card to navigate when only a context menu action was intended.

## Changes
- src/components/CardContextMenu.tsx:
  - Use createPortal to render the context menu popup at document.body, fully separating it from the card's DOM tree
  - Add onClick + stopPropagation on the menu container for defense in depth

Now card clicks navigate, and context menu actions do not also trigger card navigation.

## Verification
- Card left-click navigates to detail view (unchanged)
- Card right-click opens context menu without navigating (unchanged)
- Overflow button opens context menu without navigating (unchanged)
- Context menu "View Detail" navigates without triggering card navigation (fixed)
- All existing pointerdown dismissal behavior preserved

Closes #155