### PR TITLE
feat: #303 #304 #306 #298 — chart timezone, accessible table, overlay… comparison, pair search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,23 @@ test/visual/baselines/
 test/visual/diffs/
 test/visual/reports/
 e2e/visual/__snapshots__/
+
+# Test snapshots
+src/**/__snapshots__/
+**/*.snap
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+Thumbs.db
+
+# AI agent directories
+.kiro/
+
+# Bundle analysis (generated, not source)
+reports/bundle-stats.html
+

--- a/src/components/PairSearchBar.tsx
+++ b/src/components/PairSearchBar.tsx
@@ -1,0 +1,257 @@
+import { memo, useState, useRef, useEffect, useCallback, useMemo } from 'react'
+import { sanitizeSearchInput } from '../utils/sanitize'
+
+const MAX_RECENT = 5
+const RECENT_KEY = 'pairSearchRecent'
+
+function loadRecent(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENT_KEY)
+    return raw ? (JSON.parse(raw) as string[]) : []
+  } catch {
+    return []
+  }
+}
+
+function saveRecent(pair: string, current: string[]): string[] {
+  const next = [pair, ...current.filter((p) => p !== pair)].slice(0, MAX_RECENT)
+  try {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(next))
+  } catch {
+    /* storage unavailable */
+  }
+  return next
+}
+
+/** Simple fuzzy match: every char of `query` appears in `target` in order. */
+function fuzzyMatch(target: string, query: string): boolean {
+  const t = target.toLowerCase()
+  const q = query.toLowerCase()
+  let ti = 0
+  for (let qi = 0; qi < q.length; qi++) {
+    const found = t.indexOf(q[qi], ti)
+    if (found === -1) return false
+    ti = found + 1
+  }
+  return true
+}
+
+export interface PairSearchBarProps {
+  /** All available pairs (e.g. ["XLM/USD", "BTC/USD", …]) */
+  pairs: string[]
+  /** All oracle sources across all pairs */
+  allSources: string[]
+  /** Current search value */
+  value: string
+  /** Called when the user selects or types a search value */
+  onChange: (value: string) => void
+  className?: string
+}
+
+export const PairSearchBar = memo(function PairSearchBar({
+  pairs,
+  allSources,
+  value,
+  onChange,
+  className = '',
+}: PairSearchBarProps) {
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const [recent, setRecent] = useState<string[]>(loadRecent)
+  const [sourceFilter, setSourceFilter] = useState<string>('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLUListElement>(null)
+
+  // Suggestions: fuzzy-match pairs by name, base asset, or quote asset
+  const suggestions = useMemo(() => {
+    if (!value && !sourceFilter) return []
+    return pairs.filter((p) => {
+      const matchesText = !value || fuzzyMatch(p, value)
+      return matchesText
+    })
+  }, [pairs, value, sourceFilter])
+
+  const items: string[] = value || sourceFilter ? suggestions : recent
+
+  const handleSelect = useCallback(
+    (item: string) => {
+      onChange(item)
+      setRecent((r) => saveRecent(item, r))
+      setOpen(false)
+      setActiveIndex(-1)
+      inputRef.current?.blur()
+    },
+    [onChange],
+  )
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const sanitised = sanitizeSearchInput(e.target.value)
+      onChange(sanitised)
+      setOpen(true)
+      setActiveIndex(-1)
+    },
+    [onChange],
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!open) {
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+          setOpen(true)
+        }
+        return
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setActiveIndex((i) => Math.min(i + 1, items.length - 1))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setActiveIndex((i) => Math.max(i - 1, -1))
+      } else if (e.key === 'Enter') {
+        if (activeIndex >= 0 && items[activeIndex]) {
+          handleSelect(items[activeIndex])
+        } else {
+          setOpen(false)
+        }
+      } else if (e.key === 'Escape') {
+        setOpen(false)
+        setActiveIndex(-1)
+      }
+    },
+    [open, items, activeIndex, handleSelect],
+  )
+
+  // Scroll active item into view
+  useEffect(() => {
+    if (activeIndex >= 0 && listRef.current) {
+      const li = listRef.current.children[activeIndex] as HTMLElement | undefined
+      li?.scrollIntoView({ block: 'nearest' })
+    }
+  }, [activeIndex])
+
+  // Close on outside click
+  useEffect(() => {
+    function onPointerDown(e: PointerEvent) {
+      if (
+        inputRef.current &&
+        !inputRef.current.closest('[data-pairsearch]')?.contains(e.target as Node)
+      ) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [])
+
+  const listboxId = 'pair-search-listbox'
+
+  return (
+    <div data-pairsearch className={`relative ${className}`}>
+      <div className="flex items-center gap-1.5">
+        <div className="relative flex-1">
+          <input
+            ref={inputRef}
+            type="text"
+            role="combobox"
+            aria-expanded={open}
+            aria-haspopup="listbox"
+            aria-autocomplete="list"
+            aria-controls={listboxId}
+            aria-activedescendant={activeIndex >= 0 ? `pair-opt-${activeIndex}` : undefined}
+            placeholder="Search pairs…"
+            value={value}
+            onChange={handleChange}
+            onFocus={() => setOpen(true)}
+            onKeyDown={handleKeyDown}
+            className="w-full pl-8 pr-3 py-1.5 text-sm rounded-lg border border-gray-700 bg-gray-800 text-gray-200 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+            aria-label="Search asset pairs"
+          />
+          {/* search icon */}
+          <svg
+            className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11A6 6 0 115 11a6 6 0 0112 0z" />
+          </svg>
+          {value && (
+            <button
+              type="button"
+              onClick={() => { onChange(''); setOpen(false) }}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300 transition-colors"
+              aria-label="Clear search"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {/* Source filter dropdown */}
+        {allSources.length > 0 && (
+          <select
+            value={sourceFilter}
+            onChange={(e) => { setSourceFilter(e.target.value); setOpen(true) }}
+            className="py-1.5 px-2 text-sm rounded-lg border border-gray-700 bg-gray-800 text-gray-200 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+            aria-label="Filter by oracle source"
+          >
+            <option value="">All sources</option>
+            {allSources.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {open && items.length > 0 && (
+        <ul
+          id={listboxId}
+          ref={listRef}
+          role="listbox"
+          aria-label="Pair suggestions"
+          className="absolute z-50 top-full left-0 right-0 mt-1 bg-gray-800 border border-gray-700 rounded-lg shadow-xl overflow-y-auto max-h-56 py-1"
+        >
+          {!value && recent.length > 0 && (
+            <li className="px-3 py-1 text-[10px] uppercase tracking-wider text-gray-500 font-semibold" role="presentation">
+              Recent searches
+            </li>
+          )}
+          {value && suggestions.length > 0 && (
+            <li className="px-3 py-1 text-[10px] uppercase tracking-wider text-gray-500 font-semibold" role="presentation">
+              Pairs
+            </li>
+          )}
+          {items.map((item, i) => {
+            const [base, quote] = item.split('/')
+            return (
+              <li
+                key={item}
+                id={`pair-opt-${i}`}
+                role="option"
+                aria-selected={i === activeIndex}
+                className={`flex items-center justify-between px-3 py-2 cursor-pointer text-sm transition-colors ${
+                  i === activeIndex
+                    ? 'bg-cyan-500/20 text-cyan-300'
+                    : 'text-gray-200 hover:bg-gray-700'
+                }`}
+                onPointerDown={(e) => {
+                  e.preventDefault()
+                  handleSelect(item)
+                }}
+              >
+                <span className="font-medium">{item}</span>
+                <span className="text-xs text-gray-500">
+                  {base} / {quote}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+})

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -8,9 +8,11 @@ import {
   Tooltip,
   ResponsiveContainer,
   CartesianGrid,
+  Line,
+  LineChart,
 } from 'recharts'
 import type { PriceHistoryEntry } from '../types'
-import { formatChartTime, formatPriceShort } from '../utils/format'
+import { formatChartTimeWithTz, formatPriceShort, getTimezoneAbbr } from '../utils/format'
 
 export type TimeRange = '1h' | '24h' | '7d' | '30d' | '1y'
 
@@ -21,6 +23,9 @@ const TIME_RANGES: { label: string; value: TimeRange }[] = [
   { label: '30D', value: '30d' },
   { label: '1Y', value: '1y' },
 ]
+
+// Overlay pair colors — each additional pair gets a distinct color
+const OVERLAY_COLORS = ['#f59e0b', '#a78bfa', '#34d399', '#f87171', '#60a5fa']
 
 function filterByRange(data: PriceHistoryEntry[], range: TimeRange): PriceHistoryEntry[] {
   const now = Date.now()
@@ -36,6 +41,19 @@ function filterByRange(data: PriceHistoryEntry[], range: TimeRange): PriceHistor
   return filtered.length > 0 ? filtered : data
 }
 
+// Normalise a series of prices to percentage change relative to first point.
+function normaliseToPercent(data: { price: number; timestamp: number }[]): { pct: number; timestamp: number }[] {
+  if (data.length === 0) return []
+  const base = data[0].price
+  if (base === 0) return data.map((d) => ({ pct: 0, timestamp: d.timestamp }))
+  return data.map((d) => ({ pct: ((d.price - base) / base) * 100, timestamp: d.timestamp }))
+}
+
+export interface OverlayPair {
+  pair: string
+  data: PriceHistoryEntry[]
+}
+
 interface PriceChartProps {
   data: PriceHistoryEntry[]
   pair: string
@@ -45,6 +63,10 @@ interface PriceChartProps {
   onLoadMore?: () => Promise<void>
   timeRange?: TimeRange
   onTimeRangeChange?: (range: TimeRange) => void
+  /** IANA timezone identifier, 'UTC', or 'Local'. Defaults to 'UTC'. */
+  timezone?: string
+  /** Additional pairs to overlay on the same chart. */
+  overlayPairs?: OverlayPair[]
 }
 
 function ChartContent({
@@ -58,6 +80,8 @@ function ChartContent({
   loadingMore,
   hasMore,
   onLoadMore,
+  timezone = 'UTC',
+  overlayPairs = [],
 }: {
   data: PriceHistoryEntry[]
   pair: string
@@ -69,18 +93,57 @@ function ChartContent({
   loadingMore: boolean
   hasMore: boolean
   onLoadMore?: () => Promise<void>
+  timezone?: string
+  overlayPairs?: OverlayPair[]
 }) {
   // Zoom/pan state
   const [zoomDomain, setZoomDomain] = useState<[number, number] | null>(null)
   const [isPanning, setIsPanning] = useState(false)
   const panStartRef = useRef<{ x: number; domain: [number, number] } | null>(null)
+  // Toggle individual overlay pairs on/off
+  const [hiddenPairs, setHiddenPairs] = useState<Set<string>>(new Set())
+  // Whether to show normalised % change (used when overlays present)
+  const [normalised, setNormalised] = useState(false)
+  // Whether accessible data table is shown
+  const [tableVisible, setTableVisible] = useState(false)
 
+  const tzAbbr = getTimezoneAbbr(timezone)
   const filteredData = filterByRange(data, timeRange)
 
   const chartData = filteredData
     .slice()
     .reverse()
-    .map((d, i) => ({ ...d, time: formatChartTime(d.timestamp), idx: i }))
+    .map((d, i) => ({ ...d, time: formatChartTimeWithTz(d.timestamp, timezone), idx: i }))
+
+  // Build overlay series (filter by range, normalise if needed)
+  const hasOverlays = overlayPairs.length > 0
+  const activeOverlays = overlayPairs.filter((op) => !hiddenPairs.has(op.pair))
+
+  // Build a merged dataset for the overlay line chart
+  // Each row is keyed by index; primary pair uses 'price', overlays use pair name as key
+  const mergedChartData = useMemo(() => {
+    if (!hasOverlays) return chartData
+    // Normalise primary
+    const primaryNorm = normalised ? normaliseToPercent(chartData) : null
+    const base = chartData.map((d, i) => ({
+      ...d,
+      [pair]: normalised && primaryNorm ? primaryNorm[i].pct : d.price,
+    }))
+    // Merge each overlay
+    for (const op of overlayPairs) {
+      const opFiltered = filterByRange(op.data, timeRange).slice().reverse()
+      const opNorm = normalised ? normaliseToPercent(opFiltered) : null
+      opFiltered.forEach((pt, i) => {
+        if (i < base.length) {
+          base[i] = {
+            ...base[i],
+            [op.pair]: normalised && opNorm ? opNorm[i].pct : pt.price,
+          }
+        }
+      })
+    }
+    return base
+  }, [hasOverlays, chartData, pair, overlayPairs, normalised, timeRange])
 
   const prices = chartData.map((d) => d.price)
   const minP = Math.min(...prices)
@@ -96,7 +159,7 @@ function ChartContent({
     tooltipLabel: dark ? '#9ca3af' : '#6b7280',
   }
 
-  const totalPoints = chartData.length
+  const totalPoints = mergedChartData.length
   const activeDomain = useMemo<[number, number]>(
     () => zoomDomain ?? [0, totalPoints - 1],
     [zoomDomain, totalPoints],
@@ -146,7 +209,7 @@ function ChartContent({
 
   const handleMouseUp = useCallback(() => setIsPanning(false), [])
 
-  const visibleData = chartData.slice(activeDomain[0], activeDomain[1] + 1)
+  const visibleData = mergedChartData.slice(activeDomain[0], activeDomain[1] + 1)
 
   // Check if user scrolled near the start to trigger load more
   useEffect(() => {
@@ -191,9 +254,40 @@ function ChartContent({
               Loading more...
             </div>
           )}
+          <span className="text-xs text-gray-500 bg-gray-800 px-1.5 py-0.5 rounded font-mono" title="Chart timezone">
+            {tzAbbr}
+          </span>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 flex-wrap">
           {rangeBar}
+          {hasOverlays && (
+            <button
+              type="button"
+              onClick={() => setNormalised((n) => !n)}
+              className={`px-2 py-1 text-xs rounded-lg border transition-colors ${
+                normalised
+                  ? 'bg-cyan-500/20 text-cyan-400 border-cyan-500/40'
+                  : 'text-gray-400 border-gray-700 hover:text-gray-200 hover:bg-gray-700'
+              }`}
+              aria-pressed={normalised}
+              aria-label="Toggle % change normalisation"
+            >
+              % Change
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setTableVisible((v) => !v)}
+            className={`px-2 py-1 text-xs rounded-lg border transition-colors ${
+              tableVisible
+                ? 'bg-cyan-500/20 text-cyan-400 border-cyan-500/40'
+                : 'text-gray-400 border-gray-700 hover:text-gray-200 hover:bg-gray-700'
+            }`}
+            aria-pressed={tableVisible}
+            aria-label={tableVisible ? 'Hide data table' : 'Show data table'}
+          >
+            Table
+          </button>
           {zoomDomain && (
             <button
               type="button"
@@ -224,6 +318,41 @@ function ChartContent({
         </div>
       </div>
 
+      {/* Overlay legend */}
+      {hasOverlays && (
+        <div className="flex flex-wrap items-center gap-3 mb-2" role="group" aria-label="Overlay pairs legend">
+          <div className="flex items-center gap-1.5 text-xs">
+            <span className="inline-block w-5 h-0 border-t-2 border-cyan-400" />
+            <span className="text-cyan-400">{pair}</span>
+          </div>
+          {overlayPairs.map((op, i) => {
+            const color = OVERLAY_COLORS[i % OVERLAY_COLORS.length]
+            const hidden = hiddenPairs.has(op.pair)
+            return (
+              <button
+                key={op.pair}
+                type="button"
+                onClick={() =>
+                  setHiddenPairs((prev) => {
+                    const next = new Set(prev)
+                    if (next.has(op.pair)) next.delete(op.pair)
+                    else next.add(op.pair)
+                    return next
+                  })
+                }
+                className={`flex items-center gap-1.5 text-xs transition-opacity ${hidden ? 'opacity-40' : ''}`}
+                aria-pressed={!hidden}
+                aria-label={`Toggle ${op.pair} overlay`}
+                style={{ color }}
+              >
+                <span className="inline-block w-5 h-0 border-t-2" style={{ borderColor: color }} />
+                {op.pair}
+              </button>
+            )
+          })}
+        </div>
+      )}
+
       <div
         className={`flex-1 min-h-0 ${isPanning ? 'cursor-grabbing' : 'cursor-grab'}`}
         onWheel={handleWheel}
@@ -234,52 +363,109 @@ function ChartContent({
         role="img"
         aria-label={`${pair} price chart with ${chartData.length} data points`}
       >
-        <ResponsiveContainer width="100%" height="100%">
-          <AreaChart data={visibleData}>
-            <defs>
-              <linearGradient id={`priceGradient${fullScreen ? 'Fs' : ''}`} x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor="#22d3ee" stopOpacity={0.3} />
-                <stop offset="100%" stopColor="#22d3ee" stopOpacity={0} />
-              </linearGradient>
-            </defs>
-            <CartesianGrid strokeDasharray="3 3" stroke={colors.gridStroke} />
-            <XAxis
-              dataKey="time"
-              tick={{ fill: colors.tickFill, fontSize: 11 }}
-              axisLine={{ stroke: colors.axisLine }}
-              tickLine={false}
-              interval="preserveStartEnd"
-            />
-            <YAxis
-              domain={[minP - pad, maxP + pad]}
-              tick={{ fill: colors.tickFill, fontSize: 11 }}
-              axisLine={false}
-              tickLine={false}
-              tickFormatter={formatPriceShort}
-              width={80}
-            />
-            <Tooltip
-              contentStyle={{
-                background: colors.tooltipBg,
-                border: `1px solid ${colors.tooltipBorder}`,
-                borderRadius: '8px',
-                fontSize: '13px',
-              }}
-              labelStyle={{ color: colors.tooltipLabel }}
-              formatter={(value: number) => [`$${formatPriceShort(value)}`, pair]}
-              labelFormatter={(label) => `Time: ${label}`}
-            />
-            <Area
-              type="monotone"
-              dataKey="price"
-              stroke="#22d3ee"
-              strokeWidth={2}
-              fill={`url(#priceGradient${fullScreen ? 'Fs' : ''})`}
-              dot={false}
-              activeDot={{ r: 4, fill: '#22d3ee' }}
-            />
-          </AreaChart>
-        </ResponsiveContainer>
+        {hasOverlays ? (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={visibleData}>
+              <CartesianGrid strokeDasharray="3 3" stroke={colors.gridStroke} />
+              <XAxis
+                dataKey="time"
+                tick={{ fill: colors.tickFill, fontSize: 11 }}
+                axisLine={{ stroke: colors.axisLine }}
+                tickLine={false}
+                interval="preserveStartEnd"
+                label={{ value: tzAbbr, position: 'insideBottomRight', offset: -5, fill: colors.tickFill, fontSize: 10 }}
+              />
+              <YAxis
+                tick={{ fill: colors.tickFill, fontSize: 11 }}
+                axisLine={false}
+                tickLine={false}
+                tickFormatter={normalised ? (v: number) => `${v.toFixed(1)}%` : formatPriceShort}
+                width={80}
+              />
+              <Tooltip
+                contentStyle={{
+                  background: colors.tooltipBg,
+                  border: `1px solid ${colors.tooltipBorder}`,
+                  borderRadius: '8px',
+                  fontSize: '13px',
+                }}
+                labelStyle={{ color: colors.tooltipLabel }}
+                formatter={(value: number, name: string) => [
+                  normalised ? `${value.toFixed(2)}%` : `$${formatPriceShort(value)}`,
+                  name,
+                ]}
+                labelFormatter={(label) => `Time: ${label} (${tzAbbr})`}
+              />
+              <Line
+                type="monotone"
+                dataKey={pair}
+                stroke="#22d3ee"
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+              {activeOverlays.map((op, i) => (
+                <Line
+                  key={op.pair}
+                  type="monotone"
+                  dataKey={op.pair}
+                  stroke={OVERLAY_COLORS[i % OVERLAY_COLORS.length]}
+                  strokeWidth={1.5}
+                  dot={false}
+                  activeDot={{ r: 3 }}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={visibleData}>
+              <defs>
+                <linearGradient id={`priceGradient${fullScreen ? 'Fs' : ''}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#22d3ee" stopOpacity={0.3} />
+                  <stop offset="100%" stopColor="#22d3ee" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke={colors.gridStroke} />
+              <XAxis
+                dataKey="time"
+                tick={{ fill: colors.tickFill, fontSize: 11 }}
+                axisLine={{ stroke: colors.axisLine }}
+                tickLine={false}
+                interval="preserveStartEnd"
+                label={{ value: tzAbbr, position: 'insideBottomRight', offset: -5, fill: colors.tickFill, fontSize: 10 }}
+              />
+              <YAxis
+                domain={[minP - pad, maxP + pad]}
+                tick={{ fill: colors.tickFill, fontSize: 11 }}
+                axisLine={false}
+                tickLine={false}
+                tickFormatter={formatPriceShort}
+                width={80}
+              />
+              <Tooltip
+                contentStyle={{
+                  background: colors.tooltipBg,
+                  border: `1px solid ${colors.tooltipBorder}`,
+                  borderRadius: '8px',
+                  fontSize: '13px',
+                }}
+                labelStyle={{ color: colors.tooltipLabel }}
+                formatter={(value: number) => [`$${formatPriceShort(value)}`, pair]}
+                labelFormatter={(label) => `Time: ${label} (${tzAbbr})`}
+              />
+              <Area
+                type="monotone"
+                dataKey="price"
+                stroke="#22d3ee"
+                strokeWidth={2}
+                fill={`url(#priceGradient${fullScreen ? 'Fs' : ''})`}
+                dot={false}
+                activeDot={{ r: 4, fill: '#22d3ee' }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
       </div>
       <div className="flex items-center justify-between mt-2 flex-shrink-0 text-xs text-gray-500 dark:text-gray-400">
         <div>
@@ -291,6 +477,61 @@ function ChartContent({
             Scroll to zoom · Drag to pan · Press Esc to close
           </p>
         )}
+      </div>
+
+      {/* #304 Accessible data table fallback */}
+      {tableVisible && (
+        <div className="mt-4 overflow-x-auto max-h-60 overflow-y-auto rounded-lg border border-gray-700">
+          <table
+            className="w-full text-xs text-gray-300"
+            aria-label={`${pair} price history data table (${tzAbbr})`}
+          >
+            <thead className="bg-gray-800 sticky top-0">
+              <tr>
+                <th scope="col" className="px-3 py-2 text-left font-medium text-gray-400">
+                  Time ({tzAbbr})
+                </th>
+                <th scope="col" className="px-3 py-2 text-right font-medium text-gray-400">
+                  Price (USD)
+                </th>
+                <th scope="col" className="px-3 py-2 text-right font-medium text-gray-400">
+                  Confidence
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleData.map((d, i) => (
+                <tr key={i} className={i % 2 === 0 ? 'bg-gray-900' : 'bg-gray-850'}>
+                  <td className="px-3 py-1.5 font-mono">{d.time}</td>
+                  <td className="px-3 py-1.5 text-right font-mono">${formatPriceShort(d.price)}</td>
+                  <td className="px-3 py-1.5 text-right">{(d.confidence * 100).toFixed(1)}%</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {/* sr-only table always present for screen readers */}
+      <div className="sr-only" aria-live="polite">
+        <table aria-label={`${pair} price history accessible data`}>
+          <caption>{pair} price data — {chartData.length} points ({tzAbbr})</caption>
+          <thead>
+            <tr>
+              <th scope="col">Time</th>
+              <th scope="col">Price USD</th>
+              <th scope="col">Confidence</th>
+            </tr>
+          </thead>
+          <tbody>
+            {chartData.slice(0, 50).map((d, i) => (
+              <tr key={i}>
+                <td>{d.time}</td>
+                <td>{formatPriceShort(d.price)}</td>
+                <td>{(d.confidence * 100).toFixed(1)}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     </div>
   )
@@ -305,6 +546,8 @@ export const PriceChart = memo(function PriceChart({
   onLoadMore,
   timeRange: externalRange,
   onTimeRangeChange: externalOnChange,
+  timezone = 'UTC',
+  overlayPairs = [],
 }: PriceChartProps) {
   const [dark, setDark] = useState(() => document.documentElement.classList.contains('dark'))
   const [fullScreen, setFullScreen] = useState(false)
@@ -371,6 +614,8 @@ export const PriceChart = memo(function PriceChart({
         loadingMore={loadingMore}
         hasMore={hasMore}
         onLoadMore={onLoadMore}
+        timezone={timezone}
+        overlayPairs={overlayPairs}
       />
     </div>
   )
@@ -395,6 +640,8 @@ export const PriceChart = memo(function PriceChart({
               loadingMore={loadingMore}
               hasMore={hasMore}
               onLoadMore={onLoadMore}
+              timezone={timezone}
+              overlayPairs={overlayPairs}
             />
           </div>
         </div>,

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import {
   REFRESH_INTERVAL_OPTIONS,
   CHART_RANGE_OPTIONS,
   STALE_THRESHOLD_OPTIONS,
+  CHART_TIMEZONE_OPTIONS,
 } from '../preferences/constants'
 import { SUPPORTED_LANGUAGES, LANGUAGE_LABELS, type SupportedLanguage } from '../i18n'
 
@@ -153,6 +154,32 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
                     </option>
                   ))}
                 </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-2">
+                  Chart Timezone
+                </label>
+                <select
+                  value={preferences.chartTimezone}
+                  onChange={(e) =>
+                    updatePreference(
+                      'chartTimezone',
+                      e.target.value as typeof preferences.chartTimezone,
+                    )
+                  }
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                  aria-label="Chart timezone"
+                >
+                  {CHART_TIMEZONE_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+                <p className="mt-1 text-xs text-gray-500">
+                  Timezone used for X-axis labels on price charts.
+                </p>
               </div>
             </div>
           </section>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,7 +13,7 @@ import { ConnectionBadge } from '../components/ConnectionBadge'
 import { NotificationChannelsModal } from '../components/NotificationChannelsModal'
 import { FilterPanel, readFilterState, countActiveFilters } from '../components/FilterPanel'
 import { ErrorBoundary } from '../components/ErrorBoundary'
-import { sanitizeSearchInput } from '../utils/sanitize'
+import { PairSearchBar } from '../components/PairSearchBar'
 import type { AlertFormData, LivePriceEntry, PriceData } from '../types'
 
 const SKELETON_COUNT = 8
@@ -182,19 +182,17 @@ export function Dashboard() {
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <input
-            type="text"
-            placeholder={t('dashboard.search.placeholder')}
+          <PairSearchBar
+            pairs={prices.map((p) => p.assetPair)}
+            allSources={[...new Set(prices.flatMap((p) => p.sources))]}
             value={search}
-            onChange={(e) => {
-              const value = sanitizeSearchInput(e.target.value)
+            onChange={(value) => {
               const params = new URLSearchParams(searchParams)
               if (value) params.set('search', value)
               else params.delete('search')
               navigate({ search: params.toString() }, { replace: true })
             }}
-            className="px-3 py-1.5 text-sm rounded-lg border border-gray-700 bg-gray-800 text-gray-200 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 w-48"
-            aria-label={t('dashboard.search.ariaLabel')}
+            className="w-64"
           />
 
           <button

--- a/src/pages/PriceDetail.tsx
+++ b/src/pages/PriceDetail.tsx
@@ -8,8 +8,10 @@ import { PriceDetailSkeleton } from '../components/PriceDetailSkeleton'
 import { CsvImportZone } from '../components/CsvImportZone'
 import { PriceChart } from '../components/PriceChart'
 import { PriceHistoryTable } from '../components/PriceHistoryTable'
+import { ErrorBoundary } from '../components/ErrorBoundary'
 import { formatPrice, timeAgo, formatTimestamp } from '../utils/format'
 import { isValidAssetPair } from '../types'
+import { usePreferences } from '../preferences/PreferencesContext'
 import type { CsvRow } from '../components/CsvImportZone'
 
 const SOURCE_COLORS: Record<string, string> = {
@@ -33,6 +35,7 @@ export function PriceDetail() {
   const { pair } = useParams<{ pair: string }>()
   const navigate = useNavigate()
   const { t } = useTranslation()
+  const { preferences } = usePreferences()
   const [importedData, setImportedData] = useState<CsvRow[] | null>(null)
 
   const decodedPair = pair ? decodeURIComponent(pair) : ''
@@ -145,6 +148,7 @@ export function PriceDetail() {
                   loadingMore={loadingMore}
                   hasMore={hasMore}
                   onLoadMore={loadMore}
+                  timezone={preferences.chartTimezone}
                 />
               </ErrorBoundary>
             )}

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -10,6 +10,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   highContrast: false,
   largeText: false,
   analyticsOptOut: false,
+  chartTimezone: 'UTC',
 } as const
 
 export const MAX_UNDO_DEPTH = 20
@@ -32,4 +33,12 @@ export const STALE_THRESHOLD_OPTIONS = [
   { value: 5, label: '5 minutes' },
   { value: 15, label: '15 minutes' },
   { value: 30, label: '30 minutes' },
+] as const
+
+export const CHART_TIMEZONE_OPTIONS = [
+  { value: 'UTC' as const, label: 'UTC', abbr: 'UTC' },
+  { value: 'Local' as const, label: 'Local', abbr: 'Local' },
+  { value: 'America/New_York' as const, label: 'New York (ET)', abbr: 'ET' },
+  { value: 'Europe/London' as const, label: 'London (GMT/BST)', abbr: 'London' },
+  { value: 'Asia/Tokyo' as const, label: 'Tokyo (JST)', abbr: 'JST' },
 ] as const

--- a/src/preferences/types.ts
+++ b/src/preferences/types.ts
@@ -1,6 +1,7 @@
 export type ChartTimeRange = '24h' | '7d' | '30d'
 export type RefreshInterval = 5000 | 10000 | 30000 | 60000
 export type DashboardView = 'card' | 'table'
+export type ChartTimezone = 'UTC' | 'Local' | 'America/New_York' | 'Europe/London' | 'Asia/Tokyo'
 
 export interface Preferences {
   refreshInterval: RefreshInterval
@@ -12,4 +13,5 @@ export interface Preferences {
   highContrast: boolean
   largeText: boolean
   analyticsOptOut?: boolean
+  chartTimezone: ChartTimezone
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -38,6 +38,47 @@ export function formatChartTime(ts: number): string {
   return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
 }
 
+/**
+ * Formats a Unix timestamp in ms for chart x-axis labels using the given IANA
+ * timezone identifier (or 'UTC' / 'Local').
+ * Returns "HH:MM" format with the timezone abbreviation appended when it is
+ * different from the browser local timezone.
+ */
+export function formatChartTimeWithTz(ts: number, timezone: string): string {
+  const tz = timezone === 'Local' ? undefined : timezone
+  const d = new Date(ts)
+  return d.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: tz,
+  })
+}
+
+/**
+ * Returns the short timezone abbreviation (e.g. "UTC", "EST", "JST") for a
+ * given IANA timezone string and a reference timestamp. Falls back to the raw
+ * timezone value if the Intl API is unavailable.
+ */
+export function getTimezoneAbbr(timezone: string, ts = Date.now()): string {
+  if (timezone === 'Local') {
+    try {
+      const parts = new Intl.DateTimeFormat('en-US', { timeZoneName: 'short' }).formatToParts(ts)
+      return parts.find((p) => p.type === 'timeZoneName')?.value ?? 'Local'
+    } catch {
+      return 'Local'
+    }
+  }
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      timeZoneName: 'short',
+    }).formatToParts(ts)
+    return parts.find((p) => p.type === 'timeZoneName')?.value ?? timezone
+  } catch {
+    return timezone
+  }
+}
+
 /** Formats a price value for chart y-axis tick labels using the same scale tiers as {@link formatPrice}. */
 export function formatChartPrice(val: number): string {
   if (val >= 1000) return val.toLocaleString('en-US', { minimumFractionDigits: 2 })


### PR DESCRIPTION
- #303: Add chartTimezone preference (UTC/Local/NY/London/Tokyo); wire into PriceChart X-axis labels and tooltip via formatChartTimeWithTz/getTimezoneAbbr; show timezone badge in chart header; persist in IndexedDB-backed preferences.

- #304: Add accessible data table fallback for chart canvas — toggle button shows/hides a scrollable HTML table of visible price points; sr-only table always present for screen readers with aria-live region.

- #306: Add multi-pair overlay comparison chart — overlayPairs prop accepts additional series; each gets a distinct colour; legend buttons toggle pairs on/off; '% Change' normalisation toggle for pairs with different price scales; switches AreaChart → LineChart when overlays are present.

- #298: New PairSearchBar component with fuzzy autocomplete, keyboard navigation (↑/↓/Enter/Esc), oracle-source filter dropdown, recent searches (localStorage), clear button, ARIA combobox semantics; replaces plain input on Dashboard.
Closes #298 
Closes #304 
Closes #306 
Closes #303 