### PR TITLE
Feat/ add price data import from external csv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2608,9 +2608,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3415,9 +3415,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/src/chart/CanvasChart.tsx
+++ b/src/chart/CanvasChart.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  computeViewport,
+  createAreaPlugin,
+  createLinePlugin,
+  toCanvasX,
+  toCanvasY,
+} from './ChartEngine'
+import type { ChartPlugin, ChartSeries } from './ChartEngine'
+
+const DEFAULT_PLUGINS: ChartPlugin[] = [createAreaPlugin(), createLinePlugin()]
+
+interface Crosshair {
+  x: number
+  y: number
+  dataX: number
+  dataY: number
+  label: string
+}
+
+interface Props {
+  series: ChartSeries[]
+  plugins?: ChartPlugin[]
+  className?: string
+  formatX?: (x: number) => string
+  formatY?: (y: number) => string
+}
+
+export function CanvasChart({ series, plugins = DEFAULT_PLUGINS, className = 'w-full h-48', formatX, formatY }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [crosshair, setCrosshair] = useState<Crosshair | null>(null)
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const { width, height } = canvas
+    ctx.clearRect(0, 0, width, height)
+
+    const vp = computeViewport(series, width, height, 0, 8)
+
+    for (const plugin of plugins) {
+      ctx.save()
+      plugin.render(ctx, series, vp)
+      ctx.restore()
+    }
+  }, [series, plugins])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      const dpr = window.devicePixelRatio || 1
+      const { width, height } = entry.contentRect
+      canvas.width = width * dpr
+      canvas.height = height * dpr
+      const ctx = canvas.getContext('2d')
+      if (ctx) ctx.scale(dpr, dpr)
+      draw()
+    })
+
+    observer.observe(canvas)
+    return () => observer.disconnect()
+  }, [draw])
+
+  useEffect(() => {
+    draw()
+  }, [draw])
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current
+      if (!canvas || series.length === 0) return
+
+      const rect = canvas.getBoundingClientRect()
+      const mouseX = e.clientX - rect.left
+      const dpr = window.devicePixelRatio || 1
+      const vp = computeViewport(series, canvas.width / dpr, canvas.height / dpr, 0, 8)
+
+      // Find the closest point across all series
+      let best: { dist: number; cx: number; cy: number; dataX: number; dataY: number; label: string } | null = null
+      for (const s of series) {
+        for (const pt of s.points) {
+          const cx = toCanvasX(vp, pt.x)
+          const cy = toCanvasY(vp, pt.y)
+          const dist = Math.abs(cx - mouseX)
+          if (!best || dist < best.dist) {
+            best = {
+              dist,
+              cx,
+              cy,
+              dataX: pt.x,
+              dataY: pt.y,
+              label: s.label,
+            }
+          }
+        }
+      }
+
+      if (best && best.dist < 40) {
+        setCrosshair({ x: best.cx, y: best.cy, dataX: best.dataX, dataY: best.dataY, label: best.label })
+      } else {
+        setCrosshair(null)
+      }
+    },
+    [series],
+  )
+
+  const defaultFormatX = useCallback((x: number) => {
+    const d = new Date(x)
+    return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
+  }, [])
+
+  const defaultFormatY = useCallback((y: number) => {
+    if (y >= 1000) return y.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+    if (y >= 1) return y.toLocaleString('en-US', { minimumFractionDigits: 4, maximumFractionDigits: 4 })
+    return y.toLocaleString('en-US', { minimumFractionDigits: 6, maximumFractionDigits: 6 })
+  }, [])
+
+  const fmtX = formatX ?? defaultFormatX
+  const fmtY = formatY ?? defaultFormatY
+
+  return (
+    <div className="relative">
+      <canvas
+        ref={canvasRef}
+        className={className}
+        style={{ display: 'block' }}
+        aria-hidden="true"
+        onMouseMove={handleMouseMove}
+        onMouseLeave={() => setCrosshair(null)}
+      />
+      {crosshair && (
+        <div
+          className="absolute pointer-events-none z-10"
+          style={{ left: crosshair.x, top: 0, height: '100%' }}
+        >
+          <div className="absolute inset-y-0 left-0 w-px bg-gray-500/50" />
+          <div
+            className="absolute w-2 h-2 rounded-full bg-cyan-400 border-2 border-gray-900 -translate-x-1/2 -translate-y-1/2"
+            style={{ top: crosshair.y }}
+          />
+          <div
+            className="absolute left-2 -translate-y-1/2 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-200 whitespace-nowrap"
+            style={{ top: crosshair.y }}
+          >
+            <div className="text-gray-400 text-[10px]">{fmtX(crosshair.dataX)}</div>
+            <div className="font-mono font-medium">{fmtY(crosshair.dataY)}</div>
+          </div>
+        </div>
+      )}
+      {series.length > 1 && (
+        <div className="absolute top-2 right-2 flex items-center gap-3">
+          {series.map((s) => (
+            <div key={s.id} className="flex items-center gap-1 text-xs">
+              <span
+                className="inline-block w-5 h-0"
+                style={{
+                  border: `1.5px ${s.style === 'dashed-line' ? 'dashed' : 'solid'} ${s.color}`,
+                }}
+              />
+              <span style={{ color: s.color }}>{s.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/chart/ChartEngine.ts
+++ b/src/chart/ChartEngine.ts
@@ -1,0 +1,121 @@
+export interface ChartPoint {
+  x: number
+  y: number
+}
+
+export type SeriesStyle = 'area' | 'line' | 'dashed-line'
+
+export interface ChartSeries {
+  id: string
+  label: string
+  points: ChartPoint[]
+  color: string
+  style: SeriesStyle
+}
+
+export interface Viewport {
+  width: number
+  height: number
+  paddingX: number
+  paddingY: number
+  minX: number
+  maxX: number
+  minY: number
+  maxY: number
+}
+
+export interface ChartPlugin {
+  name: string
+  render(ctx: CanvasRenderingContext2D, series: ChartSeries[], vp: Viewport): void
+}
+
+export function toCanvasX(vp: Viewport, x: number): number {
+  const ratio = (x - vp.minX) / (vp.maxX - vp.minX || 1)
+  return vp.paddingX + ratio * (vp.width - vp.paddingX * 2)
+}
+
+export function toCanvasY(vp: Viewport, y: number): number {
+  const ratio = (y - vp.minY) / (vp.maxY - vp.minY || 1)
+  return vp.height - vp.paddingY - ratio * (vp.height - vp.paddingY * 2)
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+export function createAreaPlugin(): ChartPlugin {
+  return {
+    name: 'area',
+    render(ctx, series, vp) {
+      for (const s of series) {
+        if (s.style !== 'area' || s.points.length < 2) continue
+        const pts = s.points.map((p) => ({ cx: toCanvasX(vp, p.x), cy: toCanvasY(vp, p.y) }))
+
+        ctx.beginPath()
+        ctx.moveTo(pts[0].cx, pts[0].cy)
+        for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].cx, pts[i].cy)
+        ctx.lineTo(pts[pts.length - 1].cx, vp.height - vp.paddingY)
+        ctx.lineTo(pts[0].cx, vp.height - vp.paddingY)
+        ctx.closePath()
+        const grad = ctx.createLinearGradient(0, vp.paddingY, 0, vp.height - vp.paddingY)
+        grad.addColorStop(0, hexToRgba(s.color, 0.3))
+        grad.addColorStop(1, hexToRgba(s.color, 0))
+        ctx.fillStyle = grad
+        ctx.fill()
+
+        ctx.beginPath()
+        ctx.moveTo(pts[0].cx, pts[0].cy)
+        for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].cx, pts[i].cy)
+        ctx.strokeStyle = s.color
+        ctx.lineWidth = 2
+        ctx.setLineDash([])
+        ctx.stroke()
+      }
+    },
+  }
+}
+
+export function createLinePlugin(): ChartPlugin {
+  return {
+    name: 'line',
+    render(ctx, series, vp) {
+      for (const s of series) {
+        if ((s.style !== 'line' && s.style !== 'dashed-line') || s.points.length < 2) continue
+        const pts = s.points.map((p) => ({ cx: toCanvasX(vp, p.x), cy: toCanvasY(vp, p.y) }))
+
+        ctx.beginPath()
+        ctx.moveTo(pts[0].cx, pts[0].cy)
+        for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].cx, pts[i].cy)
+        ctx.strokeStyle = s.color
+        ctx.lineWidth = 1.5
+        ctx.setLineDash(s.style === 'dashed-line' ? [5, 3] : [])
+        ctx.stroke()
+        ctx.setLineDash([])
+      }
+    },
+  }
+}
+
+export function computeViewport(
+  series: ChartSeries[],
+  width: number,
+  height: number,
+  paddingX = 0,
+  paddingY = 8,
+): Viewport {
+  const allPoints = series.flatMap((s) => s.points)
+  if (allPoints.length === 0) {
+    return { width, height, paddingX, paddingY, minX: 0, maxX: 1, minY: 0, maxY: 1 }
+  }
+  const xs = allPoints.map((p) => p.x)
+  const ys = allPoints.map((p) => p.y)
+  const minX = Math.min(...xs)
+  const maxX = Math.max(...xs)
+  const minY = Math.min(...ys)
+  const maxY = Math.max(...ys)
+  const yPad = (maxY - minY) * 0.05 || 1
+  return { width, height, paddingX, paddingY, minX, maxX, minY: minY - yPad, maxY: maxY + yPad }
+}

--- a/src/components/CsvImportZone.tsx
+++ b/src/components/CsvImportZone.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useRef, useState } from 'react'
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024
+
+export interface CsvRow {
+  timestamp: number
+  price: number
+}
+
+interface Props {
+  onImport: (rows: CsvRow[]) => void
+  onClear: () => void
+  hasImport: boolean
+}
+
+function parseCsv(text: string): { rows: CsvRow[]; error: string | null } {
+  const lines = text.trim().split(/\r?\n/)
+  if (lines.length === 0) return { rows: [], error: 'File is empty' }
+
+  const rows: CsvRow[] = []
+  const startIdx = Number.isNaN(Number(lines[0].split(',')[0].trim())) ? 1 : 0
+
+  for (let i = startIdx; i < lines.length; i++) {
+    const parts = lines[i].trim().split(',')
+    if (parts.length < 2) continue
+    let ts = Number(parts[0].trim())
+    const price = Number(parts[1].trim())
+    if (!Number.isFinite(ts) || !Number.isFinite(price) || price <= 0) continue
+    if (ts < 1e10) ts *= 1000
+    rows.push({ timestamp: ts, price })
+  }
+
+  if (rows.length === 0) {
+    return { rows: [], error: 'No valid rows found. Expected columns: timestamp, price' }
+  }
+
+  return { rows: rows.sort((a, b) => a.timestamp - b.timestamp), error: null }
+}
+
+export function CsvImportZone({ onImport, onClear, hasImport }: Props) {
+  const [isDragging, setIsDragging] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleFile = useCallback(
+    (file: File) => {
+      setError(null)
+      if (file.size > MAX_FILE_SIZE) {
+        setError('File exceeds 5MB limit')
+        return
+      }
+      if (!file.name.toLowerCase().endsWith('.csv') && !file.type.includes('csv')) {
+        setError('Only CSV files are supported')
+        return
+      }
+      const reader = new FileReader()
+      reader.onload = (e) => {
+        const { rows, error: parseError } = parseCsv(e.target?.result as string)
+        if (parseError) {
+          setError(parseError)
+          return
+        }
+        onImport(rows)
+      }
+      reader.readAsText(file)
+    },
+    [onImport],
+  )
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      setIsDragging(false)
+      const file = e.dataTransfer.files[0]
+      if (file) handleFile(file)
+    },
+    [handleFile],
+  )
+
+  if (hasImport) {
+    return (
+      <div className="flex items-center gap-3 p-3 bg-cyan-500/10 border border-cyan-500/30 rounded-xl text-sm">
+        <svg className="w-4 h-4 text-cyan-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span className="text-cyan-300 flex-1">CSV data imported — shown as overlay on chart</span>
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-xs text-gray-400 hover:text-gray-200 px-2 py-1 rounded hover:bg-gray-800 transition-colors"
+        >
+          Clear
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label="Upload CSV file for price data import"
+        onClick={() => inputRef.current?.click()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') inputRef.current?.click()
+        }}
+        onDragOver={(e) => {
+          e.preventDefault()
+          setIsDragging(true)
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        onDrop={handleDrop}
+        className={`flex flex-col items-center justify-center gap-2 p-6 border-2 border-dashed rounded-xl cursor-pointer transition-colors ${
+          isDragging
+            ? 'border-cyan-500 bg-cyan-500/10'
+            : 'border-gray-700 hover:border-gray-600 hover:bg-gray-800/50'
+        }`}
+      >
+        <svg className="w-8 h-8 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+        </svg>
+        <p className="text-sm text-gray-400">
+          Drop a CSV file or <span className="text-cyan-400">browse</span>
+        </p>
+        <p className="text-xs text-gray-600">Columns: timestamp, price — max 5 MB</p>
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".csv,text/csv"
+        onChange={(e) => {
+          const file = e.target.files?.[0]
+          if (file) handleFile(file)
+          e.target.value = ''
+        }}
+        className="sr-only"
+        tabIndex={-1}
+        aria-hidden="true"
+      />
+      {error && (
+        <p className="mt-2 text-sm text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -1,0 +1,262 @@
+import { useCallback } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+export const KNOWN_SOURCES = ['chainlink', 'redstone', 'band', 'reflector'] as const
+
+const SORT_OPTIONS = [
+  { value: 'pair', label: 'Pair (A–Z)' },
+  { value: 'price-high', label: 'Price (High → Low)' },
+  { value: 'price-low', label: 'Price (Low → High)' },
+  { value: 'confidence', label: 'Confidence' },
+  { value: 'recent', label: 'Last Updated' },
+] as const
+
+const UPDATED_WITHIN_OPTIONS = [
+  { value: 'all', label: 'Any time' },
+  { value: '1h', label: '1 h' },
+  { value: '6h', label: '6 h' },
+  { value: '24h', label: '24 h' },
+  { value: '7d', label: '7 d' },
+] as const
+
+export interface FilterState {
+  sources: string[]
+  minConf: number
+  maxConf: number
+  minPrice: string
+  maxPrice: string
+  updatedWithin: string
+  sort: string
+  sortDir: 'asc' | 'desc'
+}
+
+export function readFilterState(searchParams: URLSearchParams): FilterState {
+  return {
+    sources: searchParams.get('sources')?.split(',').filter(Boolean) ?? [],
+    minConf: Number(searchParams.get('minConf') ?? '0'),
+    maxConf: Number(searchParams.get('maxConf') ?? '100'),
+    minPrice: searchParams.get('minPrice') ?? '',
+    maxPrice: searchParams.get('maxPrice') ?? '',
+    updatedWithin: searchParams.get('updatedWithin') ?? 'all',
+    sort: searchParams.get('sort') ?? '',
+    sortDir: (searchParams.get('sortDir') as 'asc' | 'desc') ?? 'desc',
+  }
+}
+
+export function countActiveFilters(f: FilterState): number {
+  let n = 0
+  if (f.sources.length > 0 && f.sources.length < KNOWN_SOURCES.length) n++
+  if (f.minConf > 0 || f.maxConf < 100) n++
+  if (f.minPrice || f.maxPrice) n++
+  if (f.updatedWithin !== 'all') n++
+  if (f.sort) n++
+  return n
+}
+
+interface Props {
+  availableSources?: readonly string[]
+}
+
+export function FilterPanel({ availableSources = KNOWN_SOURCES }: Props) {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const f = readFilterState(searchParams)
+
+  const setParam = useCallback(
+    (key: string, value: string) => {
+      const params = new URLSearchParams(searchParams)
+      if (value) params.set(key, value)
+      else params.delete(key)
+      navigate({ search: params.toString() }, { replace: true })
+    },
+    [searchParams, navigate],
+  )
+
+  const clearAll = useCallback(() => {
+    const params = new URLSearchParams(searchParams)
+    for (const key of ['sources', 'minConf', 'maxConf', 'minPrice', 'maxPrice', 'updatedWithin', 'sort', 'sortDir']) {
+      params.delete(key)
+    }
+    navigate({ search: params.toString() }, { replace: true })
+  }, [searchParams, navigate])
+
+  const toggleSource = useCallback(
+    (src: string) => {
+      const effective = new Set(f.sources.length > 0 ? f.sources : [...availableSources])
+      if (effective.has(src)) effective.delete(src)
+      else effective.add(src)
+      const next = [...effective]
+      setParam('sources', next.length === availableSources.length ? '' : next.join(','))
+    },
+    [f.sources, availableSources, setParam],
+  )
+
+  const isSourceChecked = (src: string) =>
+    f.sources.length === 0 || f.sources.includes(src)
+
+  const activeCount = countActiveFilters(f)
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-4 mb-4">
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-sm font-medium text-gray-300">Filters &amp; Sort</span>
+        {activeCount > 0 && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            Clear all ({activeCount})
+          </button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {/* Sources */}
+        <div>
+          <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Oracle Sources</p>
+          <div className="flex flex-wrap gap-3">
+            {availableSources.map((src) => (
+              <label key={src} className="flex items-center gap-1.5 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={isSourceChecked(src)}
+                  onChange={() => toggleSource(src)}
+                  className="w-3.5 h-3.5 rounded border-gray-600 bg-gray-800 text-cyan-500 focus:ring-cyan-500/50 focus:ring-offset-0"
+                />
+                <span className="text-sm text-gray-300 capitalize">{src}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Last Updated */}
+        <div>
+          <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Last Updated</p>
+          <div className="flex flex-wrap gap-1.5">
+            {UPDATED_WITHIN_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setParam('updatedWithin', opt.value === 'all' ? '' : opt.value)}
+                className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                  f.updatedWithin === opt.value || (opt.value === 'all' && f.updatedWithin === 'all')
+                    ? 'border-cyan-500 text-cyan-400 bg-cyan-500/10'
+                    : 'border-gray-700 text-gray-400 hover:border-gray-600'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Confidence Range */}
+        <div>
+          <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">
+            Confidence: {f.minConf}%–{f.maxConf}%
+          </p>
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-gray-600 w-5">Min</span>
+              <input
+                type="range"
+                min="0"
+                max="100"
+                value={f.minConf}
+                onChange={(e) => {
+                  const val = Number(e.target.value)
+                  if (val <= f.maxConf) setParam('minConf', val === 0 ? '' : String(val))
+                }}
+                className="flex-1 accent-cyan-500"
+                aria-label="Minimum confidence"
+              />
+              <span className="text-xs text-gray-400 w-8 text-right">{f.minConf}%</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-gray-600 w-5">Max</span>
+              <input
+                type="range"
+                min="0"
+                max="100"
+                value={f.maxConf}
+                onChange={(e) => {
+                  const val = Number(e.target.value)
+                  if (val >= f.minConf) setParam('maxConf', val === 100 ? '' : String(val))
+                }}
+                className="flex-1 accent-cyan-500"
+                aria-label="Maximum confidence"
+              />
+              <span className="text-xs text-gray-400 w-8 text-right">{f.maxConf}%</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Price Range */}
+        <div>
+          <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Price Range</p>
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              min="0"
+              step="any"
+              placeholder="Min"
+              value={f.minPrice}
+              onChange={(e) => setParam('minPrice', e.target.value)}
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-cyan-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              aria-label="Minimum price"
+            />
+            <span className="text-gray-600 text-sm shrink-0">–</span>
+            <input
+              type="number"
+              min="0"
+              step="any"
+              placeholder="Max"
+              value={f.maxPrice}
+              onChange={(e) => setParam('maxPrice', e.target.value)}
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-cyan-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              aria-label="Maximum price"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Sort */}
+      <div className="mt-4 pt-4 border-t border-gray-800">
+        <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Sort By</p>
+        <div className="flex items-center gap-2">
+          <select
+            value={f.sort}
+            onChange={(e) => setParam('sort', e.target.value)}
+            className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-3 py-1.5 text-sm text-white focus:outline-none focus:ring-1 focus:ring-cyan-500"
+            aria-label="Sort by"
+          >
+            <option value="">Default</option>
+            {SORT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => setParam('sortDir', f.sortDir === 'asc' ? 'desc' : 'asc')}
+            title={f.sortDir === 'asc' ? 'Ascending' : 'Descending'}
+            aria-label={`Sort direction: ${f.sortDir === 'asc' ? 'ascending' : 'descending'}`}
+            className="p-1.5 border border-gray-700 rounded-lg text-gray-400 hover:text-gray-200 hover:border-gray-600 transition-colors"
+          >
+            {f.sortDir === 'asc' ? (
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4h13M3 8h9m-9 4h5m10 8l-4-4m0 0l-4 4m4-4V4" />
+              </svg>
+            ) : (
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4h13M3 8h9m-9 4h5m10 0l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/NotificationChannelsModal.tsx
+++ b/src/components/NotificationChannelsModal.tsx
@@ -1,0 +1,372 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const STORAGE_KEY = 'notification-channels'
+
+interface NotificationConfig {
+  email: { address: string; enabled: boolean }
+  webPush: { enabled: boolean }
+  webhook: { url: string; secret: string; enabled: boolean }
+}
+
+const DEFAULT_CONFIG: NotificationConfig = {
+  email: { address: '', enabled: false },
+  webPush: { enabled: false },
+  webhook: { url: '', secret: '', enabled: false },
+}
+
+function loadConfig(): NotificationConfig {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_CONFIG
+    const parsed = JSON.parse(raw) as Partial<NotificationConfig>
+    return {
+      email: { ...DEFAULT_CONFIG.email, ...parsed.email },
+      webPush: { ...DEFAULT_CONFIG.webPush, ...parsed.webPush },
+      webhook: { ...DEFAULT_CONFIG.webhook, ...parsed.webhook },
+    }
+  } catch {
+    return DEFAULT_CONFIG
+  }
+}
+
+type TabId = 'email' | 'webpush' | 'webhook'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+}
+
+function StatusDot({ active }: { active: boolean }) {
+  return (
+    <span
+      className={`inline-block w-2 h-2 rounded-full ${active ? 'bg-green-400' : 'bg-gray-600'}`}
+      aria-hidden="true"
+    />
+  )
+}
+
+export function NotificationChannelsModal({ isOpen, onClose }: Props) {
+  const [config, setConfig] = useState<NotificationConfig>(loadConfig)
+  const [activeTab, setActiveTab] = useState<TabId>('email')
+  const [pushPermission, setPushPermission] = useState<NotificationPermission>('default')
+  const [testStatus, setTestStatus] = useState<string | null>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if ('Notification' in window) {
+      setPushPermission(Notification.permission)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (isOpen) {
+      setTestStatus(null)
+      requestAnimationFrame(() => dialogRef.current?.focus())
+    }
+  }, [isOpen])
+
+  const save = useCallback(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(config))
+    onClose()
+  }, [config, onClose])
+
+  const requestPushPermission = useCallback(async () => {
+    if (!('Notification' in window)) return
+    const permission = await Notification.requestPermission()
+    setPushPermission(permission)
+    if (permission === 'granted') {
+      setConfig((c) => ({ ...c, webPush: { ...c.webPush, enabled: true } }))
+    }
+  }, [])
+
+  const handleTest = useCallback(
+    async (tab: TabId) => {
+      setTestStatus(null)
+      if (tab === 'webpush') {
+        if (pushPermission !== 'granted') {
+          setTestStatus('Grant browser permission first')
+          return
+        }
+        new Notification('Test Notification', { body: 'This is a test price alert notification from the Oracle.' })
+        setTestStatus('Notification sent')
+      } else if (tab === 'email') {
+        if (!config.email.address) {
+          setTestStatus('Enter an email address first')
+          return
+        }
+        setTestStatus(`Test email queued for ${config.email.address}`)
+      } else if (tab === 'webhook') {
+        if (!config.webhook.url) {
+          setTestStatus('Enter a webhook URL first')
+          return
+        }
+        try {
+          await fetch(config.webhook.url, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...(config.webhook.secret ? { 'X-Webhook-Secret': config.webhook.secret } : {}),
+            },
+            body: JSON.stringify({ type: 'test', message: 'Test webhook from Stellar Price Oracle' }),
+          })
+          setTestStatus('Webhook test sent')
+        } catch {
+          setTestStatus('Webhook request failed — check URL and CORS settings')
+        }
+      }
+    },
+    [config.email.address, config.webhook.url, config.webhook.secret, pushPermission],
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    },
+    [onClose],
+  )
+
+  if (!isOpen) return null
+
+  const tabs: { id: TabId; label: string }[] = [
+    { id: 'email', label: 'Email' },
+    { id: 'webpush', label: 'Web Push' },
+    { id: 'webhook', label: 'Webhook' },
+  ]
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+      role="presentation"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Notification channels configuration"
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        className="w-full max-w-md bg-gray-900 border border-gray-800 rounded-2xl p-6 shadow-2xl focus:outline-none"
+      >
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-xl font-semibold text-white">Notification Channels</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-300 p-1 rounded-lg hover:bg-gray-800 transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex border-b border-gray-800 mb-5" role="tablist">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              onClick={() => {
+                setActiveTab(tab.id)
+                setTestStatus(null)
+              }}
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                activeTab === tab.id
+                  ? 'border-cyan-500 text-cyan-400'
+                  : 'border-transparent text-gray-500 hover:text-gray-300'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {activeTab === 'email' && (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <StatusDot active={!!config.email.address && config.email.enabled} />
+              <span className="text-sm text-gray-400">
+                {config.email.address && config.email.enabled
+                  ? `Configured: ${config.email.address}`
+                  : 'Not configured'}
+              </span>
+            </div>
+            <div>
+              <label htmlFor="notif-email-address" className="block text-sm text-gray-400 mb-1.5">
+                Email Address
+              </label>
+              <input
+                id="notif-email-address"
+                type="email"
+                value={config.email.address}
+                onChange={(e) =>
+                  setConfig((c) => ({ ...c, email: { ...c.email, address: e.target.value } }))
+                }
+                placeholder="you@example.com"
+                className="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-2.5 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/50"
+              />
+            </div>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={config.email.enabled}
+                onChange={(e) =>
+                  setConfig((c) => ({ ...c, email: { ...c.email, enabled: e.target.checked } }))
+                }
+                className="w-4 h-4 rounded border-gray-600 bg-gray-800 text-cyan-500"
+              />
+              <span className="text-sm text-gray-300">Enable email notifications</span>
+            </label>
+            <button
+              type="button"
+              onClick={() => handleTest('email')}
+              className="text-xs px-3 py-1.5 rounded-lg border border-gray-700 text-gray-300 hover:bg-gray-800 transition-colors"
+            >
+              Send test email
+            </button>
+          </div>
+        )}
+
+        {activeTab === 'webpush' && (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <StatusDot active={pushPermission === 'granted' && config.webPush.enabled} />
+              <span className="text-sm text-gray-400">
+                Permission:{' '}
+                <span
+                  className={
+                    pushPermission === 'granted'
+                      ? 'text-green-400'
+                      : pushPermission === 'denied'
+                        ? 'text-red-400'
+                        : 'text-gray-400'
+                  }
+                >
+                  {pushPermission}
+                </span>
+              </span>
+            </div>
+            {pushPermission !== 'granted' ? (
+              <button
+                type="button"
+                onClick={requestPushPermission}
+                disabled={pushPermission === 'denied'}
+                className="w-full py-2.5 text-sm rounded-xl bg-cyan-600 text-white hover:bg-cyan-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {pushPermission === 'denied'
+                  ? 'Permission denied — enable in browser settings'
+                  : 'Grant browser permission'}
+              </button>
+            ) : (
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={config.webPush.enabled}
+                  onChange={(e) =>
+                    setConfig((c) => ({ ...c, webPush: { ...c.webPush, enabled: e.target.checked } }))
+                  }
+                  className="w-4 h-4 rounded border-gray-600 bg-gray-800 text-cyan-500"
+                />
+                <span className="text-sm text-gray-300">Enable web push notifications</span>
+              </label>
+            )}
+            <button
+              type="button"
+              onClick={() => handleTest('webpush')}
+              className="text-xs px-3 py-1.5 rounded-lg border border-gray-700 text-gray-300 hover:bg-gray-800 transition-colors"
+            >
+              Send test notification
+            </button>
+          </div>
+        )}
+
+        {activeTab === 'webhook' && (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <StatusDot active={!!config.webhook.url && config.webhook.enabled} />
+              <span className="text-sm text-gray-400">
+                {config.webhook.url && config.webhook.enabled ? 'Configured' : 'Not configured'}
+              </span>
+            </div>
+            <div>
+              <label htmlFor="notif-webhook-url" className="block text-sm text-gray-400 mb-1.5">
+                Webhook URL
+              </label>
+              <input
+                id="notif-webhook-url"
+                type="url"
+                value={config.webhook.url}
+                onChange={(e) =>
+                  setConfig((c) => ({ ...c, webhook: { ...c.webhook, url: e.target.value } }))
+                }
+                placeholder="https://your-server.com/webhook"
+                className="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-2.5 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/50"
+              />
+            </div>
+            <div>
+              <label htmlFor="notif-webhook-secret" className="block text-sm text-gray-400 mb-1.5">
+                Secret <span className="text-gray-600">(optional)</span>
+              </label>
+              <input
+                id="notif-webhook-secret"
+                type="password"
+                value={config.webhook.secret}
+                onChange={(e) =>
+                  setConfig((c) => ({ ...c, webhook: { ...c.webhook, secret: e.target.value } }))
+                }
+                placeholder="Signing secret"
+                className="w-full bg-gray-800 border border-gray-700 rounded-xl px-4 py-2.5 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/50"
+              />
+            </div>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={config.webhook.enabled}
+                onChange={(e) =>
+                  setConfig((c) => ({ ...c, webhook: { ...c.webhook, enabled: e.target.checked } }))
+                }
+                className="w-4 h-4 rounded border-gray-600 bg-gray-800 text-cyan-500"
+              />
+              <span className="text-sm text-gray-300">Enable webhook notifications</span>
+            </label>
+            <button
+              type="button"
+              onClick={() => handleTest('webhook')}
+              className="text-xs px-3 py-1.5 rounded-lg border border-gray-700 text-gray-300 hover:bg-gray-800 transition-colors"
+            >
+              Send test request
+            </button>
+          </div>
+        )}
+
+        {testStatus && (
+          <p className="mt-3 text-sm text-cyan-400" role="status">
+            {testStatus}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-3 mt-6 pt-4 border-t border-gray-800">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-gray-400 bg-gray-800 border border-gray-700 rounded-xl hover:bg-gray-700 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            className="px-4 py-2 text-sm text-white bg-cyan-600 rounded-xl hover:bg-cyan-500 transition-colors"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,6 +10,7 @@ import { AlertModal } from '../components/AlertModal'
 import { AlertBadge } from '../components/AlertBadge'
 import { ConnectionBadge } from '../components/ConnectionBadge'
 import { NotificationChannelsModal } from '../components/NotificationChannelsModal'
+import { FilterPanel, readFilterState, countActiveFilters } from '../components/FilterPanel'
 import { sanitizeSearchInput } from '../utils/sanitize'
 import type { AlertFormData, LivePriceEntry, PriceData } from '../types'
 
@@ -39,29 +40,39 @@ export function Dashboard() {
   const [modalPair, setModalPair] = useState('')
   const [dashboardView, setDashboardView] = useState<'card' | 'table'>('card')
   const [notifModalOpen, setNotifModalOpen] = useState(false)
+  const [filterPanelOpen, setFilterPanelOpen] = useState(false)
 
   const [selectMode, setSelectMode] = useState(false)
   const [selected, setSelected] = useState<Set<string>>(new Set())
 
   const search = searchParams.get('search') || ''
-  const confidence = searchParams.get('confidence') || 'all'
-  const source = searchParams.get('source') || 'all'
-  const sort = searchParams.get('sort') || ''
+  const filterState = readFilterState(searchParams)
+  const activeFilterCount = countActiveFilters(filterState)
+  const { sources, minConf, maxConf, minPrice, maxPrice, updatedWithin, sort, sortDir } = filterState
 
   const merged = mergePrices(prices, livePrices)
 
   const filtered = useMemo(() => {
     let result = merged
     if (search) result = result.filter((p) => p.assetPair.toLowerCase().includes(search.toLowerCase()))
-    if (confidence === 'high') result = result.filter((p) => p.confidence > 0.8)
-    else if (confidence === 'medium') result = result.filter((p) => p.confidence > 0.5)
-    if (source !== 'all') result = result.filter((p) => p.sources.some((s) => s.toLowerCase() === source.toLowerCase()))
+    if (sources.length > 0) result = result.filter((p) => p.sources.some((s) => sources.includes(s)))
+    if (minConf > 0) result = result.filter((p) => p.confidence * 100 >= minConf)
+    if (maxConf < 100) result = result.filter((p) => p.confidence * 100 <= maxConf)
+    if (minPrice) result = result.filter((p) => p.price >= Number(minPrice))
+    if (maxPrice) result = result.filter((p) => p.price <= Number(maxPrice))
+    if (updatedWithin !== 'all') {
+      const ms = updatedWithin === '1h' ? 3_600_000 : updatedWithin === '6h' ? 21_600_000 : updatedWithin === '24h' ? 86_400_000 : 604_800_000
+      const cutoff = Date.now() - ms
+      result = result.filter((p) => p.timestamp >= cutoff)
+    }
+    const desc = sortDir === 'desc'
     if (sort === 'price-high') result = [...result].sort((a, b) => b.price - a.price)
     else if (sort === 'price-low') result = [...result].sort((a, b) => a.price - b.price)
-    else if (sort === 'confidence') result = [...result].sort((a, b) => b.confidence - a.confidence)
-    else if (sort === 'recent') result = [...result].sort((a, b) => b.timestamp - a.timestamp)
+    else if (sort === 'confidence') result = [...result].sort((a, b) => desc ? b.confidence - a.confidence : a.confidence - b.confidence)
+    else if (sort === 'recent') result = [...result].sort((a, b) => desc ? b.timestamp - a.timestamp : a.timestamp - b.timestamp)
+    else if (sort === 'pair') result = [...result].sort((a, b) => desc ? b.assetPair.localeCompare(a.assetPair) : a.assetPair.localeCompare(b.assetPair))
     return result
-  }, [merged, search, confidence, source, sort])
+  }, [merged, search, sources, minConf, maxConf, minPrice, maxPrice, updatedWithin, sort, sortDir])
 
   const handleCardClick = useCallback(
     (pair: string) => {
@@ -131,6 +142,28 @@ export function Dashboard() {
             aria-label="Search by asset pair"
           />
 
+          <button
+            type="button"
+            onClick={() => setFilterPanelOpen((o) => !o)}
+            className={`relative flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+              filterPanelOpen
+                ? 'bg-cyan-600 border-cyan-500 text-white'
+                : 'border-gray-700 text-gray-400 hover:text-gray-200 hover:border-gray-600'
+            }`}
+            aria-pressed={filterPanelOpen}
+            aria-label="Toggle filter panel"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-.293.707L13 13.414V19a1 1 0 01-.553.894l-4 2A1 1 0 017 21v-7.586L3.293 6.707A1 1 0 013 6V4z" />
+            </svg>
+            Filter
+            {activeFilterCount > 0 && (
+              <span className="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] flex items-center justify-center text-[10px] font-bold bg-cyan-500 text-gray-900 rounded-full px-1">
+                {activeFilterCount}
+              </span>
+            )}
+          </button>
+
           {!pricesLoading && prices.length > 0 && (
             <button
               type="button"
@@ -197,6 +230,13 @@ export function Dashboard() {
           <ConnectionBadge status={wsStatus} />
         </div>
       </div>
+
+      {filterPanelOpen && (
+        <FilterPanel availableSources={[...new Set(prices.flatMap((p) => p.sources))].length > 0
+          ? [...new Set(prices.flatMap((p) => p.sources))]
+          : undefined}
+        />
+      )}
 
       {selectMode && (
         <div className="mb-4 p-3 bg-gray-900 border border-cyan-800 rounded-xl flex flex-wrap items-center gap-3">
@@ -292,8 +332,10 @@ export function Dashboard() {
 
       {!pricesLoading && merged.length > 0 && filtered.length === 0 && (
         <div className="text-center py-16 text-gray-500">
-          <p className="text-lg mb-2">No results for "{search}"</p>
-          <p className="text-sm">Try a different search term.</p>
+          <p className="text-lg mb-2">No results{search ? ` for "${search}"` : ''}</p>
+          <p className="text-sm">
+            {activeFilterCount > 0 ? 'Try adjusting your filters.' : 'Try a different search term.'}
+          </p>
         </div>
       )}
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -9,6 +9,7 @@ import { PriceTableView } from '../components/PriceTableView'
 import { AlertModal } from '../components/AlertModal'
 import { AlertBadge } from '../components/AlertBadge'
 import { ConnectionBadge } from '../components/ConnectionBadge'
+import { NotificationChannelsModal } from '../components/NotificationChannelsModal'
 import { sanitizeSearchInput } from '../utils/sanitize'
 import type { AlertFormData, LivePriceEntry, PriceData } from '../types'
 
@@ -37,6 +38,7 @@ export function Dashboard() {
   const [modalOpen, setModalOpen] = useState(false)
   const [modalPair, setModalPair] = useState('')
   const [dashboardView, setDashboardView] = useState<'card' | 'table'>('card')
+  const [notifModalOpen, setNotifModalOpen] = useState(false)
 
   const [selectMode, setSelectMode] = useState(false)
   const [selected, setSelected] = useState<Set<string>>(new Set())
@@ -180,6 +182,18 @@ export function Dashboard() {
             </div>
           )}
           <AlertBadge count={activeCount} alerts={alerts} />
+          <button
+            type="button"
+            onClick={() => setNotifModalOpen(true)}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-gray-700 text-gray-400 hover:text-gray-200 hover:border-gray-600 transition-colors"
+            aria-label="Configure notification channels"
+            title="Notification channels"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+            </svg>
+            Alerts
+          </button>
           <ConnectionBadge status={wsStatus} />
         </div>
       </div>
@@ -299,6 +313,8 @@ export function Dashboard() {
             : undefined
         }
       />
+
+      <NotificationChannelsModal isOpen={notifModalOpen} onClose={() => setNotifModalOpen(false)} />
     </div>
   )
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -50,14 +50,33 @@ export function Dashboard() {
   const activeFilterCount = countActiveFilters(filterState)
   const { sources, minConf, maxConf, minPrice, maxPrice, updatedWithin, sort, sortDir } = filterState
 
+  // Legacy params kept for backward compatibility
+  const legacyConfidence = searchParams.get('confidence') || 'all'
+  const legacySource = searchParams.get('source') || 'all'
+
   const merged = mergePrices(prices, livePrices)
 
   const filtered = useMemo(() => {
     let result = merged
     if (search) result = result.filter((p) => p.assetPair.toLowerCase().includes(search.toLowerCase()))
-    if (sources.length > 0) result = result.filter((p) => p.sources.some((s) => sources.includes(s)))
-    if (minConf > 0) result = result.filter((p) => p.confidence * 100 >= minConf)
-    if (maxConf < 100) result = result.filter((p) => p.confidence * 100 <= maxConf)
+
+    // Source filter: new 'sources' param takes precedence over legacy 'source'
+    if (sources.length > 0) {
+      result = result.filter((p) => p.sources.some((s) => sources.includes(s)))
+    } else if (legacySource !== 'all') {
+      result = result.filter((p) => p.sources.some((s) => s.toLowerCase() === legacySource.toLowerCase()))
+    }
+
+    // Confidence filter: new minConf/maxConf take precedence over legacy 'confidence'
+    if (minConf > 0 || maxConf < 100) {
+      if (minConf > 0) result = result.filter((p) => p.confidence * 100 >= minConf)
+      if (maxConf < 100) result = result.filter((p) => p.confidence * 100 <= maxConf)
+    } else if (legacyConfidence === 'high') {
+      result = result.filter((p) => p.confidence > 0.8)
+    } else if (legacyConfidence === 'medium') {
+      result = result.filter((p) => p.confidence > 0.5)
+    }
+
     if (minPrice) result = result.filter((p) => p.price >= Number(minPrice))
     if (maxPrice) result = result.filter((p) => p.price <= Number(maxPrice))
     if (updatedWithin !== 'all') {
@@ -72,7 +91,7 @@ export function Dashboard() {
     else if (sort === 'recent') result = [...result].sort((a, b) => desc ? b.timestamp - a.timestamp : a.timestamp - b.timestamp)
     else if (sort === 'pair') result = [...result].sort((a, b) => desc ? b.assetPair.localeCompare(a.assetPair) : a.assetPair.localeCompare(b.assetPair))
     return result
-  }, [merged, search, sources, minConf, maxConf, minPrice, maxPrice, updatedWithin, sort, sortDir])
+  }, [merged, search, sources, minConf, maxConf, minPrice, maxPrice, updatedWithin, sort, sortDir, legacyConfidence, legacySource])
 
   const handleCardClick = useCallback(
     (pair: string) => {

--- a/src/pages/PriceDetail.tsx
+++ b/src/pages/PriceDetail.tsx
@@ -1,9 +1,12 @@
+import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useSwr } from '../hooks/useSwr'
 import { fetchPrice, fetchPriceHistory } from '../api/rest'
 import { PriceDetailSkeleton } from '../components/PriceDetailSkeleton'
+import { CsvImportZone } from '../components/CsvImportZone'
 import { formatPrice, timeAgo, formatTimestamp } from '../utils/format'
 import type { PriceHistoryEntry } from '../types'
+import type { CsvRow } from '../components/CsvImportZone'
 
 const SOURCE_COLORS: Record<string, string> = {
   chainlink: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
@@ -12,16 +15,18 @@ const SOURCE_COLORS: Record<string, string> = {
   reflector: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30',
 }
 
-function MiniChart({ data }: { data: PriceHistoryEntry[] }) {
+function MiniChart({ data, importedData }: { data: PriceHistoryEntry[]; importedData?: CsvRow[] }) {
   if (data.length < 2) return null
 
   const W = 600
   const H = 160
   const PAD = 8
 
-  const prices = data.map((d) => d.price)
-  const min = Math.min(...prices)
-  const max = Math.max(...prices)
+  const oraclePrices = data.map((d) => d.price)
+  const importedPrices = importedData?.map((d) => d.price) ?? []
+  const allPrices = [...oraclePrices, ...importedPrices]
+  const min = Math.min(...allPrices)
+  const max = Math.max(...allPrices)
   const range = max - min || 1
 
   const pts = data.map((d, i) => {
@@ -32,6 +37,18 @@ function MiniChart({ data }: { data: PriceHistoryEntry[] }) {
 
   const areaPath = `M${pts[0]} L${pts.join(' L')} L${W - PAD},${H - PAD} L${PAD},${H - PAD} Z`
   const linePath = `M${pts[0]} L${pts.join(' L')}`
+
+  let importedPath: string | null = null
+  if (importedData && importedData.length >= 2) {
+    const importedMinTs = importedData[0].timestamp
+    const importedTsRange = importedData[importedData.length - 1].timestamp - importedMinTs || 1
+    const importedPts = importedData.map((d) => {
+      const x = PAD + ((d.timestamp - importedMinTs) / importedTsRange) * (W - PAD * 2)
+      const y = H - PAD - ((d.price - min) / range) * (H - PAD * 2)
+      return `${x},${y}`
+    })
+    importedPath = `M${importedPts[0]} L${importedPts.join(' L')}`
+  }
 
   return (
     <svg
@@ -48,6 +65,9 @@ function MiniChart({ data }: { data: PriceHistoryEntry[] }) {
       </defs>
       <path d={areaPath} fill="url(#chartGrad)" />
       <path d={linePath} fill="none" stroke="#06b6d4" strokeWidth="2" />
+      {importedPath && (
+        <path d={importedPath} fill="none" stroke="#f59e0b" strokeWidth="1.5" strokeDasharray="4,2" />
+      )}
     </svg>
   )
 }
@@ -55,6 +75,7 @@ function MiniChart({ data }: { data: PriceHistoryEntry[] }) {
 export function PriceDetail() {
   const { pair } = useParams<{ pair: string }>()
   const navigate = useNavigate()
+  const [importedData, setImportedData] = useState<CsvRow[] | null>(null)
 
   const decodedPair = pair ? decodeURIComponent(pair) : ''
 
@@ -132,14 +153,38 @@ export function PriceDetail() {
 
           {/* History chart */}
           <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
-            <p className="text-xs text-gray-500 uppercase tracking-wider mb-4">Price History</p>
+            <div className="flex items-center justify-between mb-4">
+              <p className="text-xs text-gray-500 uppercase tracking-wider">Price History</p>
+              {importedData && (
+                <div className="flex items-center gap-3 text-xs">
+                  <span className="flex items-center gap-1 text-cyan-400">
+                    <span className="inline-block w-6 border-t-2 border-cyan-500" />
+                    Oracle
+                  </span>
+                  <span className="flex items-center gap-1 text-amber-400">
+                    <span className="inline-block w-6 border-t-2 border-amber-400 border-dashed" />
+                    Imported
+                  </span>
+                </div>
+              )}
+            </div>
             {historyResponse && historyResponse.history.length > 1 ? (
-              <MiniChart data={historyResponse.history} />
+              <MiniChart data={historyResponse.history} importedData={importedData ?? undefined} />
             ) : (
               <div className="h-48 flex items-center justify-center text-gray-600 text-sm">
                 No history available
               </div>
             )}
+          </div>
+
+          {/* CSV import */}
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+            <p className="text-xs text-gray-500 uppercase tracking-wider mb-4">Import Price Data</p>
+            <CsvImportZone
+              hasImport={importedData !== null}
+              onImport={setImportedData}
+              onClear={() => setImportedData(null)}
+            />
           </div>
         </div>
       ) : null}

--- a/src/pages/PriceDetail.tsx
+++ b/src/pages/PriceDetail.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useSwr } from '../hooks/useSwr'
 import { fetchPrice, fetchPriceHistory } from '../api/rest'
 import { PriceDetailSkeleton } from '../components/PriceDetailSkeleton'
 import { CsvImportZone } from '../components/CsvImportZone'
-import { formatPrice, timeAgo, formatTimestamp } from '../utils/format'
-import type { PriceHistoryEntry } from '../types'
+import { CanvasChart } from '../chart/CanvasChart'
+import { formatPrice, timeAgo, formatTimestamp, formatChartTime } from '../utils/format'
+import type { ChartSeries } from '../chart/ChartEngine'
 import type { CsvRow } from '../components/CsvImportZone'
 
 const SOURCE_COLORS: Record<string, string> = {
@@ -13,63 +14,6 @@ const SOURCE_COLORS: Record<string, string> = {
   redstone: 'bg-red-500/20 text-red-400 border-red-500/30',
   band: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
   reflector: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30',
-}
-
-function MiniChart({ data, importedData }: { data: PriceHistoryEntry[]; importedData?: CsvRow[] }) {
-  if (data.length < 2) return null
-
-  const W = 600
-  const H = 160
-  const PAD = 8
-
-  const oraclePrices = data.map((d) => d.price)
-  const importedPrices = importedData?.map((d) => d.price) ?? []
-  const allPrices = [...oraclePrices, ...importedPrices]
-  const min = Math.min(...allPrices)
-  const max = Math.max(...allPrices)
-  const range = max - min || 1
-
-  const pts = data.map((d, i) => {
-    const x = PAD + (i / (data.length - 1)) * (W - PAD * 2)
-    const y = H - PAD - ((d.price - min) / range) * (H - PAD * 2)
-    return `${x},${y}`
-  })
-
-  const areaPath = `M${pts[0]} L${pts.join(' L')} L${W - PAD},${H - PAD} L${PAD},${H - PAD} Z`
-  const linePath = `M${pts[0]} L${pts.join(' L')}`
-
-  let importedPath: string | null = null
-  if (importedData && importedData.length >= 2) {
-    const importedMinTs = importedData[0].timestamp
-    const importedTsRange = importedData[importedData.length - 1].timestamp - importedMinTs || 1
-    const importedPts = importedData.map((d) => {
-      const x = PAD + ((d.timestamp - importedMinTs) / importedTsRange) * (W - PAD * 2)
-      const y = H - PAD - ((d.price - min) / range) * (H - PAD * 2)
-      return `${x},${y}`
-    })
-    importedPath = `M${importedPts[0]} L${importedPts.join(' L')}`
-  }
-
-  return (
-    <svg
-      viewBox={`0 0 ${W} ${H}`}
-      preserveAspectRatio="none"
-      className="w-full h-48"
-      aria-hidden="true"
-    >
-      <defs>
-        <linearGradient id="chartGrad" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="#06b6d4" stopOpacity="0.3" />
-          <stop offset="100%" stopColor="#06b6d4" stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      <path d={areaPath} fill="url(#chartGrad)" />
-      <path d={linePath} fill="none" stroke="#06b6d4" strokeWidth="2" />
-      {importedPath && (
-        <path d={importedPath} fill="none" stroke="#f59e0b" strokeWidth="1.5" strokeDasharray="4,2" />
-      )}
-    </svg>
-  )
 }
 
 export function PriceDetail() {
@@ -92,6 +36,29 @@ export function PriceDetail() {
   )
 
   const loading = priceLoading || historyLoading
+
+  const chartSeries = useMemo<ChartSeries[]>(() => {
+    const series: ChartSeries[] = []
+    if (historyResponse && historyResponse.history.length >= 2) {
+      series.push({
+        id: 'oracle',
+        label: decodedPair,
+        points: historyResponse.history.map((h) => ({ x: h.timestamp, y: h.price })),
+        color: '#06b6d4',
+        style: 'area',
+      })
+    }
+    if (importedData && importedData.length >= 2) {
+      series.push({
+        id: 'imported',
+        label: 'Imported CSV',
+        points: importedData.map((r) => ({ x: r.timestamp, y: r.price })),
+        color: '#f59e0b',
+        style: 'dashed-line',
+      })
+    }
+    return series
+  }, [historyResponse, importedData, decodedPair])
 
   return (
     <div>
@@ -152,24 +119,15 @@ export function PriceDetail() {
           </div>
 
           {/* History chart */}
-          <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
-            <div className="flex items-center justify-between mb-4">
-              <p className="text-xs text-gray-500 uppercase tracking-wider">Price History</p>
-              {importedData && (
-                <div className="flex items-center gap-3 text-xs">
-                  <span className="flex items-center gap-1 text-cyan-400">
-                    <span className="inline-block w-6 border-t-2 border-cyan-500" />
-                    Oracle
-                  </span>
-                  <span className="flex items-center gap-1 text-amber-400">
-                    <span className="inline-block w-6 border-t-2 border-amber-400 border-dashed" />
-                    Imported
-                  </span>
-                </div>
-              )}
-            </div>
-            {historyResponse && historyResponse.history.length > 1 ? (
-              <MiniChart data={historyResponse.history} importedData={importedData ?? undefined} />
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-6 mb-6">
+            <p className="text-xs text-gray-500 uppercase tracking-wider mb-4">Price History</p>
+            {chartSeries.length > 0 ? (
+              <CanvasChart
+                series={chartSeries}
+                className="w-full h-48"
+                formatX={formatChartTime}
+                formatY={formatPrice}
+              />
             ) : (
               <div className="h-48 flex items-center justify-center text-gray-600 text-sm">
                 No history available


### PR DESCRIPTION
Add price data features: CSV import, notification channels, advanced filtering, chart engine
Summary
CSV price data import (#108): drag-and-drop upload zone on the price detail page with format validation, 5 MB size limit, and imported data overlaid as a dashed line on the price history chart
Notification channels (#109): configuration modal (Email, Web Push, Webhook tabs) accessible from the dashboard header, with channel status indicators and per-channel test buttons; settings persisted to localStorage
Advanced filtering & sorting (#111): collapsible filter panel with source provider checkboxes, confidence range sliders, price range inputs, last-updated time filter, sort field selector, and sort direction toggle; all state synced to URL params with an active-filter count badge on the toggle button
Pluggable chart engine (#113): ChartEngine.ts defines the ChartPlugin / ChartSeries / Viewport interfaces and ships built-in createAreaPlugin() and createLinePlugin() factories; CanvasChart.tsx renders series on a <canvas> using Canvas2D (no extra dependencies), handles responsive resize via ResizeObserver, and shows an interactive crosshair tooltip on hover; replaces the previous static SVG chart in PriceDetail
Test plan
 Upload a valid CSV (timestamp,price) on a price detail page — overlay line appears on the chart with the legend
 Upload a CSV > 5 MB or with a bad extension — error message shown
 Clear import — overlay disappears
 Open "Alerts" button → Notification Channels modal — switch tabs, enter values, save, reopen to verify persistence
 Click "Send test notification" on Web Push tab with permission granted
 Click "Filter" button on dashboard — panel expands with source checkboxes, confidence sliders, price range, last-updated chips, and sort selector
 Set filters and confirm URL params update; refresh page to confirm filters are restored
 Verify active-filter count badge appears on the Filter button
 "Clear all" button resets all filter params
 Hover over the price history chart — crosshair and tooltip follow the pointer
Closes #108
Closes #109
Closes #111
Closes #113