### PR TITLE
feat: add route-level code splitting with skeleton fallbacks (#11)

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,8 +1,10 @@
 import { test, expect } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 
 test('dashboard page loads', async ({ page }) => {
   await page.goto('/')
-  await expect(page.getByRole('heading', { name: 'Price Oracle Dashboard' })).toBeVisible()
+  await page.waitForLoadState('networkidle')
+  await expect(page.getByRole('heading', { name: 'Price Oracle Dashboard' })).toBeVisible({ timeout: 10_000 })
 })
 
 test('dashboard renders price cards or empty state', async ({ page }) => {
@@ -16,10 +18,12 @@ test('dashboard renders price cards or empty state', async ({ page }) => {
 
 test('search input is visible', async ({ page }) => {
   await page.goto('/')
-  await expect(page.getByRole('textbox', { name: 'Search by asset pair' })).toBeVisible()
+  await page.waitForLoadState('networkidle')
+  await expect(page.getByRole('textbox', { name: 'Search by asset pair' })).toBeVisible({ timeout: 10_000 })
 })
 
 test('404 page renders for unknown routes', async ({ page }) => {
   await page.goto('/unknown-route-xyz')
-  await expect(page.getByRole('heading', { name: /404|not found/i })).toBeVisible()
+  await page.waitForLoadState('networkidle')
+  await expect(page.getByRole('heading', { name: /404|not found/i })).toBeVisible({ timeout: 10_000 })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,21 @@
-import { Suspense, type ReactElement } from 'react'
+import { lazy, type ReactElement } from 'react'
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { Layout } from './components/Layout'
 import { ErrorBoundary } from './components/ErrorBoundary'
-import { Dashboard } from './pages/Dashboard'
-import { PriceDetail } from './pages/PriceDetail'
-import { ApiDocs } from './pages/ApiDocs'
-import { NotFound } from './pages/NotFound'
+import { RouteSuspense } from './components/Skeletons/RouteSuspense'
+import { DashboardSkeleton } from './components/Skeletons/DashboardSkeleton'
+import { PriceDetailSkeleton } from './components/PriceDetailSkeleton'
+import { ApiDocsSkeleton } from './components/Skeletons/ApiDocsSkeleton'
+import { NotFoundSkeleton } from './components/Skeletons/NotFoundSkeleton'
 import { AlertsProvider } from './hooks/useAlerts'
 import { useWebVitals } from './hooks/useWebVitals'
 import { useAccessibility } from './hooks/useAccessibility'
 import { initAnalytics, trackPageview } from './hooks/useAnalytics'
+
+const Dashboard = lazy(() => import('./pages/Dashboard').then((m) => ({ default: m.Dashboard })))
+const PriceDetail = lazy(() => import('./pages/PriceDetail').then((m) => ({ default: m.PriceDetail })))
+const ApiDocs = lazy(() => import('./pages/ApiDocs').then((m) => ({ default: m.ApiDocs })))
+const NotFound = lazy(() => import('./pages/NotFound').then((m) => ({ default: m.NotFound })))
 
 const BASENAME = import.meta.env.BASE_URL.replace(/\/$/, '')
 
@@ -21,14 +27,40 @@ function AppContent(): ReactElement {
     <ErrorBoundary key={location.key}>
       <AlertsProvider>
         <Layout>
-          <Suspense fallback={null}>
-            <Routes>
-              <Route path="/" element={<Dashboard />} />
-              <Route path="/prices/:pair" element={<PriceDetail />} />
-              <Route path="/api-docs" element={<ApiDocs />} />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </Suspense>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <RouteSuspense fallback={<DashboardSkeleton />}>
+                  <Dashboard />
+                </RouteSuspense>
+              }
+            />
+            <Route
+              path="/prices/:pair"
+              element={
+                <RouteSuspense fallback={<PriceDetailSkeleton />}>
+                  <PriceDetail />
+                </RouteSuspense>
+              }
+            />
+            <Route
+              path="/api-docs"
+              element={
+                <RouteSuspense fallback={<ApiDocsSkeleton />}>
+                  <ApiDocs />
+                </RouteSuspense>
+              }
+            />
+            <Route
+              path="*"
+              element={
+                <RouteSuspense fallback={<NotFoundSkeleton />}>
+                  <NotFound />
+                </RouteSuspense>
+              }
+            />
+          </Routes>
         </Layout>
       </AlertsProvider>
     </ErrorBoundary>

--- a/src/components/Skeletons/ApiDocsSkeleton.tsx
+++ b/src/components/Skeletons/ApiDocsSkeleton.tsx
@@ -1,0 +1,38 @@
+import { type ReactElement } from 'react'
+
+const ENDPOINT_PLACEHOLDERS = 6
+
+export function ApiDocsSkeleton(): ReactElement {
+  return (
+    <div
+      role="status"
+      className="max-w-3xl mx-auto min-h-[calc(100vh-8rem)] animate-pulse"
+      aria-label="Loading API documentation"
+      aria-busy="true"
+    >
+      <div className="mb-8">
+        <div className="h-8 w-56 rounded bg-gray-200 dark:bg-gray-800 mb-2" />
+        <div className="h-4 w-full max-w-xl rounded bg-gray-200 dark:bg-gray-800 mb-3" />
+        <div className="h-9 w-40 rounded-lg bg-gray-200 dark:bg-gray-800" />
+      </div>
+
+      <div className="mb-4 flex flex-wrap gap-3">
+        <div className="h-4 w-48 rounded bg-gray-200 dark:bg-gray-800" />
+        <div className="h-4 w-40 rounded bg-gray-200 dark:bg-gray-800" />
+      </div>
+
+      <div className="space-y-4" aria-hidden="true">
+        {Array.from({ length: ENDPOINT_PLACEHOLDERS }, (_, i) => (
+          <div key={i} className="rounded-xl border border-gray-200 dark:border-gray-800 bg-gray-100 dark:bg-gray-900/50 p-4">
+            <div className="flex flex-wrap items-center gap-3 mb-3">
+              <div className="h-6 w-12 rounded bg-gray-200 dark:bg-gray-800" />
+              <div className="h-5 w-48 rounded bg-gray-200 dark:bg-gray-800" />
+            </div>
+            <div className="h-4 w-full max-w-md rounded bg-gray-200 dark:bg-gray-800 mb-4" />
+            <div className="h-24 w-full rounded-lg bg-gray-200 dark:bg-gray-800" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Skeletons/DashboardSkeleton.test.tsx
+++ b/src/components/Skeletons/DashboardSkeleton.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { DashboardSkeleton } from './DashboardSkeleton'
+import { checkAccessibility } from '../../test/accessibility'
+
+describe('DashboardSkeleton', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<DashboardSkeleton />)
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument()
+  })
+
+  it('has aria-busy and aria-label during loading', () => {
+    const { container } = render(<DashboardSkeleton />)
+    const el = container.querySelector('[aria-label="Loading dashboard"]')
+    expect(el).toBeInTheDocument()
+    expect(el).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('should have no accessibility violations', async () => {
+    await checkAccessibility(<DashboardSkeleton />)
+  })
+})

--- a/src/components/Skeletons/DashboardSkeleton.tsx
+++ b/src/components/Skeletons/DashboardSkeleton.tsx
@@ -1,0 +1,32 @@
+import { type ReactElement } from 'react'
+import { PriceCardSkeleton } from '../PriceCardSkeleton'
+
+const SKELETON_COUNT = 8
+
+export function DashboardSkeleton(): ReactElement {
+  return (
+    <div role="status" className="min-h-[calc(100vh-8rem)]" aria-label="Loading dashboard" aria-busy="true">
+      <div className="flex items-center justify-between mb-6 animate-pulse">
+        <div>
+          <div className="h-8 w-64 rounded bg-gray-200 dark:bg-gray-800 mb-2" />
+          <div className="h-4 w-80 rounded bg-gray-200 dark:bg-gray-800" />
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="h-9 w-48 rounded-lg bg-gray-200 dark:bg-gray-800" />
+          <div className="h-9 w-20 rounded-lg bg-gray-200 dark:bg-gray-800" />
+          <div className="h-9 w-24 rounded-lg bg-gray-200 dark:bg-gray-800" />
+          <div className="h-9 w-16 rounded-lg bg-gray-200 dark:bg-gray-800" />
+        </div>
+      </div>
+
+      <section
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+        aria-hidden="true"
+      >
+        {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+          <PriceCardSkeleton key={i} />
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/src/components/Skeletons/NotFoundSkeleton.tsx
+++ b/src/components/Skeletons/NotFoundSkeleton.tsx
@@ -1,0 +1,16 @@
+import { type ReactElement } from 'react'
+
+export function NotFoundSkeleton(): ReactElement {
+  return (
+    <div
+      role="status"
+      className="flex flex-col items-center justify-center py-32 text-center min-h-[calc(100vh-8rem)] animate-pulse"
+      aria-label="Loading page"
+      aria-busy="true"
+    >
+      <div className="h-16 w-24 rounded bg-gray-200 dark:bg-gray-800 mb-4" />
+      <div className="h-5 w-40 rounded bg-gray-200 dark:bg-gray-800 mb-8" />
+      <div className="h-10 w-36 rounded-lg bg-gray-200 dark:bg-gray-800" />
+    </div>
+  )
+}

--- a/src/components/Skeletons/RouteSuspense.tsx
+++ b/src/components/Skeletons/RouteSuspense.tsx
@@ -1,0 +1,55 @@
+import {
+  Suspense,
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+
+const MIN_SKELETON_MS = 200
+
+const RouteLoadContext = createContext<number>(Date.now())
+
+function EnsureMinSkeletonTime({
+  children,
+  placeholder,
+  minMs,
+}: {
+  children: ReactNode
+  placeholder: ReactNode
+  minMs: number
+}): ReactElement {
+  const loadStartedAt = useContext(RouteLoadContext)
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    const remaining = minMs - (Date.now() - loadStartedAt)
+    const timer = window.setTimeout(() => setReady(true), Math.max(0, remaining))
+    return () => window.clearTimeout(timer)
+  }, [loadStartedAt, minMs])
+
+  if (!ready) return <>{placeholder}</>
+  return <>{children}</>
+}
+
+interface RouteSuspenseProps {
+  fallback: ReactNode
+  children: ReactNode
+}
+
+export function RouteSuspense({ fallback, children }: RouteSuspenseProps): ReactElement {
+  const loadStartedAt = useRef(Date.now())
+
+  return (
+    <RouteLoadContext.Provider value={loadStartedAt.current}>
+      <Suspense fallback={fallback}>
+        <EnsureMinSkeletonTime placeholder={fallback} minMs={MIN_SKELETON_MS}>
+          {children}
+        </EnsureMinSkeletonTime>
+      </Suspense>
+    </RouteLoadContext.Provider>
+  )
+}


### PR DESCRIPTION
Lazy-load all page routes with React.lazy and per-route Suspense.

Add layout-matching skeleton fallbacks to shrink the initial bundle.

Prevent flash-of-empty-content during route navigation.