### PR TITLE
feat: add confidence indicator with color coding to PriceDetail

### DIFF
--- a/src/pages/PriceDetail.tsx
+++ b/src/pages/PriceDetail.tsx
@@ -16,6 +16,16 @@ const SOURCE_COLORS: Record<string, string> = {
   reflector: 'bg-cyan-500/20 text-cyan-400 border-cyan-500/30',
 }
 
+function getConfidenceColor(confidence: number): string {
+  if (confidence > 0.9) {
+    return 'bg-green-500/20 text-green-400 border-green-500/30'
+  }
+  if (confidence > 0.8) {
+    return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30'
+  }
+  return 'bg-red-500/20 text-red-400 border-red-500/30'
+}
+
 export function PriceDetail() {
   const { pair } = useParams<{ pair: string }>()
   const navigate = useNavigate()
@@ -75,7 +85,9 @@ export function PriceDetail() {
             </p>
             <div className="flex items-center justify-between text-sm">
               <span className="text-gray-400">Updated {timeAgo(price.timestamp)}</span>
-              <span className="text-cyan-400">{(price.confidence * 100).toFixed(1)}% confidence</span>
+              <span className={`px-2 py-0.5 rounded text-xs font-medium border ${getConfidenceColor(price.confidence)}`}>
+                {(price.confidence * 100).toFixed(1)}% confidence
+              </span>
             </div>
             <p className="text-xs text-gray-600 mt-1">{formatTimestamp(price.timestamp)}</p>
           </div>


### PR DESCRIPTION
## Summary
This PR implements a confidence indicator with color coding for the PriceDetail component, addressing issue #160.

## Changes Made
- Added getConfidenceColor function to determine color based on confidence value
- Updated confidence display in PriceDetail to show color-coded badge
- Color coding follows the specification:
  - **Green (>0.9)**: High confidence - indicates very reliable price data
  - **Yellow (>0.8)**: Medium confidence - indicates moderately reliable price data
  - **Red (<=0.8)**: Low confidence - indicates less reliable price data

## Implementation Details
The confidence indicator is displayed as a badge with:
- Semi-transparent background color
- Matching text color
- Subtle border
- Rounded corners
- Small padding for visual appeal

This visual enhancement helps users quickly assess the reliability of price data at a glance, improving the overall user experience when viewing price details.

## Testing
- Changes are localized to PriceDetail.tsx
- No existing tests were modified (no PriceDetail-specific tests exist)
- The implementation follows the existing pattern used for source badges (SOURCE_COLORS)
- TypeScript compilation succeeds for the modified file
- The change is minimal and focused on the specific requirement

## Screenshots
N/A (visual change only)

## Checklist
- [x] Code follows project style guidelines
- [x] Commit message follows conventional commits format
- [x] Changes are minimal and focused
- [x] No breaking changes introduced
- [x] Addresses the acceptance criteria from issue #160

closes #160 