### PR TITLE
test: add routing integration tests and fix jsdom SVG getTotalLength mock

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { AppContent } from './App'
+import type { PriceContextValue } from './context/PriceContext'
+
+// Routing is orthogonal to the accessibility side-effects, and useAccessibility pulls in
+// PreferencesProvider (IndexedDB + useLocation). Stub it so the route tests stay focused
+// on navigation rather than the preferences/IndexedDB wiring.
+vi.mock('./hooks/useAccessibility', () => ({ useAccessibility: () => {} }))
+
+vi.mock('./context/PriceContext', () => ({
+  usePriceContext: vi.fn(),
+}))
+
+// Keep the real data hooks (useSwr, usePriceHistory) but stub the network so the
+// PriceDetail route renders with well-formed data instead of the malformed global
+// fetch fallback from setup.ts.
+vi.mock('./api/rest', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./api/rest')>()
+  return {
+    ...actual,
+    fetchPrice: vi.fn().mockResolvedValue({
+      assetPair: 'BTC/USD',
+      price: 50000,
+      timestamp: 1700040000000,
+      confidence: 0.99,
+      sources: ['chainlink'],
+    }),
+    fetchPriceHistory: vi.fn().mockResolvedValue({ history: [] }),
+  }
+})
+
+const mockPrices = [
+  { assetPair: 'BTC/USD', price: 50000, timestamp: 1700040000000, confidence: 0.99, sources: ['chainlink'] },
+  { assetPair: 'ETH/USD', price: 3000, timestamp: 1700039000000, confidence: 0.95, sources: ['redstone'] },
+]
+
+const priceContextValue = {
+  prices: mockPrices,
+  pricesLoading: false,
+  pricesError: null,
+  pricesValidating: false,
+  livePrices: new Map(),
+  wsStatus: 'connected',
+  rateLimitStatus: 'ok',
+  rateLimitRetryAfterMs: 0,
+  refetchPrices: vi.fn(),
+  subscribe: vi.fn(),
+  unsubscribe: vi.fn(),
+} as unknown as PriceContextValue
+
+// Routes are lazy-loaded behind RouteSuspense, which enforces a minimum skeleton time,
+// so findBy* assertions need a slightly generous timeout.
+const FIND = { timeout: 5000 }
+
+function renderRoute(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppContent />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(async () => {
+  localStorage.clear()
+  const { usePriceContext } = await import('./context/PriceContext')
+  vi.mocked(usePriceContext).mockReturnValue(priceContextValue)
+})
+
+afterEach(cleanup)
+
+describe('App routing', () => {
+  it('renders the Dashboard at the index route', async () => {
+    renderRoute('/')
+    expect(await screen.findByRole('heading', { name: 'Price Oracle Dashboard' }, FIND)).toBeInTheDocument()
+  })
+
+  it('renders the API Docs page at /api-docs', async () => {
+    renderRoute('/api-docs')
+    expect(await screen.findByRole('heading', { name: 'API Documentation' }, FIND)).toBeInTheDocument()
+  })
+
+  it('renders the Price Detail page at /prices/:pair', async () => {
+    renderRoute('/prices/BTC%2FUSD')
+    // The "Go back" control is unique to the Price Detail page and always rendered.
+    expect(await screen.findByRole('button', { name: 'Go back' }, FIND)).toBeInTheDocument()
+  })
+
+  it('renders the 404 NotFound page for an unknown route', async () => {
+    renderRoute('/this-route-does-not-exist')
+    expect(await screen.findByText('404', {}, FIND)).toBeInTheDocument()
+    expect(screen.getByText('Page not found')).toBeInTheDocument()
+  })
+
+  it('navigates between routes via the nav bar (route transitions)', async () => {
+    const user = userEvent.setup()
+    renderRoute('/')
+    await screen.findByRole('heading', { name: 'Price Oracle Dashboard' }, FIND)
+
+    await user.click(screen.getByRole('link', { name: 'API Docs' }))
+    expect(await screen.findByRole('heading', { name: 'API Documentation' }, FIND)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('link', { name: 'Dashboard' }))
+    expect(await screen.findByRole('heading', { name: 'Price Oracle Dashboard' }, FIND)).toBeInTheDocument()
+  })
+
+  it('recovers to the Dashboard from the 404 page via its link', async () => {
+    const user = userEvent.setup()
+    renderRoute('/nope')
+    await screen.findByText('404', {}, FIND)
+
+    await user.click(screen.getByRole('link', { name: 'Back to Dashboard' }))
+    expect(await screen.findByRole('heading', { name: 'Price Oracle Dashboard' }, FIND)).toBeInTheDocument()
+  })
+
+  it('navigates to Price Detail when a Dashboard price card is clicked', async () => {
+    const user = userEvent.setup()
+    renderRoute('/')
+    const card = await screen.findByRole('button', { name: 'View details for BTC/USD' }, FIND)
+
+    await user.click(card)
+    expect(await screen.findByRole('button', { name: 'Go back' }, FIND)).toBeInTheDocument()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ const NotFound = lazy(() => import('./pages/NotFound').then((m) => ({ default: m
 
 const BASENAME = import.meta.env.BASE_URL.replace(/\/$/, '')
 
-function AppContent(): ReactElement {
+export function AppContent(): ReactElement {
   const location = useLocation()
   useAccessibility()
   trackPageview(location.pathname)

--- a/src/test/setup.test.ts
+++ b/src/test/setup.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Guards the jsdom SVG polyfills installed in setup.ts.
+ *
+ * jsdom implements neither SVGPathElement nor getTotalLength — a freshly created
+ * <path> is a plain SVGElement whose getTotalLength is undefined. Recharts calls
+ * getTotalLength while animating its line/area paths, so the missing method would
+ * throw "getTotalLength is not a function" in any test that renders an animated chart.
+ */
+describe('jsdom SVG setup', () => {
+  it('exposes a getTotalLength stub on SVG path elements', () => {
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path') as SVGElement & {
+      getTotalLength: () => number
+    }
+
+    expect(typeof path.getTotalLength).toBe('function')
+    expect(path.getTotalLength()).toBe(0)
+  })
+
+  it('exposes a getTotalLength stub on SVG line elements', () => {
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line') as SVGElement & {
+      getTotalLength: () => number
+    }
+
+    expect(typeof line.getTotalLength).toBe('function')
+    expect(line.getTotalLength()).toBe(0)
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -27,10 +27,24 @@ Object.defineProperty(window, 'matchMedia', {
   }),
 })
 
-// SVGPathElement.getTotalLength is not implemented in jsdom (used by Recharts)
-if (typeof SVGPathElement !== 'undefined' && !SVGPathElement.prototype.getTotalLength) {
-  SVGPathElement.prototype.getTotalLength = () => 0
+// jsdom implements neither SVGPathElement nor getTotalLength, which Recharts calls on
+// its <path> nodes while animating lines and areas. Depending on the jsdom version a
+// <path> is an instance of SVGPathElement, SVGGeometryElement, or just the base
+// SVGElement (the current case — the more specific classes are `undefined`), so install
+// the stub on whichever prototypes exist. The previous guard keyed off SVGPathElement,
+// which is undefined here, so the mock never applied. (SVGElement's type does not declare
+// getTotalLength, hence the cast.)
+function mockGetTotalLength(ctor: { prototype: object } | undefined): void {
+  if (!ctor) return
+  const proto = ctor.prototype as { getTotalLength?: () => number }
+  if (typeof proto.getTotalLength !== 'function') {
+    proto.getTotalLength = () => 0
+  }
 }
+
+mockGetTotalLength(typeof SVGElement !== 'undefined' ? SVGElement : undefined)
+mockGetTotalLength(typeof SVGGeometryElement !== 'undefined' ? SVGGeometryElement : undefined)
+mockGetTotalLength(typeof SVGPathElement !== 'undefined' ? SVGPathElement : undefined)
 
 // Mock fetch globally so components that call the REST API in unit tests
 // don't fail with "fetch is not defined".
@@ -40,4 +54,3 @@ global.fetch = vi.fn().mockResolvedValue({
   json: async () => ({ pair: '', history: [] }),
   text: async () => '',
 } as unknown as Response)
-


### PR DESCRIPTION
## Summary

Resolves two test-infrastructure issues.

### #172 — Routing integration tests
Adds `src/App.test.tsx`, which drives the **real** route table via `MemoryRouter` over the now-exported `AppContent`:
- All main routes render without error: `/` (Dashboard), `/api-docs`, `/prices/:pair` (Price Detail), and unknown paths → 404
- Route transitions through the nav bar (Dashboard ↔ API Docs)
- 404 page and recovery via its "Back to Dashboard" link
- Navigation from a Dashboard price card → Price Detail

The only production change is exporting `AppContent` from `App.tsx` so the route table can be mounted under a test router.

### #173 — SVG `getTotalLength` mock
The previous `setup.ts` stub was **dead code**: it guarded on `typeof SVGPathElement !== 'undefined'`, but jsdom leaves `SVGPathElement` undefined and renders `<path>` as a base `SVGElement`, so the mock never installed. It now installs the stub on whichever SVG prototypes exist (`SVGElement` / `SVGGeometryElement` / `SVGPathElement`), and `src/test/setup.test.ts` guards the behaviour.

## Testing
- All 9 new tests pass; ESLint and `tsc` are clean for the changed files.
- No regressions: the full suite went from 390 → 399 passing (+9); pre-existing failures are unchanged.

> Note: `main` already has unrelated `build`/`test` failures left untouched here — `rateLimitStatus`/`rateLimitRetryAfterMs` are missing from the `PriceContextValue` interface, and `rest.test.ts`/`ConnectionBadge` have failing tests/snapshots.

Closes #172
Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
