### PR TITLE
refactor: remove duplicate exportCSV and stale useSparkline reference

### DIFF
--- a/src/hooks/useExport.test.ts
+++ b/src/hooks/useExport.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useExport } from './useExport'
+
+const mockPrices = [
+  { assetPair: 'BTC/USD', price: 50000, timestamp: 0, confidence: 0.99, sources: ['chainlink'] },
+  { assetPair: 'ETH/USD', price: 3000, timestamp: 0, confidence: 0.95, sources: ['redstone', 'band'] },
+]
+
+describe('useExport', () => {
+  let createObjectURLSpy: ReturnType<typeof vi.fn>
+  let revokeObjectURLSpy: ReturnType<typeof vi.fn>
+  let clickSpy: ReturnType<typeof vi.fn>
+  let originalCreateElement: typeof document.createElement
+
+  beforeEach(() => {
+    createObjectURLSpy = vi.fn(() => 'blob:test')
+    revokeObjectURLSpy = vi.fn()
+    clickSpy = vi.fn()
+    URL.createObjectURL = createObjectURLSpy
+    URL.revokeObjectURL = revokeObjectURLSpy
+
+    originalCreateElement = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') {
+        return { href: '', download: '', click: clickSpy } as unknown as HTMLAnchorElement
+      }
+      return originalCreateElement(tag)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns an exportCSV function', () => {
+    const { result } = renderHook(() => useExport())
+    expect(typeof result.current.exportCSV).toBe('function')
+  })
+
+  it('triggers a file download when exportCSV is called', () => {
+    const { result } = renderHook(() => useExport())
+    result.current.exportCSV(mockPrices)
+    expect(createObjectURLSpy).toHaveBeenCalled()
+    expect(clickSpy).toHaveBeenCalled()
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:test')
+  })
+
+  it('exports correct CSV content with price data fields', () => {
+    let capturedContent = ''
+    vi.spyOn(global, 'Blob').mockImplementation((parts) => {
+      capturedContent = (parts as string[])[0]
+      return { type: 'text/csv' } as Blob
+    })
+
+    const { result } = renderHook(() => useExport())
+    result.current.exportCSV(mockPrices)
+
+    expect(capturedContent).toContain('assetPair')
+    expect(capturedContent).toContain('BTC/USD')
+    expect(capturedContent).toContain('ETH/USD')
+  })
+
+  it('exports empty CSV with only headers when given no items', () => {
+    let capturedContent = ''
+    vi.spyOn(global, 'Blob').mockImplementation((parts) => {
+      capturedContent = (parts as string[])[0]
+      return { type: 'text/csv' } as Blob
+    })
+
+    const { result } = renderHook(() => useExport())
+    result.current.exportCSV([])
+
+    expect(capturedContent).toContain('assetPair')
+    const lines = capturedContent.split('\n')
+    expect(lines).toHaveLength(1)
+  })
+
+  it('returns a stable exportCSV reference across renders', () => {
+    const { result, rerender } = renderHook(() => useExport())
+    const first = result.current.exportCSV
+    rerender()
+    expect(result.current.exportCSV).toBe(first)
+  })
+})

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -1,0 +1,13 @@
+import { useCallback } from 'react'
+import type { PriceData } from '../types'
+import { toCsv, priceDataToCsvRows, downloadFile, exportFilename } from '../utils/export'
+
+export function useExport() {
+  const exportCSV = useCallback((items: PriceData[]) => {
+    const { rows, headers } = priceDataToCsvRows(items)
+    const csv = toCsv(rows, headers)
+    downloadFile(csv, exportFilename('oracle-prices', 'csv'), 'text/csv')
+  }, [])
+
+  return { exportCSV }
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { usePriceContext } from '../context/PriceContext'
 import { useAlerts } from '../hooks/useAlerts'
+import { useExport } from '../hooks/useExport'
 import { PriceCard } from '../components/PriceCard'
 import { PriceCardSkeleton } from '../components/PriceCardSkeleton'
 import { PriceTableView } from '../components/PriceTableView'
@@ -25,30 +26,11 @@ function mergePrices(
   })
 }
 
-function exportCSV(items: PriceData[]) {
-  const header = 'Asset Pair,Price,Confidence,Sources,Updated'
-  const rows = items.map((p) =>
-    [
-      p.assetPair,
-      p.price,
-      (p.confidence * 100).toFixed(2) + '%',
-      p.sources.join(';'),
-      new Date(p.timestamp).toISOString(),
-    ].join(',')
-  )
-  const blob = new Blob([[header, ...rows].join('\n')], { type: 'text/csv' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = `oracle-prices-${Date.now()}.csv`
-  a.click()
-  URL.revokeObjectURL(url)
-}
-
 export function Dashboard() {
   const { prices, pricesLoading, pricesError, pricesValidating, livePrices, wsStatus } = usePriceContext()
   const navigate = useNavigate()
   const { alerts, addAlert, removeAlert, hasAlertsForPair, activeCount } = useAlerts()
+  const { exportCSV } = useExport()
   const [searchParams] = useSearchParams()
 
   const [modalOpen, setModalOpen] = useState(false)

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -33,7 +33,7 @@ if (typeof SVGPathElement !== 'undefined' && !SVGPathElement.prototype.getTotalL
 }
 
 // Mock fetch globally so components that call the REST API in unit tests
-// (e.g. useSparkline inside PriceCard) don't fail with "fetch is not defined".
+// don't fail with "fetch is not defined".
 // Individual tests can override this with vi.spyOn(global, 'fetch') as needed.
 global.fetch = vi.fn().mockResolvedValue({
   ok: true,


### PR DESCRIPTION
closes #167
closes #169


## Summary

- Removes the inline `exportCSV` function (~19 lines) from `Dashboard.tsx` that duplicated logic already present in `src/utils/export.ts`
- Introduces a new `useExport` hook (`src/hooks/useExport.ts`) that composes `priceDataToCsvRows`, `toCsv`, `downloadFile`, and `exportFilename` from `src/utils/export.ts`
- `Dashboard` now calls `useExport().exportCSV` for selection-based CSV exports, satisfying the acceptance criterion
- Removes the stale comment in `src/test/setup.ts` that referenced the deleted `useSparkline` hook


## Changes

- `src/hooks/useExport.ts` — new hook wrapping export utilities
- `src/hooks/useExport.test.ts` — 5 tests: download trigger, CSV content, empty input, stable reference
- `src/pages/Dashboard.tsx` — removed 19-line inline `exportCSV`, added `useExport` import and call
- `src/test/setup.ts` — removed stale reference to `useSparkline` in comment