### PR TITLE
feat: add back navigation to dashboard in PriceDetail

### DIFF
--- a/src/pages/PriceDetail.tsx
+++ b/src/pages/PriceDetail.tsx
@@ -41,9 +41,9 @@ export function PriceDetail() {
     <div>
       <button
         type="button"
-        onClick={() => navigate(-1)}
+        onClick={() => navigate('/dashboard')}
         className="flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-200 mb-6 transition-colors"
-        aria-label="Go back"
+        aria-label="Go back to dashboard"
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />


### PR DESCRIPTION
## Summary

This PR implements back navigation to the dashboard from the PriceDetail page, addressing issue #161.

## Problem

The PriceDetail page had a back button that used navigate(-1) to go back in browser history. This approach has limitations:
- If a user navigates directly to PriceDetail (e.g., via URL or bookmark), navigate(-1) would not work as expected
- The behavior is inconsistent and depends on the user's navigation history
- Users could not reliably return to the dashboard

## Solution

Changed the back button to explicitly navigate to /dashboard instead of using browser history navigation.

## Changes Made

- Modified the back button's onClick handler from navigate(-1) to navigate('/dashboard')
- Updated the aria-label from Go back to Go back to dashboard for better accessibility
- This ensures users can always return to the dashboard regardless of how they arrived at the PriceDetail page

## Implementation Details

The change is minimal and focused:
- Only 2 lines modified in src/pages/PriceDetail.tsx
- No new dependencies or complex logic added
- Maintains existing styling and UI behavior
- Improves user experience by providing predictable navigation

## Testing

- Changes are localized to PriceDetail.tsx
- No existing tests were modified (no PriceDetail-specific tests exist)
- The implementation follows React Router best practices
- TypeScript compilation succeeds for the modified file
- The change is minimal and focused on the specific requirement

## Accessibility

- Updated aria-label to be more descriptive
- Screen readers will now announce Go back to dashboard instead of just Go back
- Improves understanding of the button's purpose for assistive technology users

## Checklist

- Code follows project style guidelines
- Commit message follows conventional commits format
- Changes are minimal and focused
- No breaking changes introduced
- Addresses the acceptance criteria from issue #161
- Accessibility improved with better aria-label

closes #161