### PR TITLE
feat: PriceDetail page with historical chart, source badges, and /price/:pair route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,14 @@ function AppContent(): ReactElement {
               }
             />
             <Route
+              path="/price/:pair"
+              element={
+                <RouteSuspense fallback={<PriceDetailSkeleton />}>
+                  <PriceDetail />
+                </RouteSuspense>
+              }
+            />
+            <Route
               path="/api-docs"
               element={
                 <RouteSuspense fallback={<ApiDocsSkeleton />}>


### PR DESCRIPTION
## Summary

Adds the PriceDetail page with full historical chart visualization, oracle source badges, and the missing `/price/:pair` route.

## Changes

- **`src/pages/PriceDetail.tsx`** — New page component displaying current price, confidence, oracle source badges, and paginated price history chart
- **`src/components/PriceChart.tsx`** — Area chart rendering fetched `PriceHistoryEntry[]` data with time-range selector, zoom/pan, and full-screen mode
- **`src/hooks/usePriceHistory.ts`** — Hook that fetches paginated price history from `GET /api/prices/:pair/history`
- **`src/App.tsx`** — Added `/price/:pair` route (lazy-loaded with Suspense) so `CardContextMenu` navigation no longer 404s

## Issues Closed

Closes #146
Closes #152
Closes #159
Closes #150