### PR TITLE
feat: ADRs, inline tooltips, JSDoc comments, and improved README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![CI](https://github.com/Stellar-Unified-Price-Oracle/Stellar-Unified-Price-Oracle-Frontend-/actions/workflows/ci.yml/badge.svg)](https://github.com/Stellar-Unified-Price-Oracle/Stellar-Unified-Price-Oracle-Frontend-/actions/workflows/ci.yml)
 [![Bundle JS](https://img.shields.io/badge/JS-%3C200%20kB-44cc11?logo=javascript&labelColor=1a1a2e)](https://github.com/Stellar-Unified-Price-Oracle/Stellar-Unified-Price-Oracle-Frontend-/actions/workflows/ci.yml)
 [![Bundle CSS](https://img.shields.io/badge/CSS-%3C50%20kB-44cc11?logo=css3&labelColor=1a1a2e)](https://github.com/Stellar-Unified-Price-Oracle/Stellar-Unified-Price-Oracle-Frontend-/actions/workflows/ci.yml)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 # Stellar Unified Price Oracle — Frontend
 
@@ -14,6 +16,8 @@ A real-time dashboard for the Stellar Unified Price Oracle & Aggregator. Display
 - **Multi-source aggregation** — See which oracles contributed to each price
 - **Historical charts** — Area chart with price history for any asset pair
 - **Source health** — Visual indicators for Chainlink, Redstone, Band & Reflector
+- **Price alerts** — Set upper/lower threshold alerts with browser notifications
+- **Inline help** — Tooltips explain oracle terminology directly in the UI
 - **Responsive** — Works on desktop and mobile
 - **Dark theme** — Low-light UI designed for monitoring dashboards
 
@@ -28,23 +32,43 @@ A real-time dashboard for the Stellar Unified Price Oracle & Aggregator. Display
 | Routing | React Router v7 |
 | Real-time | Native WebSocket |
 
-## Getting Started
+## Quick Start
 
 ```bash
+# 1. Install dependencies
 npm install
+
+# 2. Copy environment config
+cp .env.example .env
+
+# 3. Start the dev server (proxies /api and /ws to localhost:3000)
 npm run dev
 ```
 
-The dev server starts at `http://localhost:5173` and proxies `/api` and `/ws` to `http://localhost:3000`.
+The dev server starts at `http://localhost:5173`.
 
 ### Environment Variables
-
-Copy `.env.example` to `.env` to override defaults:
 
 | Variable | Default | Description |
 |---|---|---|
 | `VITE_API_URL` | `/api` | REST API base URL |
 | `VITE_WS_URL` | `ws://localhost:3000` | WebSocket endpoint |
+
+## Scripts Reference
+
+| Command | Description |
+|---|---|
+| `npm run dev` | Start the Vite dev server with HMR |
+| `npm run build` | Type-check and build for production (outputs to `dist/`) |
+| `npm run preview` | Serve the production build locally |
+| `npm run test` | Run tests in watch mode (Vitest) |
+| `npm run test:run` | Run tests once and exit |
+| `npm run typecheck` | Run TypeScript without emitting files |
+| `npm run lint` | Lint with ESLint |
+| `npm run format` | Format source files with Prettier |
+| `npm run format:check` | Check formatting without writing files |
+| `npm run build:analyze` | Build and open an interactive bundle treemap |
+| `npm run size-limit` | Check bundle size against CI budgets |
 
 ## Build
 
@@ -59,7 +83,8 @@ npm run preview        # preview production build locally
 
 | Asset | Limit | Status |
 |---|---|---|
-| JavaScript | 200 kB | Enforced in CI |
+| JavaScript (entry) | 200 kB | Enforced in CI |
+| JavaScript (total) | 600 kB | Enforced in CI |
 | CSS | 50 kB | Enforced in CI |
 
 The CI pipeline generates a [bundle-stats.html](./reports/bundle-stats.html) report using `rollup-plugin-visualizer` — an interactive treemap of the production bundle. This report is uploaded as a CI artifact on every build.
@@ -71,7 +96,69 @@ The CI pipeline generates a [bundle-stats.html](./reports/bundle-stats.html) rep
 | `GET` | `/api/prices` | All latest prices |
 | `GET` | `/api/prices/:pair` | Single pair price |
 | `GET` | `/api/prices/:pair/history` | Price history |
+| `POST` | `/api/prices/history/batch` | Batch price history (coalesced) |
+| `GET` | `/health` | API server health |
 | `WS` | `/ws` | Real-time price updates |
+
+## Architecture
+
+```
+Browser
+  │
+  ├─ PriceProvider (React Context)
+  │    ├─ WebSocketClient ──────────────────► WS /ws
+  │    │    └─ price_update events
+  │    │         └─ optimistic update → REST confirm/rollback
+  │    └─ useSwr (polling) ────────────────► GET /api/prices
+  │
+  ├─ AlertsProvider (React Context)
+  │    └─ threshold eval against live prices → browser notifications
+  │
+  └─ Pages / Components
+       ├─ Dashboard ─ PriceCard, PriceTableView
+       ├─ ConnectionBadge (WebSocket status)
+       ├─ SourceHealthBadge (per-oracle indicator)
+       └─ AlertPanel / AlertModal
+```
+
+Data flow for a live update:
+
+```
+WS message → PriceContext (optimistic) → component re-render
+                  └─► REST /api/prices/:pair
+                            ├─ match → syncState: confirmed
+                            └─ mismatch → syncState: rollback (REST value wins)
+```
+
+## Deployment
+
+### Vercel
+
+The repo ships with a [`vercel.json`](vercel.json) that rewrites all routes to `index.html` for client-side routing:
+
+```bash
+npm install -g vercel
+vercel --prod
+```
+
+Set `VITE_API_URL` and `VITE_WS_URL` as environment variables in the Vercel project settings.
+
+### Netlify
+
+A [`netlify.toml`](netlify.toml) is included with the equivalent redirect rule:
+
+```bash
+npm install -g netlify-cli
+netlify deploy --prod --dir dist
+```
+
+### Static hosting (generic)
+
+```bash
+npm run build
+# Upload the contents of dist/ to any static host.
+# Configure the server to serve index.html for all 404 routes.
+```
 
 ## Directory Structure
 
@@ -80,9 +167,12 @@ src/
 ├── api/          # REST + WebSocket clients
 ├── components/   # Reusable UI components
 ├── config/       # Environment configuration
-├── hooks/        # React hooks for data fetching
+├── context/      # React context providers
+├── hooks/        # React hooks for data fetching and alerts
 ├── pages/        # Route pages
-└── types/        # TypeScript definitions
+├── test/         # Test utilities and setup
+├── types/        # TypeScript definitions
+└── utils/        # Formatting and export helpers
 docs/
 └── adr/          # Architecture Decision Records
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,21 @@ src/
 ├── hooks/        # React hooks for data fetching
 ├── pages/        # Route pages
 └── types/        # TypeScript definitions
+docs/
+└── adr/          # Architecture Decision Records
 ```
+
+## Architecture Decision Records
+
+Key architectural decisions are documented in [`docs/adr/`](docs/adr/):
+
+| ADR | Decision |
+|---|---|
+| [ADR-001](docs/adr/ADR-001-react-vite-typescript.md) | React + Vite + TypeScript |
+| [ADR-002](docs/adr/ADR-002-state-management.md) | State management strategy |
+| [ADR-003](docs/adr/ADR-003-websocket-vs-polling.md) | WebSocket vs polling architecture |
+| [ADR-004](docs/adr/ADR-004-tailwind-css.md) | Tailwind CSS for styling |
+| [ADR-005](docs/adr/ADR-005-error-handling.md) | Error handling strategy |
 
 ## License
 

--- a/docs/adr/ADR-001-react-vite-typescript.md
+++ b/docs/adr/ADR-001-react-vite-typescript.md
@@ -1,0 +1,27 @@
+# ADR-001: React + Vite + TypeScript
+
+- **Status:** accepted
+- **Date:** 2024-01-01
+
+## Context
+
+We need a UI framework and build toolchain for the Stellar Unified Price Oracle dashboard. The dashboard must handle real-time data, render efficiently under frequent price updates, and be maintainable by a small team. The project needs fast iteration cycles during development.
+
+## Decision
+
+Use **React 19** as the UI framework, **Vite 6** as the build tool, and **TypeScript** for static typing across the entire codebase.
+
+- React's component model maps naturally to the card-based price grid.
+- Vite's native ESM dev server gives near-instant HMR during development.
+- TypeScript catches interface mismatches between the API layer, context, and components at compile time rather than at runtime.
+
+## Consequences
+
+**Easier:**
+- Large ecosystem of libraries (React Router, Recharts, Testing Library) works out of the box.
+- Vite's build produces optimised, tree-shaken bundles with built-in code splitting.
+- TypeScript surface types serve as lightweight documentation for component props and API responses.
+
+**Harder:**
+- React's concurrent renderer adds complexity when reasoning about render order for optimistic WebSocket updates.
+- TypeScript compilation adds a build step and requires type definitions for every third-party dependency.

--- a/docs/adr/ADR-002-state-management.md
+++ b/docs/adr/ADR-002-state-management.md
@@ -1,0 +1,35 @@
+# ADR-002: State Management Strategy
+
+- **Status:** accepted
+- **Date:** 2024-01-01
+
+## Context
+
+The dashboard needs two distinct kinds of state:
+
+1. **Server state** — paginated price snapshots fetched via REST, needs caching and background revalidation.
+2. **Real-time state** — live price updates pushed over WebSocket, needs optimistic application and REST-based confirmation.
+
+We also need lightweight cross-cutting state for UI panels (alerts, sidebar) that must be reachable from many components without prop drilling.
+
+## Decision
+
+Use **React Context** for cross-cutting state with two providers:
+
+- `PriceProvider` — owns WebSocket lifecycle, live price map, REST polling via a custom `useSwr` hook, and pair subscription management.
+- `AlertsProvider` — owns alert CRUD, `localStorage` persistence, and real-time threshold evaluation against live prices.
+
+Write a minimal `useSwr` hook internally instead of pulling in SWR or React Query, keeping the bundle small and the retry/caching behaviour fully under our control.
+
+No external state management library (Redux, Zustand, Jotai) is added at this time.
+
+## Consequences
+
+**Easier:**
+- Zero extra runtime dependencies for state management.
+- `useSwr` retry and caching logic is transparent and fully testable.
+- Context consumers re-render only when their slice of context changes.
+
+**Harder:**
+- Context updates re-render every consumer — high-frequency WebSocket ticks hitting `PriceContext` may cause unnecessary renders in deeply nested consumers; `memo` must be applied at component boundaries.
+- As the app grows, multiple nested providers may become difficult to track. Migration to a dedicated library would require refactoring context consumers.

--- a/docs/adr/ADR-003-websocket-vs-polling.md
+++ b/docs/adr/ADR-003-websocket-vs-polling.md
@@ -1,0 +1,38 @@
+# ADR-003: WebSocket vs Polling Architecture
+
+- **Status:** accepted
+- **Date:** 2024-01-01
+
+## Context
+
+Price data for oracle-aggregated asset pairs can update multiple times per minute. Clients need to reflect these changes promptly. Two approaches were considered:
+
+1. **HTTP polling** — clients request `/api/prices` on a fixed interval.
+2. **WebSocket** — server pushes updates to subscribed clients as they occur.
+
+We also need to account for the possibility that WebSocket pushes could be slightly ahead of the REST API (race condition between the push pipeline and the write pipeline).
+
+## Decision
+
+Use a **native WebSocket client** (`WebSocketClient` class) as the primary channel for live updates, with REST polling as both a fallback and a consistency-check layer.
+
+Flow:
+1. `PriceProvider` opens a WebSocket connection and subscribes to all tracked pairs.
+2. Each `price_update` message is applied **optimistically** to the live price map immediately.
+3. After applying an optimistic update, `PriceProvider` fires a REST request to `/api/prices/:pair` to confirm the value; on mismatch the live value is rolled back to the REST result.
+4. The `useSwr` hook polls `/api/prices` every 10 seconds as a fallback if the WebSocket drops.
+5. On disconnect, `WebSocketClient` schedules an automatic reconnect after a configurable delay (default 3 s).
+
+Optional gzip compression is negotiated at connect time if `DecompressionStream` is available in the browser.
+
+## Consequences
+
+**Easier:**
+- Sub-second price update latency for connected clients.
+- Automatic recovery from transient WebSocket failures without user intervention.
+- REST-based confirmation prevents stale or out-of-order WebSocket messages from permanently corrupting displayed prices.
+
+**Harder:**
+- The optimistic → confirmed → synced state machine in `PriceContext` adds complexity; bugs in rollback logic can cause flickering.
+- WebSocket connections consume server resources; the server must manage per-client subscription sets.
+- Testing requires a fake WebSocket implementation to avoid real network calls.

--- a/docs/adr/ADR-004-tailwind-css.md
+++ b/docs/adr/ADR-004-tailwind-css.md
@@ -1,0 +1,32 @@
+# ADR-004: Tailwind CSS for Styling
+
+- **Status:** accepted
+- **Date:** 2024-01-01
+
+## Context
+
+The dashboard is a monitoring UI with a dark-theme-first design. Styling needs to be fast to write, easy to co-locate with components, and produce small production CSS. The team is small, so a design system with many custom abstractions would be premature.
+
+Options considered:
+
+- **CSS Modules** — scoped styles, no runtime, but verbose for utility patterns.
+- **CSS-in-JS** (e.g. styled-components) — runtime overhead, poor for a performance-sensitive dashboard.
+- **Tailwind CSS** — utility-first, zero runtime, integrates with Vite via the official plugin.
+
+## Decision
+
+Use **Tailwind CSS v4** via `@tailwindcss/vite`, integrated directly into the Vite build pipeline.
+
+All component styles are written as utility class strings inside JSX. No custom CSS files beyond `src/index.css` (which contains the Tailwind directives). Dark-mode variants (`dark:`) are used extensively as the UI is dark-first.
+
+## Consequences
+
+**Easier:**
+- No context switching between JSX and CSS files for routine styling.
+- Tailwind's JIT compiler emits only the classes actually used, keeping CSS bundle size well below the 50 kB budget.
+- Responsive and dark-mode variants are available without writing any media queries.
+
+**Harder:**
+- Long class strings inside JSX can become hard to read without IDE assistance or Prettier formatting.
+- Deviating from Tailwind's default scale (e.g. custom colours, spacing tokens) requires extending the config rather than writing one-off CSS rules.
+- Developers unfamiliar with utility-first CSS face a learning curve.

--- a/docs/adr/ADR-005-error-handling.md
+++ b/docs/adr/ADR-005-error-handling.md
@@ -1,0 +1,34 @@
+# ADR-005: Error Handling Strategy
+
+- **Status:** accepted
+- **Date:** 2024-01-01
+
+## Context
+
+The application fetches data from a REST API and a WebSocket server, both of which can fail transiently (network outages, server restarts, rate limiting). Errors need to be handled at multiple layers:
+
+1. **Network/HTTP** — retryable vs non-retryable failures, rate-limit back-off.
+2. **Data validation** — API responses may not match expected schemas.
+3. **Component render errors** — an uncaught exception in a component tree must not crash the entire page.
+4. **User feedback** — errors must be surfaced in a useful, non-intrusive way.
+
+## Decision
+
+Use a layered error handling approach:
+
+- **`fetchWithRetry`** — wraps `fetch` with exponential back-off (configurable via `RetryOptions`). Retries on 5xx and 429 responses; honours `Retry-After`; aborts cleanly on `AbortSignal`. Throws a structured `HttpRetryError` after all attempts are exhausted.
+- **Zod schema validation** — every REST response is validated against a Zod schema immediately after parsing. Invalid responses throw before the data reaches any component.
+- **`useSwr` error state** — catches thrown errors and exposes them as `error: string | null` so components can render inline error messages without crashing.
+- **`ErrorBoundary` component** — wraps the component tree at the router level. Catches synchronous render errors and displays a fallback UI instead of a blank page.
+- **WebSocket errors** — the `WebSocketClient` silently drops malformed messages and schedules automatic reconnection on disconnect, avoiding error propagation to the UI for transient issues.
+
+## Consequences
+
+**Easier:**
+- Transient API failures resolve themselves without user intervention.
+- Schema validation fails fast at the API boundary, preventing corrupt data from reaching the UI.
+- `ErrorBoundary` prevents a single component error from taking down the whole dashboard.
+
+**Harder:**
+- Retry logic adds latency on first-load if the backend is temporarily unavailable — users may wait several seconds before seeing the final error state.
+- Zod validation schemas must be kept in sync with the backend API contract; drift causes silent failures in production.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,16 @@
+# ADR-XXX: Title
+
+- **Status:** proposed | accepted | deprecated | superseded by [ADR-XXX](ADR-XXX.md)
+- **Date:** YYYY-MM-DD
+
+## Context
+
+What is the issue or situation that motivates this decision?
+
+## Decision
+
+What is the change we are proposing or making?
+
+## Consequences
+
+What becomes easier or more difficult as a result of this change?

--- a/package-lock.json
+++ b/package-lock.json
@@ -2010,9 +2010,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4609,9 +4609,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.49",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.49.tgz",
-      "integrity": "sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/api/rest.ts
+++ b/src/api/rest.ts
@@ -11,6 +11,7 @@ import { validate } from './validate'
 
 let rateLimitInfo: RateLimitInfo | null = null
 
+/** Returns the rate-limit metadata parsed from the most recent API response headers, or `null` if none has been received yet. */
 export function getRateLimitInfo(): RateLimitInfo | null {
   return rateLimitInfo
 }
@@ -124,17 +125,27 @@ async function _fetchHistoryDirect(
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+/** Fetches the latest aggregated price for every tracked asset pair, or a filtered subset when `pairs` is provided. */
 export async function fetchAllPrices(pairs?: string[]): Promise<PriceData[]> {
   const params = pairs?.length ? `?pairs=${pairs.join(',')}` : ''
   const raw = await request<PriceData[]>(`/api/prices${params}`)
   return validate(PriceDataSchema.array(), raw)
 }
 
+/** Fetches the latest aggregated price for a single asset pair. */
 export async function fetchPrice(pair: string): Promise<PriceData> {
   const raw = await request<PriceData>(`/api/prices/${encodeURIComponent(pair)}`)
   return validate(PriceDataSchema, raw)
 }
 
+/**
+ * Fetches the price history for an asset pair.
+ *
+ * Requests from multiple callers within a 50 ms window are coalesced into a single
+ * batch POST to `/api/prices/history/batch`, reducing parallel round-trips when many
+ * cards mount simultaneously.
+ */
 export function fetchPriceHistory(
   pair: string,
   limit = 100,
@@ -157,6 +168,7 @@ export function fetchPriceHistory(
   })
 }
 
+/** Fetches price history for multiple asset pairs in a single POST request. */
 export async function fetchBatchHistory(pairs: string[]): Promise<PriceHistoryResponse[]> {
   const raw = await request<PriceHistoryResponse[]>('/api/prices/history/batch', {
     method: 'POST',
@@ -165,6 +177,7 @@ export async function fetchBatchHistory(pairs: string[]): Promise<PriceHistoryRe
   return validate(BatchHistoryResponseSchema, raw)
 }
 
+/** Checks the API server health endpoint. Returns the server status and uptime in seconds. */
 export async function fetchHealth(): Promise<{ status: string; uptime: number }> {
   const raw = await request('/health')
   return validate(HealthSchema, raw)

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -29,6 +29,13 @@ async function decompress(data: Blob): Promise<string> {
   }
 }
 
+/**
+ * Manages a single WebSocket connection to the price feed server.
+ *
+ * Handles connect/disconnect lifecycle, automatic reconnection, per-pair subscriptions,
+ * optional gzip decompression of binary frames, and fan-out to registered message and
+ * status-change handlers.
+ */
 export class WebSocketClient {
   private ws: WebSocket | null = null
   private messageHandlers = new Set<MessageHandler>()
@@ -48,6 +55,7 @@ export class WebSocketClient {
     this.statusHandlers.forEach((h) => h(status))
   }
 
+  /** Opens the WebSocket connection. Appends `?compress=1` when the browser supports `DecompressionStream`. */
   connect() {
     if (this.destroyed) return
     this.setStatus('connecting')
@@ -105,6 +113,7 @@ export class WebSocketClient {
     }, config.wsReconnectDelay)
   }
 
+  /** Permanently closes the connection and cancels any pending reconnect timer. Calling {@link connect} again after this is a no-op. */
   disconnect() {
     this.destroyed = true
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
@@ -113,29 +122,34 @@ export class WebSocketClient {
     this.setStatus('disconnected')
   }
 
+  /** Sends a raw subscribe or unsubscribe message. Silently dropped if the socket is not open. */
   send(msg: WsSubscribeMessage | WsUnsubscribeMessage) {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(msg))
     }
   }
 
+  /** Adds pairs to the tracked subscription set and sends a subscribe message. Re-subscribed automatically on reconnect. */
   subscribe(pairs: string | string[]) {
     const arr = typeof pairs === 'string' ? [pairs] : pairs
     arr.forEach((p) => this.subscribedPairs.add(p))
     this.send({ action: 'subscribe', assetPairs: arr })
   }
 
+  /** Removes pairs from the tracked subscription set and sends an unsubscribe message. */
   unsubscribe(pairs: string | string[]) {
     const arr = typeof pairs === 'string' ? [pairs] : pairs
     arr.forEach((p) => this.subscribedPairs.delete(p))
     this.send({ action: 'unsubscribe', assetPairs: arr })
   }
 
+  /** Registers a handler to be called for every incoming {@link WsMessage}. Returns an unsubscribe function. */
   onMessage(handler: MessageHandler): () => void {
     this.messageHandlers.add(handler)
     return () => this.messageHandlers.delete(handler)
   }
 
+  /** Registers a handler to be called whenever the connection status changes. Returns an unsubscribe function. */
   onStatusChange(handler: StatusHandler): () => void {
     this.statusHandlers.add(handler)
     return () => this.statusHandlers.delete(handler)

--- a/src/components/ConnectionBadge.tsx
+++ b/src/components/ConnectionBadge.tsx
@@ -1,18 +1,21 @@
 import type { ConnectionStatus } from '../api/websocket'
+import { Tooltip } from './Tooltip'
 
-const STATUS_MAP: Record<ConnectionStatus, { label: string; color: string }> = {
-  connected: { label: 'Live', color: 'bg-green-500' },
-  connecting: { label: 'Connecting', color: 'bg-yellow-500' },
-  reconnecting: { label: 'Reconnecting', color: 'bg-yellow-500' },
-  disconnected: { label: 'Offline', color: 'bg-red-500' },
+const STATUS_MAP: Record<ConnectionStatus, { label: string; color: string; tooltip: string }> = {
+  connected: { label: 'Live', color: 'bg-green-500', tooltip: 'WebSocket is connected. Price updates are streaming in real time.' },
+  connecting: { label: 'Connecting', color: 'bg-yellow-500', tooltip: 'Establishing a WebSocket connection to the price feed server.' },
+  reconnecting: { label: 'Reconnecting', color: 'bg-yellow-500', tooltip: 'The WebSocket connection was lost. Attempting to reconnect automatically.' },
+  disconnected: { label: 'Offline', color: 'bg-red-500', tooltip: 'WebSocket is offline. Prices are updated via REST polling only.' },
 }
 
 export function ConnectionBadge({ status }: { status: ConnectionStatus }) {
   const s = STATUS_MAP[status]
   return (
-    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300" role="status" aria-label={`WebSocket ${s.label}`}>
-      <span className={`w-2 h-2 rounded-full ${s.color} ${status === 'connected' ? 'animate-pulse' : ''}`} aria-hidden="true" />
-      {s.label}
-    </span>
+    <Tooltip content={s.tooltip}>
+      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300" role="status" aria-label={`WebSocket ${s.label}`}>
+        <span className={`w-2 h-2 rounded-full ${s.color} ${status === 'connected' ? 'animate-pulse' : ''}`} aria-hidden="true" />
+        {s.label}
+      </span>
+    </Tooltip>
   )
 }

--- a/src/components/PriceCard.tsx
+++ b/src/components/PriceCard.tsx
@@ -1,12 +1,20 @@
 import { memo } from 'react'
 import type { PriceData, PriceSyncState } from '../types'
 import { formatPrice, timeAgo } from '../utils/format'
+import { Tooltip } from './Tooltip'
 
 const SOURCE_COLORS: Record<string, string> = {
   chainlink: 'bg-blue-500/20 text-blue-600 dark:text-blue-400 border-blue-500/30',
   redstone: 'bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/30',
   band: 'bg-purple-500/20 text-purple-600 dark:text-purple-400 border-purple-500/30',
   reflector: 'bg-cyan-500/20 text-cyan-600 dark:text-cyan-400 border-cyan-500/30',
+}
+
+const SOURCE_DESCRIPTIONS: Record<string, string> = {
+  chainlink: 'Chainlink is a decentralised oracle network that delivers tamper-proof price data from premium data providers.',
+  redstone: 'RedStone is a modular oracle that streams signed price feeds on demand, reducing gas costs by storing data off-chain.',
+  band: 'Band Protocol aggregates real-world data from multiple sources and makes it available on-chain via delegated validators.',
+  reflector: 'Reflector is a Stellar-native oracle that publishes asset prices directly on the Stellar network.',
 }
 
 interface PriceCardProps {
@@ -65,17 +73,20 @@ export const PriceCard = memo(function PriceCard({ price, onClick, isStale, hasA
 
       <div className="flex items-center justify-between text-xs text-gray-400 dark:text-gray-500 mb-3">
         <span>Updated {timeAgo(price.timestamp)}</span>
-        <span className="text-cyan-600 dark:text-cyan-400">{confidencePct}% confidence</span>
+        <Tooltip content="Confidence reflects how consistent the price is across oracle sources. 100% means all sources agree exactly.">
+          <span className="text-cyan-600 dark:text-cyan-400">{confidencePct}% confidence</span>
+        </Tooltip>
       </div>
 
       <div className="flex flex-wrap gap-1.5">
         {price.sources.map((src) => (
-          <span
-            key={src}
-            className={`px-2 py-0.5 rounded text-xs font-medium border ${SOURCE_COLORS[src] ?? 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700'}`}
-          >
-            {src}
-          </span>
+          <Tooltip key={src} content={SOURCE_DESCRIPTIONS[src] ?? `${src} contributed a price feed to this aggregated value.`}>
+            <span
+              className={`px-2 py-0.5 rounded text-xs font-medium border ${SOURCE_COLORS[src] ?? 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-gray-200 dark:border-gray-700'}`}
+            >
+              {src}
+            </span>
+          </Tooltip>
         ))}
       </div>
 

--- a/src/components/PriceCard.tsx
+++ b/src/components/PriceCard.tsx
@@ -17,17 +17,29 @@ const SOURCE_DESCRIPTIONS: Record<string, string> = {
   reflector: 'Reflector is a Stellar-native oracle that publishes asset prices directly on the Stellar network.',
 }
 
+/** Props for {@link PriceCard}. */
 interface PriceCardProps {
+  /** The price data to display. */
   price: PriceData
+  /** Called when the card is clicked or activated via keyboard. */
   onClick?: () => void
+  /** Whether the price value is currently being updated over WebSocket (reserved for future flash animation). */
   isLive?: boolean
+  /** When `true` the card is rendered at reduced opacity to indicate the data may be outdated. */
   isStale?: boolean
+  /** Optimistic update sync state (reserved for future visual indicators). */
   syncState?: PriceSyncState
+  /** Increments on each WebSocket update to trigger CSS flash animations. */
   flashVersion?: number
+  /** Whether a background REST revalidation is in progress. */
   isValidating?: boolean
+  /** When `true` shows the alert button in its active (amber) state. */
   hasAlert?: boolean
+  /** Called when the alert button is clicked. Receives the raw mouse event so callers can stop propagation. */
   onAlertClick?: (e: React.MouseEvent) => void
+  /** When `true` the card renders in multi-select mode, showing a checkbox. */
   selectMode?: boolean
+  /** Whether this card is currently selected in multi-select mode. */
   isSelected?: boolean
 }
 

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,56 @@
+import { useState, useRef, useEffect, type ReactNode } from 'react'
+
+interface TooltipProps {
+  content: string
+  children: ReactNode
+}
+
+export function Tooltip({ content, children }: TooltipProps) {
+  const [visible, setVisible] = useState(false)
+  const ref = useRef<HTMLSpanElement>(null)
+
+  useEffect(() => {
+    if (!visible) return
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setVisible(false)
+    }
+    const onPointer = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setVisible(false)
+    }
+
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onPointer)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onPointer)
+    }
+  }, [visible])
+
+  return (
+    <span ref={ref} className="relative inline-flex items-center">
+      <span
+        onMouseEnter={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+        onFocus={() => setVisible(true)}
+        onBlur={() => setVisible(false)}
+        tabIndex={0}
+        role="button"
+        aria-describedby={visible ? 'tooltip-popup' : undefined}
+        className="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+      >
+        {children}
+      </span>
+      {visible && (
+        <span
+          id="tooltip-popup"
+          role="tooltip"
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 w-56 rounded-lg bg-gray-800 border border-gray-700 px-3 py-2 text-xs text-gray-200 shadow-xl pointer-events-none"
+        >
+          {content}
+          <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-700" />
+        </span>
+      )}
+    </span>
+  )
+}

--- a/src/components/__snapshots__/ConnectionBadge.test.tsx.snap
+++ b/src/components/__snapshots__/ConnectionBadge.test.tsx.snap
@@ -2,56 +2,96 @@
 
 exports[`snapshots > connected 1`] = `
 <span
-  aria-label="WebSocket Live"
-  class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
-  role="status"
+  class="relative inline-flex items-center"
 >
   <span
-    aria-hidden="true"
-    class="w-2 h-2 rounded-full bg-green-500 animate-pulse"
-  />
-  Live
+    class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+    role="button"
+    tabindex="0"
+  >
+    <span
+      aria-label="WebSocket Live"
+      class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
+      role="status"
+    >
+      <span
+        aria-hidden="true"
+        class="w-2 h-2 rounded-full bg-green-500 animate-pulse"
+      />
+      Live
+    </span>
+  </span>
 </span>
 `;
 
 exports[`snapshots > connecting 1`] = `
 <span
-  aria-label="WebSocket Connecting"
-  class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
-  role="status"
+  class="relative inline-flex items-center"
 >
   <span
-    aria-hidden="true"
-    class="w-2 h-2 rounded-full bg-yellow-500 "
-  />
-  Connecting
+    class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+    role="button"
+    tabindex="0"
+  >
+    <span
+      aria-label="WebSocket Connecting"
+      class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
+      role="status"
+    >
+      <span
+        aria-hidden="true"
+        class="w-2 h-2 rounded-full bg-yellow-500 "
+      />
+      Connecting
+    </span>
+  </span>
 </span>
 `;
 
 exports[`snapshots > disconnected 1`] = `
 <span
-  aria-label="WebSocket Offline"
-  class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
-  role="status"
+  class="relative inline-flex items-center"
 >
   <span
-    aria-hidden="true"
-    class="w-2 h-2 rounded-full bg-red-500 "
-  />
-  Offline
+    class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+    role="button"
+    tabindex="0"
+  >
+    <span
+      aria-label="WebSocket Offline"
+      class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
+      role="status"
+    >
+      <span
+        aria-hidden="true"
+        class="w-2 h-2 rounded-full bg-red-500 "
+      />
+      Offline
+    </span>
+  </span>
 </span>
 `;
 
 exports[`snapshots > reconnecting 1`] = `
 <span
-  aria-label="WebSocket Reconnecting"
-  class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
-  role="status"
+  class="relative inline-flex items-center"
 >
   <span
-    aria-hidden="true"
-    class="w-2 h-2 rounded-full bg-yellow-500 "
-  />
-  Reconnecting
+    class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+    role="button"
+    tabindex="0"
+  >
+    <span
+      aria-label="WebSocket Reconnecting"
+      class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300"
+      role="status"
+    >
+      <span
+        aria-hidden="true"
+        class="w-2 h-2 rounded-full bg-yellow-500 "
+      />
+      Reconnecting
+    </span>
+  </span>
 </span>
 `;

--- a/src/components/__snapshots__/PriceCard.test.tsx.snap
+++ b/src/components/__snapshots__/PriceCard.test.tsx.snap
@@ -34,24 +34,54 @@ exports[`snapshots > default 1`] = `
       27h ago
     </span>
     <span
-      class="text-cyan-600 dark:text-cyan-400"
+      class="relative inline-flex items-center"
     >
-      98.8
-      % confidence
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="text-cyan-600 dark:text-cyan-400"
+        >
+          98.8
+          % confidence
+        </span>
+      </span>
     </span>
   </div>
   <div
     class="flex flex-wrap gap-1.5"
   >
     <span
-      class="px-2 py-0.5 rounded text-xs font-medium border bg-blue-500/20 text-blue-600 dark:text-blue-400 border-blue-500/30"
+      class="relative inline-flex items-center"
     >
-      chainlink
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="px-2 py-0.5 rounded text-xs font-medium border bg-blue-500/20 text-blue-600 dark:text-blue-400 border-blue-500/30"
+        >
+          chainlink
+        </span>
+      </span>
     </span>
     <span
-      class="px-2 py-0.5 rounded text-xs font-medium border bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/30"
+      class="relative inline-flex items-center"
     >
-      redstone
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="px-2 py-0.5 rounded text-xs font-medium border bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/30"
+        >
+          redstone
+        </span>
+      </span>
     </span>
   </div>
   <div
@@ -116,24 +146,54 @@ exports[`snapshots > hasAlert 1`] = `
       27h ago
     </span>
     <span
-      class="text-cyan-600 dark:text-cyan-400"
+      class="relative inline-flex items-center"
     >
-      98.8
-      % confidence
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="text-cyan-600 dark:text-cyan-400"
+        >
+          98.8
+          % confidence
+        </span>
+      </span>
     </span>
   </div>
   <div
     class="flex flex-wrap gap-1.5"
   >
     <span
-      class="px-2 py-0.5 rounded text-xs font-medium border bg-blue-500/20 text-blue-600 dark:text-blue-400 border-blue-500/30"
+      class="relative inline-flex items-center"
     >
-      chainlink
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="px-2 py-0.5 rounded text-xs font-medium border bg-blue-500/20 text-blue-600 dark:text-blue-400 border-blue-500/30"
+        >
+          chainlink
+        </span>
+      </span>
     </span>
     <span
-      class="px-2 py-0.5 rounded text-xs font-medium border bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/30"
+      class="relative inline-flex items-center"
     >
-      redstone
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="px-2 py-0.5 rounded text-xs font-medium border bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/30"
+        >
+          redstone
+        </span>
+      </span>
     </span>
   </div>
   <div
@@ -198,24 +258,54 @@ exports[`snapshots > isLive 1`] = `
       27h ago
     </span>
     <span
-      class="text-cyan-600 dark:text-cyan-400"
+      class="relative inline-flex items-center"
     >
-      98.8
-      % confidence
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="text-cyan-600 dark:text-cyan-400"
+        >
+          98.8
+          % confidence
+        </span>
+      </span>
     </span>
   </div>
   <div
     class="flex flex-wrap gap-1.5"
   >
     <span
-      class="px-2 py-0.5 rounded text-xs font-medium border bg-blue-500/20 text-blue-600 dark:text-blue-400 border-blue-500/30"
+      class="relative inline-flex items-center"
     >
-      chainlink
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="px-2 py-0.5 rounded text-xs font-medium border bg-blue-500/20 text-blue-600 dark:text-blue-400 border-blue-500/30"
+        >
+          chainlink
+        </span>
+      </span>
     </span>
     <span
-      class="px-2 py-0.5 rounded text-xs font-medium border bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/30"
+      class="relative inline-flex items-center"
     >
-      redstone
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="px-2 py-0.5 rounded text-xs font-medium border bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/30"
+        >
+          redstone
+        </span>
+      </span>
     </span>
   </div>
   <div
@@ -280,24 +370,54 @@ exports[`snapshots > isStale 1`] = `
       27h ago
     </span>
     <span
-      class="text-cyan-600 dark:text-cyan-400"
+      class="relative inline-flex items-center"
     >
-      98.8
-      % confidence
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="text-cyan-600 dark:text-cyan-400"
+        >
+          98.8
+          % confidence
+        </span>
+      </span>
     </span>
   </div>
   <div
     class="flex flex-wrap gap-1.5"
   >
     <span
-      class="px-2 py-0.5 rounded text-xs font-medium border bg-blue-500/20 text-blue-600 dark:text-blue-400 border-blue-500/30"
+      class="relative inline-flex items-center"
     >
-      chainlink
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="px-2 py-0.5 rounded text-xs font-medium border bg-blue-500/20 text-blue-600 dark:text-blue-400 border-blue-500/30"
+        >
+          chainlink
+        </span>
+      </span>
     </span>
     <span
-      class="px-2 py-0.5 rounded text-xs font-medium border bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/30"
+      class="relative inline-flex items-center"
     >
-      redstone
+      <span
+        class="cursor-help focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-500 rounded"
+        role="button"
+        tabindex="0"
+      >
+        <span
+          class="px-2 py-0.5 rounded text-xs font-medium border bg-red-500/20 text-red-600 dark:text-red-400 border-red-500/30"
+        >
+          redstone
+        </span>
+      </span>
     </span>
   </div>
   <div

--- a/src/context/PriceContext.tsx
+++ b/src/context/PriceContext.tsx
@@ -5,20 +5,38 @@ import { fetchAllPrices, fetchPrice } from '../api/rest'
 import { config } from '../config'
 import type { LivePriceEntry, PriceData } from '../types'
 
+/** Value exposed by {@link PriceProvider} via React context. */
 export interface PriceContextValue {
+  /** Latest REST-fetched snapshot of all tracked asset pair prices. */
   prices: PriceData[]
+  /** `true` while the initial REST fetch has not yet resolved. */
   pricesLoading: boolean
+  /** Error message from the last failed REST fetch, or `null` on success. */
   pricesError: string | null
+  /** `true` whenever a background REST revalidation is in flight. */
   pricesValidating: boolean
+  /** Live price entries keyed by asset pair, updated optimistically on each WebSocket message. */
   livePrices: Map<string, LivePriceEntry>
+  /** Current WebSocket connection status. */
   wsStatus: ConnectionStatus
+  /** Trigger an immediate refetch of all prices outside the normal polling cycle. */
   refetchPrices: () => void
+  /** Subscribe to live WebSocket updates for the given asset pairs. */
   subscribe: (pairs: string[]) => void
+  /** Unsubscribe from WebSocket updates for the given asset pairs. */
   unsubscribe: (pairs: string[]) => void
 }
 
 const PriceContext = createContext<PriceContextValue | null>(null)
 
+/**
+ * Provides real-time price data and WebSocket lifecycle management to its subtree.
+ *
+ * On mount it opens a WebSocket connection, subscribes to all tracked pairs, and
+ * applies incoming price updates optimistically. Each update is confirmed against
+ * the REST API and rolled back if the values differ. REST polling runs in parallel
+ * as a fallback when the WebSocket is disconnected.
+ */
 export function PriceProvider({ children }: { children: ReactNode }) {
   const { data: prices = [], loading: pricesLoading, error: pricesError, isValidating: pricesValidating, refetch: refetchPrices } = useSwr<PriceData[]>(
     'prices',
@@ -192,6 +210,11 @@ export function PriceProvider({ children }: { children: ReactNode }) {
   )
 }
 
+/**
+ * Returns the price context value.
+ * Must be called inside a component that is a descendant of {@link PriceProvider}.
+ * Throws if called outside of that tree.
+ */
 export function usePriceContext(): PriceContextValue {
   const ctx = useContext(PriceContext)
   if (!ctx) {

--- a/src/hooks/useAlerts.tsx
+++ b/src/hooks/useAlerts.tsx
@@ -19,6 +19,13 @@ function saveAlerts(alerts: Alert[]) {
 
 const AlertsContext = createContext<AlertsContextType | null>(null)
 
+/**
+ * Provides the {@link AlertsContextType} to its subtree.
+ *
+ * Persists alerts to `localStorage` and evaluates them against live prices from {@link usePriceContext}.
+ * Fires browser notifications when a threshold is crossed (if permission is granted).
+ * Must be rendered inside `PriceProvider`.
+ */
 export function AlertsProvider({ children }: { children: ReactNode }) {
   const [alerts, setAlerts] = useState<Alert[]>(loadAlerts)
   const [isPanelOpen, setIsPanelOpen] = useState(false)
@@ -144,6 +151,11 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
   return <AlertsContext.Provider value={value}>{children}</AlertsContext.Provider>
 }
 
+/**
+ * Returns the alerts context value.
+ * Must be called inside a component that is a descendant of {@link AlertsProvider}.
+ * Throws if called outside of that tree.
+ */
 export function useAlerts() {
   const context = useContext(AlertsContext)
   if (!context) {

--- a/src/hooks/useSwr.ts
+++ b/src/hooks/useSwr.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+/** In-memory cache entry storing the last fetched value and the time it was stored. */
 interface CacheEntry {
   data: unknown
   timestamp: number
@@ -7,21 +8,43 @@ interface CacheEntry {
 
 const cache = new Map<string, CacheEntry>()
 
+/** Configuration options for {@link useSwr}. */
 export interface SwrOptions {
+  /** Interval in ms between automatic background refetches. 0 disables polling. */
   refreshInterval?: number
+  /** Time in ms before a cached value is considered stale and triggers a background revalidation. */
   staleTime?: number
+  /** Number of additional attempts after the first failure before settling on an error state. */
   retryCount?: number
+  /** Set to false to skip fetching entirely (e.g. while a dependency is not yet ready). */
   enabled?: boolean
 }
 
+/** Return value of {@link useSwr}. */
 export interface SwrResult<T> {
+  /** The most recently fetched data, or `undefined` while loading for the first time. */
   data: T | undefined
+  /** Error message from the last failed fetch, or `null` when the last fetch succeeded. */
   error: string | null
+  /** `true` only on the initial fetch before any data is available. */
   loading: boolean
+  /** `true` whenever a background revalidation is in progress (data may already be visible). */
   isValidating: boolean
+  /** Trigger an immediate refetch outside of the normal polling cycle. */
   refetch: () => void
 }
 
+/**
+ * Minimal stale-while-revalidate hook for data fetching.
+ *
+ * Fetches data using `fetcher` and caches the result in a module-level Map keyed by `key`.
+ * On mount it immediately returns cached data (if available) while revalidating in the background.
+ * Supports optional polling via `refreshInterval`, exponential-back-off retries, and an `enabled` gate.
+ *
+ * @param key - Unique string key for this request. Changing the key resets state and re-fetches.
+ * @param fetcher - Async function that returns the data. Re-created each render; the hook always calls the latest version.
+ * @param options - Optional behaviour overrides (see {@link SwrOptions}).
+ */
 export function useSwr<T>(
   key: string,
   fetcher: () => Promise<T>,

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -4,6 +4,7 @@ function isoTs(ts: number): string {
   return new Date(ts).toISOString()
 }
 
+/** Serialises an array of plain objects to a CSV string. Values containing commas, quotes, or newlines are quoted and escaped. */
 export function toCsv(rows: Array<Record<string, unknown>>, headers: string[]): string {
   const escape = (v: unknown) => {
     const s = String(v ?? '')
@@ -13,6 +14,7 @@ export function toCsv(rows: Array<Record<string, unknown>>, headers: string[]): 
   return lines.join('\n')
 }
 
+/** Converts an array of {@link PriceData} to CSV-ready rows. Timestamps are serialised as ISO-8601 strings; sources joined with ";". */
 export function priceDataToCsvRows(prices: PriceData[]): { rows: Array<Record<string, unknown>>; headers: string[] } {
   const headers = ['assetPair', 'price', 'timestamp', 'confidence', 'sources']
   const rows = prices.map((p) => ({
@@ -25,6 +27,7 @@ export function priceDataToCsvRows(prices: PriceData[]): { rows: Array<Record<st
   return { rows, headers }
 }
 
+/** Converts a pair's {@link PriceHistoryEntry} array to CSV-ready rows, injecting the asset pair name into each row. */
 export function historyToCsvRows(
   pair: string,
   history: PriceHistoryEntry[],
@@ -40,6 +43,7 @@ export function historyToCsvRows(
   return { rows, headers }
 }
 
+/** Triggers a browser file download for the given content string. Creates and immediately revokes an object URL. */
 export function downloadFile(content: string, filename: string, mimeType: string): void {
   const blob = new Blob([content], { type: mimeType })
   const url = URL.createObjectURL(blob)
@@ -50,6 +54,7 @@ export function downloadFile(content: string, filename: string, mimeType: string
   URL.revokeObjectURL(url)
 }
 
+/** Generates a safe export filename like `XLM-USD_2024-01-01T12-00-00.csv` for a given asset pair and format. */
 export function exportFilename(pair: string, format: 'csv' | 'json'): string {
   const safe = pair.replace(/\//g, '-')
   const ts = new Date().toISOString().slice(0, 19).replace(/:/g, '-')

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,15 +1,18 @@
+/** Formats a price with variable decimal precision: 2 dp for ≥1000, 4 dp for ≥1, 6–8 dp otherwise. */
 export function formatPrice(price: number): string {
   if (price >= 1000) return price.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
   if (price >= 1) return price.toLocaleString('en-US', { minimumFractionDigits: 4, maximumFractionDigits: 4 })
   return price.toLocaleString('en-US', { minimumFractionDigits: 6, maximumFractionDigits: 8 })
 }
 
+/** Same scale tiers as {@link formatPrice} but without a fixed maximum decimal count (for chart labels). */
 export function formatPriceShort(price: number): string {
   if (price >= 1000) return price.toLocaleString('en-US', { minimumFractionDigits: 2 })
   if (price >= 1) return price.toLocaleString('en-US', { minimumFractionDigits: 4 })
   return price.toLocaleString('en-US', { minimumFractionDigits: 6 })
 }
 
+/** Returns a human-readable relative time string (e.g. "5s ago", "2m ago") from a Unix timestamp in ms. */
 export function timeAgo(ts: number): string {
   const sec = Math.floor((Date.now() - ts) / 1000)
   if (sec < 60) return `${sec}s ago`
@@ -18,6 +21,7 @@ export function timeAgo(ts: number): string {
   return `${Math.floor(min / 60)}h ago`
 }
 
+/** Formats a Unix timestamp in ms as a localised short datetime string. */
 export function formatTimestamp(ts: number): string {
   return new Date(ts).toLocaleString('en-US', {
     month: 'short',
@@ -28,11 +32,13 @@ export function formatTimestamp(ts: number): string {
   })
 }
 
+/** Formats a Unix timestamp in ms as "HH:MM" for chart x-axis labels. */
 export function formatChartTime(ts: number): string {
   const d = new Date(ts)
   return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
 }
 
+/** Formats a price value for chart y-axis tick labels using the same scale tiers as {@link formatPrice}. */
 export function formatChartPrice(val: number): string {
   if (val >= 1000) return val.toLocaleString('en-US', { minimumFractionDigits: 2 })
   if (val >= 1) return val.toLocaleString('en-US', { minimumFractionDigits: 4 })


### PR DESCRIPTION
## Summary

- Adds Architecture Decision Records documenting key technical choices in `docs/adr/`
- Adds inline help `Tooltip` component and wires it to oracle source badges, confidence score, and WebSocket status badge
- Adds JSDoc comments to all public hooks, API client methods, utility functions, and component props interfaces
- Improves README with TypeScript and license badges, a quick-start section, a full scripts reference table, a deployment guide, and an ASCII architecture diagram

## Closes

Closes #101
Closes #102
Closes #103
Closes #104

## Test plan

- [ ] Verify `docs/adr/` contains `template.md` and `ADR-001` through `ADR-005`
- [ ] Verify README renders correctly on GitHub (badges, tables, architecture diagram)
- [ ] Hover/focus oracle source badges and confidence score in the UI — tooltip should appear with explanatory text
- [ ] Focus `ConnectionBadge` via keyboard — tooltip should appear; pressing Escape should dismiss it
- [ ] Clicking outside an open tooltip should dismiss it
- [ ] Verify JSDoc comments appear in IDE hover/intellisense for hooks, API functions, and utility helpers