### PR TITLE
fix: add chart error boundary, memo components, defer fetching, add return types

### DIFF
--- a/src/components/CsvImportZone.tsx
+++ b/src/components/CsvImportZone.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useRef, useState, type ReactElement } from 'react'
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024
 
@@ -37,7 +37,7 @@ function parseCsv(text: string): { rows: CsvRow[]; error: string | null } {
   return { rows: rows.sort((a, b) => a.timestamp - b.timestamp), error: null }
 }
 
-export function CsvImportZone({ onImport, onClear, hasImport }: Props) {
+export function CsvImportZone({ onImport, onClear, hasImport }: Props): ReactElement {
   const [isDragging, setIsDragging] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)

--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useId } from 'react'
+import { memo, useCallback, useState, useId, type ReactElement } from 'react'
 
 export type PresetRange = '1h' | '24h' | '7d' | '30d' | '1y' | 'all'
 
@@ -23,7 +23,7 @@ interface DateRangePickerProps {
   maxRangeDays?: number
 }
 
-export function DateRangePicker({ value, onChange, maxRangeDays = 365 }: DateRangePickerProps) {
+export const DateRangePicker = memo(function DateRangePicker({ value, onChange, maxRangeDays = 365 }: DateRangePickerProps): ReactElement {
   const startId = useId()
   const endId = useId()
   const [customError, setCustomError] = useState<string | null>(null)
@@ -132,7 +132,7 @@ export function DateRangePicker({ value, onChange, maxRangeDays = 365 }: DateRan
       )}
     </div>
   )
-}
+})
 
 /** Convert a DateRange to the API `limit` param and optional start/end timestamps */
 export function dateRangeToParams(range: DateRange): { limit: number; startTs?: number; endTs?: number } {

--- a/src/components/ExportButton.tsx
+++ b/src/components/ExportButton.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { memo, useState, useRef, useEffect, type ReactElement } from 'react'
 import type { ExportFormat } from '../hooks/useExport'
 
 interface ExportButtonProps {
@@ -7,7 +7,7 @@ interface ExportButtonProps {
   disabled?: boolean
 }
 
-export function ExportButton({ onExport, exporting, disabled }: ExportButtonProps) {
+export const ExportButton = memo(function ExportButton({ onExport, exporting, disabled }: ExportButtonProps): ReactElement {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
@@ -69,4 +69,4 @@ export function ExportButton({ onExport, exporting, disabled }: ExportButtonProp
       )}
     </div>
   )
-}
+})

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, type ReactElement } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
 export const KNOWN_SOURCES = ['chainlink', 'redstone', 'band', 'reflector'] as const
@@ -57,7 +57,7 @@ interface Props {
   availableSources?: readonly string[]
 }
 
-export function FilterPanel({ availableSources = KNOWN_SOURCES }: Props) {
+export function FilterPanel({ availableSources = KNOWN_SOURCES }: Props): ReactElement {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
   const f = readFilterState(searchParams)

--- a/src/components/NotificationChannelsModal.tsx
+++ b/src/components/NotificationChannelsModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react'
 import { useFocusTrap } from '../hooks/useFocusTrap'
 
 const STORAGE_KEY = 'notification-channels'
@@ -46,7 +46,7 @@ function StatusDot({ active }: { active: boolean }) {
   )
 }
 
-export function NotificationChannelsModal({ isOpen, onClose }: Props) {
+export function NotificationChannelsModal({ isOpen, onClose }: Props): ReactElement | null {
   const [config, setConfig] = useState<NotificationConfig>(loadConfig)
   const [activeTab, setActiveTab] = useState<TabId>('email')
   const [pushPermission, setPushPermission] = useState<NotificationPermission>('default')

--- a/src/components/PriceDetailSkeleton.tsx
+++ b/src/components/PriceDetailSkeleton.tsx
@@ -1,4 +1,6 @@
-export function PriceDetailSkeleton() {
+import { type ReactElement } from 'react'
+
+export function PriceDetailSkeleton(): ReactElement {
   return (
     <div role="status" className="animate-pulse" aria-label="Loading price detail" aria-busy="true">
       {/* Header */}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,3 +1,4 @@
+import { type ReactElement } from 'react'
 import { usePreferences } from '../preferences/PreferencesContext'
 import {
   REFRESH_INTERVAL_OPTIONS,
@@ -49,7 +50,7 @@ function AccessibilityToggle({
   )
 }
 
-export function SettingsPanel({ onClose }: SettingsPanelProps) {
+export function SettingsPanel({ onClose }: SettingsPanelProps): ReactElement {
   const { preferences, updatePreference, undo, redo, canUndo, canRedo, clearHistory } =
     usePreferences()
 

--- a/src/components/SourceHealthBadge.tsx
+++ b/src/components/SourceHealthBadge.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement } from 'react'
+import { memo, type ReactElement } from 'react'
 const SOURCE_INFO: Record<string, { label: string; color: string }> = {
   chainlink: { label: 'Chainlink', color: 'bg-blue-500' },
   redstone: { label: 'Redstone', color: 'bg-red-500' },
@@ -10,7 +10,7 @@ interface SourceHealthProps {
   sources: readonly string[]
 }
 
-export function SourceHealthBadge({ sources }: SourceHealthProps): ReactElement {
+export const SourceHealthBadge = memo(function SourceHealthBadge({ sources }: SourceHealthProps): ReactElement {
   if (!sources.length) {
     return <span className="text-xs text-gray-400 dark:text-gray-500">No sources</span>
   }
@@ -32,4 +32,4 @@ export function SourceHealthBadge({ sources }: SourceHealthProps): ReactElement 
       })}
     </div>
   )
-}
+})

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, type ReactElement } from 'react'
 import { createPortal } from 'react-dom'
 import { useToast, type Toast, type ToastType } from '../context/ToastContext'
 
@@ -96,7 +96,7 @@ function ToastItem({ toast }: { toast: Toast }) {
   )
 }
 
-export function ToastContainer() {
+export function ToastContainer(): ReactElement | null {
   const { toasts } = useToast()
 
   if (toasts.length === 0) return null

--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -5,7 +5,7 @@ import { usePreferences } from '../preferences/PreferencesContext'
  * Applies accessibility class names to the document root based on user preferences.
  * Also respects the system-level prefers-reduced-motion media query.
  */
-export function useAccessibility() {
+export function useAccessibility(): void {
   const { preferences } = usePreferences()
 
   useEffect(() => {

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -3,7 +3,7 @@ type Provider = 'plausible' | 'umami' | undefined
 const provider = (import.meta.env.VITE_ANALYTICS_PROVIDER as Provider) || undefined
 const id = (import.meta.env.VITE_ANALYTICS_ID as string) || undefined
 
-export function shouldCollect() {
+export function shouldCollect(): boolean {
   try {
     if (typeof navigator !== 'undefined' && (navigator as Navigator & { doNotTrack?: string }).doNotTrack === '1') return false
   } catch { /* ignore */ }
@@ -13,7 +13,7 @@ export function shouldCollect() {
   return true
 }
 
-export function initAnalytics() {
+export function initAnalytics(): void {
   if (!shouldCollect()) return
 
   if (provider === 'plausible' && id) {
@@ -38,7 +38,7 @@ type WindowWithAnalytics = Window & {
   umami?: { trackEvent?: (name: string, props?: Record<string, unknown>) => void; trackView?: (path?: string) => void }
 }
 
-export function trackEvent(name: string, props?: Record<string, unknown>) {
+export function trackEvent(name: string, props?: Record<string, unknown>): void {
   if (!shouldCollect()) return
   try {
     const w = window as WindowWithAnalytics
@@ -50,7 +50,7 @@ export function trackEvent(name: string, props?: Record<string, unknown>) {
   } catch { /* swallow */ }
 }
 
-export function trackPageview(path?: string) {
+export function trackPageview(path?: string): void {
   if (!shouldCollect()) return
   try {
     const w = window as WindowWithAnalytics

--- a/src/hooks/useAnnounce.ts
+++ b/src/hooks/useAnnounce.ts
@@ -9,7 +9,7 @@ interface UseAnnounceOptions {
  * Returns a function that announces text to screen readers via an aria-live region.
  * Announcements are throttled to avoid overwhelming the user.
  */
-export function useAnnounce(options: UseAnnounceOptions = {}) {
+export function useAnnounce(options: UseAnnounceOptions = {}): (text: string) => void {
   const { throttleMs = 5000 } = options
   const lastAnnounced = useRef(0)
   const liveRegionRef = useRef<HTMLDivElement | null>(null)

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -4,7 +4,11 @@ import { toCsv, priceDataToCsvRows, downloadFile, exportFilename } from '../util
 
 export type ExportFormat = 'csv' | 'json'
 
-export function useExport() {
+interface UseExportReturn {
+  exportCSV: (items: PriceData[]) => void
+}
+
+export function useExport(): UseExportReturn {
   const exportCSV = useCallback((items: PriceData[]) => {
     const { rows, headers } = priceDataToCsvRows(items)
     const csv = toCsv(rows, headers)

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useCallback, useRef, type RefObject } from 'react'
 
 const FOCUSABLE_SELECTORS =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
@@ -7,7 +7,7 @@ const FOCUSABLE_SELECTORS =
  * Traps keyboard focus within a container element.
  * Returns ref to attach to the container and handleKeyDown for the container.
  */
-export function useFocusTrap() {
+export function useFocusTrap(): { containerRef: RefObject<HTMLDivElement | null>; handleKeyDown: (e: React.KeyboardEvent) => void } {
   const containerRef = useRef<HTMLDivElement>(null)
 
   const handleKeyDown = useCallback(

--- a/src/hooks/useIdbQuery.ts
+++ b/src/hooks/useIdbQuery.ts
@@ -58,10 +58,16 @@ export function useIdbQuery<T>(
   return { data, loading, error }
 }
 
+interface UseIdbMutationReturn {
+  set: <T>(store: StoreName, key: string, value: T) => Promise<void>
+  remove: (store: StoreName, key: string) => Promise<void>
+  clear: (store: StoreName) => Promise<void>
+}
+
 /**
  * Provides a setter that writes to IndexedDB and notifies subscribers.
  */
-export function useIdbMutation() {
+export function useIdbMutation(): UseIdbMutationReturn {
   const set = useCallback(
     async <T>(store: StoreName, key: string, value: T) => {
       await idbCache.set(store, key, value)

--- a/src/hooks/usePriceHistory.ts
+++ b/src/hooks/usePriceHistory.ts
@@ -22,6 +22,7 @@ interface PriceHistoryState {
  * Hook for managing paginated price history with infinite scroll support.
  * Fetches historical price data for a given pair with pagination capabilities.
  * Includes a refresh interval to keep the latest data updated.
+ * Defers fetching until the page is visible using the Page Visibility API.
  */
 export function usePriceHistory(
   pair: string | null,
@@ -40,6 +41,12 @@ export function usePriceHistory(
   const isMountedRef = useRef(true)
   const loadingMoreRef = useRef(false)
   const hasMoreRef = useRef(true)
+  const hasFetchedRef = useRef(false)
+
+  // Track page visibility
+  const isVisibleRef = useRef(
+    typeof document !== 'undefined' ? !document.hidden : true,
+  )
 
   // Fetch initial data
   const refetch = useCallback(async () => {
@@ -59,6 +66,7 @@ export function usePriceHistory(
       setHasMore(hasMore)
       hasMoreRef.current = hasMore
       offsetRef.current = pageSize
+      hasFetchedRef.current = true
     } catch (err) {
       if (!isMountedRef.current) return
       const error = err instanceof Error ? err : new Error(String(err))
@@ -110,17 +118,50 @@ export function usePriceHistory(
     }
   }, [pair, pageSize, onError])
 
-  // Initial fetch and refresh interval
+  // Initial fetch and refresh interval with visibility deferral
   useEffect(() => {
-    refetch()
-    intervalRef.current = setInterval(refetch, refreshInterval)
+    if (!pair) return
+
+    // Defer initial fetch until page is visible
+    if (isVisibleRef.current) {
+      refetch()
+    }
+
+    // Set up refresh interval
+    if (refreshInterval > 0) {
+      intervalRef.current = setInterval(() => {
+        if (isVisibleRef.current) {
+          refetch()
+        }
+      }, refreshInterval)
+    }
 
     return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current)
       }
     }
-  }, [refetch, refreshInterval])
+  }, [pair, refetch, refreshInterval])
+
+  // Page Visibility API: pause/resume fetching
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+
+    const handleVisibilityChange = () => {
+      const visible = !document.hidden
+      isVisibleRef.current = visible
+
+      // When becoming visible and haven't fetched yet, fetch now
+      if (visible && !hasFetchedRef.current && pair) {
+        refetch()
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [pair, refetch])
 
   // Cleanup on unmount
   useEffect(() => {

--- a/src/hooks/useUndoRedo.ts
+++ b/src/hooks/useUndoRedo.ts
@@ -12,7 +12,20 @@ interface UndoRedoState<T> {
   future: Command<T>[]
 }
 
-export function useUndoRedo<T>(initialState: T, maxDepth: number = 20) {
+interface UndoRedoReturn<T> {
+  state: T
+  canUndo: boolean
+  canRedo: boolean
+  undoCount: number
+  redoCount: number
+  execute: (command: Command<T>) => void
+  undo: () => void
+  redo: () => void
+  clear: () => void
+  reset: (newPresent: T) => void
+}
+
+export function useUndoRedo<T>(initialState: T, maxDepth: number = 20): UndoRedoReturn<T> {
   const maxDepthRef = useRef(maxDepth)
   maxDepthRef.current = maxDepth
 

--- a/src/hooks/useWebVitals.ts
+++ b/src/hooks/useWebVitals.ts
@@ -41,7 +41,7 @@ function sendToAnalytics(report: WebVitalReport) {
   }
 }
 
-export function useWebVitals() {
+export function useWebVitals(): void {
   useEffect(() => {
     if (!shouldTrack()) return
 

--- a/src/pages/PriceDetail.test.tsx
+++ b/src/pages/PriceDetail.test.tsx
@@ -15,10 +15,15 @@ const defaultHistory = {
   refetch: vi.fn(),
 }
 
+const chartThrowRef = { current: false }
+
 vi.mock('../hooks/useSwr', () => ({ useSwr: vi.fn() }))
 vi.mock('../hooks/usePriceHistory', () => ({ usePriceHistory: vi.fn() }))
 vi.mock('../components/PriceChart', () => ({
-  PriceChart: () => <div data-testid="price-chart" />,
+  PriceChart: () => {
+    if (chartThrowRef.current) throw new Error('Chart render failed')
+    return <div data-testid="price-chart" />
+  },
 }))
 vi.mock('../components/CsvImportZone', () => ({
   CsvImportZone: () => null,
@@ -84,5 +89,26 @@ describe('PriceDetail', () => {
 
     renderWithPair()
     expect(screen.getByTestId('price-chart')).toBeInTheDocument()
+  })
+
+  it('renders chart error fallback when PriceChart throws', async () => {
+    const { useSwr } = await import('../hooks/useSwr')
+    vi.mocked(useSwr).mockReturnValue({
+      data: { assetPair: 'BTC/USD', price: 50000, timestamp: Date.now(), confidence: 0.99, sources: ['chainlink'] },
+      loading: false,
+      error: null,
+      isValidating: false,
+      refetch: vi.fn(),
+    })
+
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    chartThrowRef.current = true
+
+    renderWithPair()
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Chart failed to render. Please try refreshing the page.')).toBeInTheDocument()
+
+    chartThrowRef.current = false
+    spy.mockRestore()
   })
 })

--- a/src/pages/PriceDetail.tsx
+++ b/src/pages/PriceDetail.tsx
@@ -6,6 +6,7 @@ import { fetchPrice } from '../api/rest'
 import { PriceDetailSkeleton } from '../components/PriceDetailSkeleton'
 import { CsvImportZone } from '../components/CsvImportZone'
 import { PriceChart } from '../components/PriceChart'
+import { ErrorBoundary } from '../components/ErrorBoundary'
 import { formatPrice, timeAgo, formatTimestamp } from '../utils/format'
 import type { CsvRow } from '../components/CsvImportZone'
 
@@ -116,14 +117,22 @@ export function PriceDetail() {
                 Failed to load price history: {historyError.message}
               </div>
             ) : (
-              <PriceChart
-                data={history}
-                pair={decodedPair}
-                loading={historyLoading && history.length === 0}
-                loadingMore={loadingMore}
-                hasMore={hasMore}
-                onLoadMore={loadMore}
-              />
+              <ErrorBoundary
+                fallback={
+                  <div className="p-4 bg-red-900/30 border border-red-800 rounded-lg text-sm text-red-400" role="alert">
+                    Chart failed to render. Please try refreshing the page.
+                  </div>
+                }
+              >
+                <PriceChart
+                  data={history}
+                  pair={decodedPair}
+                  loading={historyLoading && history.length === 0}
+                  loadingMore={loadingMore}
+                  hasMore={hasMore}
+                  onLoadMore={loadMore}
+                />
+              </ErrorBoundary>
             )}
           </div>
 


### PR DESCRIPTION
## Summary

This PR addresses four issues by improving error handling, performance, data fetching efficiency, and TypeScript type safety across the codebase.

### Changes

**#269 — Add error boundary tests for chart failure in PriceDetail**
- Wrapped `PriceChart` in `ErrorBoundary` with a chart-specific fallback message in `PriceDetail.tsx`
- Added test that mocks `PriceChart` to throw and verifies the chart error fallback renders correctly

**#266 — Wrap frequently-rendered components with React.memo()**
- Wrapped `SourceHealthBadge`, `ExportButton`, and `DateRangePicker` with `React.memo()` to prevent unnecessary re-renders during rapid WebSocket price updates

**#267 — Defer usePriceHistory data fetching until visible**
- Added Page Visibility API support to `usePriceHistory` hook
- Defers initial fetch until the page is visible
- Pauses refresh interval when the tab is hidden
- Resumes fetching when the tab becomes visible again

**#265 — Add missing return type annotations to exported components and hooks**
- Added explicit return type annotations to all exported component and hook functions that were missing them across `src/components/` and `src/hooks/`

### Verification

All checks pass:
- ✅ `npm run typecheck` — zero TypeScript errors
- ✅ `npm run lint` — zero lint errors
- ✅ `npm run build` — production build succeeds
- ✅ `npm run test:run` — all 404 unit tests pass

Closes #269
Closes #266
Closes #267
Closes #265