### PR TITLE
fix(#182): add exponential backoff reconnect to WebSocket client

### DIFF
--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -41,6 +41,7 @@ export class WebSocketClient {
   private messageHandlers = new Set<MessageHandler>()
   private statusHandlers = new Set<StatusHandler>()
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempt = 0
   private destroyed = false
   private subscribedPairs = new Set<string>()
   private useCompression = false
@@ -68,6 +69,7 @@ export class WebSocketClient {
     this.ws.binaryType = 'blob'
 
     this.ws.onopen = () => {
+      this.reconnectAttempt = 0
       this.setStatus('connected')
       if (this.subscribedPairs.size > 0) {
         this.send({
@@ -107,15 +109,18 @@ export class WebSocketClient {
   private scheduleReconnect() {
     if (this.destroyed || this.reconnectTimer) return
     this.setStatus('reconnecting')
+    const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempt), 8000)
+    this.reconnectAttempt++
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
       this.connect()
-    }, config.wsReconnectDelay)
+    }, delay)
   }
 
   /** Permanently closes the connection and cancels any pending reconnect timer. Calling {@link connect} again after this is a no-op. */
   disconnect() {
     this.destroyed = true
+    this.reconnectAttempt = 0
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
     this.ws?.close()
     this.ws = null


### PR DESCRIPTION
## Summary
Replace fixed reconnect delay with exponential backoff (1s → 2s → 4s → 8s max).

## Changes
- Added `reconnectAttempt` counter to `WebSocketClient`
- `scheduleReconnect()` computes delay as `Math.min(1000 * 2^attempt, 8000)`
- Counter resets on successful connect and on `disconnect()`

Closes #182
Closes #183 