### PR TITLE
feat: resolve #293 #294 #296 #297 — touch gestures, drag-drop reorder print stylesheet, landing hero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,22 +38,28 @@ test/visual/diffs/
 test/visual/reports/
 e2e/visual/__snapshots__/
 
-# Test snapshots
-src/**/__snapshots__/
+# ── Vitest / Jest snapshots ───────────────────────────────────────────────────
 **/*.snap
+src/**/__snapshots__/
 
-# IDE / editor
+# ── IDE / editor ──────────────────────────────────────────────────────────────
 .vscode/
 .idea/
 *.swp
 *.swo
 
-# OS
+# ── OS ────────────────────────────────────────────────────────────────────────
 Thumbs.db
 
-# AI agent directories
+# ── AI agent directories ──────────────────────────────────────────────────────
 .kiro/
 
-# Bundle analysis (generated, not source)
+# ── Bundle analysis (generated, not source) ───────────────────────────────────
 reports/bundle-stats.html
 
+# ── Temporary / scratch files ─────────────────────────────────────────────────
+*.tmp
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
-import { lazy, Suspense, type ReactElement } from 'react'
+import { lazy, type ReactElement } from 'react'
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { Layout } from './components/Layout'
-import { ErrorBoundary, PageErrorBoundary } from './components/ErrorBoundary'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import { RouteSuspense } from './components/Skeletons/RouteSuspense'
 import { DashboardSkeleton } from './components/Skeletons/DashboardSkeleton'
 import { PriceDetailSkeleton } from './components/PriceDetailSkeleton'
@@ -11,21 +11,19 @@ import { AlertsProvider } from './hooks/useAlerts'
 import { ToastProvider } from './context/ToastContext'
 import { PreferencesProvider } from './preferences/PreferencesContext'
 import { ErrorReporterProvider, useErrorReporter } from './context/ErrorReporterContext'
+import { PriceProvider } from './context/PriceContext'
 import { useWebVitals } from './hooks/useWebVitals'
 import { useAccessibility } from './hooks/useAccessibility'
 import { initAnalytics, trackPageview } from './hooks/useAnalytics'
 import type { ErrorInfo } from 'react'
 
-const Dashboard = lazy(() => import('./pages/Dashboard').then((m) => ({ default: m.Dashboard })))
-const PriceDetail = lazy(() => import('./pages/PriceDetail').then((m) => ({ default: m.PriceDetail })))
-const ApiDocs = lazy(() => import('./pages/ApiDocs').then((m) => ({ default: m.ApiDocs })))
-const NotFound = lazy(() => import('./pages/NotFound').then((m) => ({ default: m.NotFound })))
-
 // Route-level code splitting: each page becomes its own chunk.
-// All four pages use named exports, so we re-export them as `default`
-// inside the .then() callback so React.lazy can consume them.
+// All pages use named exports, re-exported as `default` for React.lazy.
 const Dashboard = lazy(() =>
   import('./pages/Dashboard').then((m) => ({ default: m.Dashboard })),
+)
+const Landing = lazy(() =>
+  import('./pages/Landing').then((m) => ({ default: m.Landing })),
 )
 const PriceDetail = lazy(() =>
   import('./pages/PriceDetail').then((m) => ({ default: m.PriceDetail })),
@@ -46,59 +44,66 @@ export function AppContent(): ReactElement {
   useAccessibility()
   trackPageview(location.pathname)
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const makeOnError = (boundaryId: string) =>
     (error: Error, info: ErrorInfo) => captureError(error, info, boundaryId)
 
   return (
     <ErrorBoundary key={location.key}>
-      <PriceProvider>
-        <AlertsProvider>
-          <Layout>
-            <Routes>
-              <Route
-                path="/"
-                element={
-                  <RouteSuspense fallback={<DashboardSkeleton />}>
-                    <Dashboard />
-                  </RouteSuspense>
-                }
-              />
-              <Route
-                path="/prices/:pair"
-                element={
-                  <RouteSuspense fallback={<PriceDetailSkeleton />}>
-                    <PriceDetail />
-                  </RouteSuspense>
-                }
-              />
-              <Route
-                path="/price/:pair"
-                element={
-                  <RouteSuspense fallback={<PriceDetailSkeleton />}>
-                    <PriceDetail />
-                  </RouteSuspense>
-                }
-              />
-              <Route
-                path="/api-docs"
-                element={
-                  <RouteSuspense fallback={<ApiDocsSkeleton />}>
-                    <ApiDocs />
-                  </RouteSuspense>
-                }
-              />
-              <Route
-                path="*"
-                element={
-                  <RouteSuspense fallback={<NotFoundSkeleton />}>
-                    <NotFound />
-                  </RouteSuspense>
-                }
-              />
-            </Routes>
-          </Layout>
-        </AlertsProvider>
-      </PriceProvider>
+      <AlertsProvider>
+        <Layout>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <RouteSuspense fallback={<DashboardSkeleton />}>
+                  <Landing />
+                </RouteSuspense>
+              }
+            />
+            <Route
+              path="/dashboard"
+              element={
+                <RouteSuspense fallback={<DashboardSkeleton />}>
+                  <Dashboard />
+                </RouteSuspense>
+              }
+            />
+            <Route
+              path="/prices/:pair"
+              element={
+                <RouteSuspense fallback={<PriceDetailSkeleton />}>
+                  <PriceDetail />
+                </RouteSuspense>
+              }
+            />
+            <Route
+              path="/price/:pair"
+              element={
+                <RouteSuspense fallback={<PriceDetailSkeleton />}>
+                  <PriceDetail />
+                </RouteSuspense>
+              }
+            />
+            <Route
+              path="/api-docs"
+              element={
+                <RouteSuspense fallback={<ApiDocsSkeleton />}>
+                  <ApiDocs />
+                </RouteSuspense>
+              }
+            />
+            <Route
+              path="*"
+              element={
+                <RouteSuspense fallback={<NotFoundSkeleton />}>
+                  <NotFound />
+                </RouteSuspense>
+              }
+            />
+          </Routes>
+        </Layout>
+      </AlertsProvider>
     </ErrorBoundary>
   )
 }
@@ -109,13 +114,15 @@ export default function App(): ReactElement {
 
   return (
     <BrowserRouter basename={BASENAME}>
-      <PreferencesProvider>
-        <ToastProvider>
-          <PriceProvider>
-            <AppContent />
-          </PriceProvider>
-        </ToastProvider>
-      </PreferencesProvider>
+      <ErrorReporterProvider>
+        <PreferencesProvider>
+          <ToastProvider>
+            <PriceProvider>
+              <AppContent />
+            </PriceProvider>
+          </ToastProvider>
+        </PreferencesProvider>
+      </ErrorReporterProvider>
     </BrowserRouter>
   )
 }

--- a/src/components/DraggablePriceGrid.tsx
+++ b/src/components/DraggablePriceGrid.tsx
@@ -1,0 +1,99 @@
+import { memo, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { PriceCard } from './PriceCard'
+import { useDragSort } from '../hooks/useDragSort'
+import type { PriceData } from '../types'
+
+interface DraggablePriceGridProps {
+  items: PriceData[]
+  livePairs: Set<string>
+  isStale?: boolean
+  hasAlertFn: (pair: string) => boolean
+  onCardClick: (pair: string) => void
+  onAlertClick: (e: React.MouseEvent, pair: string) => void
+  selectMode?: boolean
+  selected?: Set<string>
+  onReorder: (orderedPairs: string[]) => void
+}
+
+/**
+ * A price card grid that supports drag-and-drop reordering via the HTML5
+ * drag API. Delegates to {@link useDragSort} for state and calls `onReorder`
+ * with the new ordered list of asset-pair strings whenever a card is dropped.
+ */
+export const DraggablePriceGrid = memo(function DraggablePriceGrid({
+  items,
+  livePairs,
+  isStale,
+  hasAlertFn,
+  onCardClick,
+  onAlertClick,
+  selectMode,
+  selected,
+  onReorder,
+}: DraggablePriceGridProps) {
+  const { t } = useTranslation()
+
+  const handleReorder = useCallback(
+    (reordered: PriceData[]) => {
+      onReorder(reordered.map((p) => p.assetPair))
+    },
+    [onReorder],
+  )
+
+  const { items: orderedItems, dragState, getItemProps } = useDragSort(items, handleReorder)
+
+  return (
+    <section
+      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+      aria-label={t('dashboard.feedsAriaLabel')}
+    >
+      {orderedItems.map((p, index) => {
+        const dragProps = getItemProps(index)
+        const isDragging = dragState.dragIndex === index
+        const isOver = dragState.overIndex === index && dragState.dragIndex !== index
+
+        return (
+          <div
+            key={p.assetPair}
+            {...dragProps}
+            className={[
+              'transition-all duration-150 cursor-grab active:cursor-grabbing',
+              isDragging ? 'opacity-40 scale-95' : '',
+              isOver ? 'ring-2 ring-cyan-500/60 ring-offset-2 ring-offset-gray-950 rounded-xl' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            title={t('draggableGrid.dragHint')}
+          >
+            {/* Drag handle indicator */}
+            <div
+              className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 pointer-events-none z-10 text-gray-600"
+              aria-hidden="true"
+            >
+              <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 16 16">
+                <circle cx="5" cy="4" r="1.2" />
+                <circle cx="11" cy="4" r="1.2" />
+                <circle cx="5" cy="8" r="1.2" />
+                <circle cx="11" cy="8" r="1.2" />
+                <circle cx="5" cy="12" r="1.2" />
+                <circle cx="11" cy="12" r="1.2" />
+              </svg>
+            </div>
+
+            <PriceCard
+              price={p}
+              isLive={livePairs.has(p.assetPair)}
+              isStale={isStale}
+              hasAlert={hasAlertFn(p.assetPair)}
+              onClick={onCardClick}
+              onAlertClick={onAlertClick}
+              selectMode={selectMode}
+              isSelected={selected?.has(p.assetPair)}
+            />
+          </div>
+        )
+      })}
+    </section>
+  )
+})

--- a/src/components/LandingHero.tsx
+++ b/src/components/LandingHero.tsx
@@ -1,0 +1,196 @@
+import { memo } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { PriceData } from '../types'
+import { formatPrice } from '../utils/format'
+
+interface MarketStatProps {
+  label: string
+  value: string
+  subValue?: string
+  highlight?: boolean
+}
+
+const MarketStat = memo(function MarketStat({ label, value, subValue, highlight }: MarketStatProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-gray-400 uppercase tracking-wider">{label}</span>
+      <span className={`text-2xl font-bold font-mono ${highlight ? 'text-cyan-400' : 'text-white'}`}>
+        {value}
+      </span>
+      {subValue && <span className="text-xs text-gray-500">{subValue}</span>}
+    </div>
+  )
+})
+
+interface TopPairCardProps {
+  price: PriceData
+}
+
+const TopPairCard = memo(function TopPairCard({ price }: TopPairCardProps) {
+  const { t } = useTranslation()
+  return (
+    <Link
+      to={`/prices/${encodeURIComponent(price.assetPair)}`}
+      className="flex items-center justify-between px-4 py-3 bg-gray-800/60 border border-gray-700 rounded-xl hover:border-cyan-500/50 hover:bg-gray-800 transition-all"
+      aria-label={t('landing.topPairs.pairAriaLabel', { pair: price.assetPair })}
+    >
+      <div className="flex items-center gap-3">
+        <div className="w-8 h-8 rounded-full bg-gradient-to-br from-cyan-500/20 to-blue-600/20 border border-cyan-500/30 flex items-center justify-center">
+          <span className="text-[10px] font-bold text-cyan-400">{price.assetPair.split('/')[0].slice(0, 3)}</span>
+        </div>
+        <div>
+          <div className="text-sm font-semibold text-gray-100">{price.assetPair}</div>
+          <div className="text-xs text-gray-500">{price.sources.length} {t('landing.topPairs.sources')}</div>
+        </div>
+      </div>
+      <div className="text-right">
+        <div className="text-sm font-bold font-mono text-white">${formatPrice(price.price)}</div>
+        <div className="text-xs text-cyan-400">{(price.confidence * 100).toFixed(0)}% {t('landing.topPairs.confidence')}</div>
+      </div>
+    </Link>
+  )
+})
+
+interface LandingHeroProps {
+  prices: PriceData[]
+  loading?: boolean
+  onEnterDashboard?: () => void
+}
+
+export const LandingHero = memo(function LandingHero({ prices, loading = false, onEnterDashboard }: LandingHeroProps) {
+  const { t } = useTranslation()
+
+  const totalPairs = prices.length
+  const activeSources = [...new Set(prices.flatMap((p) => p.sources))].length
+  const avgConfidence = prices.length > 0
+    ? (prices.reduce((sum, p) => sum + p.confidence, 0) / prices.length * 100).toFixed(1)
+    : '—'
+  const highConfCount = prices.filter((p) => p.confidence > 0.9).length
+
+  // Top 4 pairs sorted by confidence desc
+  const topPairs = [...prices]
+    .sort((a, b) => b.confidence - a.confidence)
+    .slice(0, 4)
+
+  return (
+    <section
+      className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-gray-900 via-gray-900 to-gray-950 border border-gray-800 mb-8 print:hidden"
+      aria-label={t('landing.hero.ariaLabel')}
+    >
+      {/* Background glow */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        aria-hidden="true"
+      >
+        <div className="absolute -top-24 -left-24 w-96 h-96 bg-cyan-500/5 rounded-full blur-3xl" />
+        <div className="absolute -bottom-24 -right-24 w-96 h-96 bg-blue-600/5 rounded-full blur-3xl" />
+      </div>
+
+      <div className="relative px-6 py-8 sm:px-10 sm:py-10">
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-6 mb-8">
+          <div className="max-w-lg">
+            <div className="flex items-center gap-2 mb-3">
+              <div className="w-2 h-2 bg-cyan-400 rounded-full animate-pulse" aria-hidden="true" />
+              <span className="text-xs text-cyan-400 font-medium uppercase tracking-wider">
+                {t('landing.hero.liveStatus')}
+              </span>
+            </div>
+            <h1 className="text-3xl sm:text-4xl font-bold text-white mb-3 leading-tight">
+              {t('landing.hero.title')}
+            </h1>
+            <p className="text-gray-400 text-base leading-relaxed">
+              {t('landing.hero.subtitle')}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 shrink-0">
+            <Link
+              to="/dashboard"
+              onClick={onEnterDashboard}
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-cyan-600 hover:bg-cyan-500 text-white font-semibold rounded-xl transition-colors shadow-lg shadow-cyan-900/30"
+              aria-label={t('landing.hero.ctaAriaLabel')}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+              </svg>
+              {t('landing.hero.cta')}
+            </Link>
+            <Link
+              to="/api-docs"
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 border border-gray-700 text-gray-300 hover:text-white hover:border-gray-600 font-medium rounded-xl transition-colors"
+            >
+              {t('landing.hero.apiDocs')}
+            </Link>
+          </div>
+        </div>
+
+        {/* Market stats */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 mb-8 p-4 bg-gray-900/60 rounded-xl border border-gray-800">
+          <MarketStat
+            label={t('landing.stats.totalPairs')}
+            value={loading ? '…' : String(totalPairs)}
+            subValue={t('landing.stats.totalPairsDetail')}
+            highlight
+          />
+          <MarketStat
+            label={t('landing.stats.activeSources')}
+            value={loading ? '…' : String(activeSources)}
+            subValue={t('landing.stats.activeSourcesDetail')}
+          />
+          <MarketStat
+            label={t('landing.stats.avgConfidence')}
+            value={loading ? '…' : `${avgConfidence}%`}
+            subValue={t('landing.stats.avgConfidenceDetail')}
+          />
+          <MarketStat
+            label={t('landing.stats.highConfidence')}
+            value={loading ? '…' : String(highConfCount)}
+            subValue={t('landing.stats.highConfidenceDetail')}
+            highlight
+          />
+        </div>
+
+        {/* Top pairs */}
+        {(loading || topPairs.length > 0) && (
+          <div>
+            <h2 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-3">
+              {t('landing.topPairs.title')}
+            </h2>
+            {loading ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {Array.from({ length: 4 }, (_, i) => (
+                  <div
+                    key={i}
+                    className="h-[60px] bg-gray-800/40 border border-gray-700 rounded-xl animate-pulse"
+                    aria-hidden="true"
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {topPairs.map((p) => (
+                  <TopPairCard key={p.assetPair} price={p} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Oracle source badges */}
+        <div className="flex flex-wrap items-center gap-2 mt-6 pt-6 border-t border-gray-800">
+          <span className="text-xs text-gray-500">{t('landing.powered.label')}</span>
+          {['Chainlink', 'Redstone', 'Band', 'Reflector'].map((src) => (
+            <span
+              key={src}
+              className="px-2.5 py-1 text-xs font-medium rounded-lg bg-gray-800 border border-gray-700 text-gray-300"
+            >
+              {src}
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+})

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -24,7 +24,8 @@ export function Layout({ children }: { children: ReactNode }): ReactElement {
   const { t } = useTranslation()
 
   const NAV_ITEMS = [
-    { path: '/', label: t('nav.dashboard') },
+    { path: '/', label: t('nav.home') },
+    { path: '/dashboard', label: t('nav.dashboard') },
     { path: '/api-docs', label: t('nav.apiDocs') },
   ]
 

--- a/src/hooks/useDragSort.ts
+++ b/src/hooks/useDragSort.ts
@@ -1,0 +1,123 @@
+import { useCallback, useRef, useState } from 'react'
+
+export interface DragSortState {
+  dragIndex: number | null
+  overIndex: number | null
+}
+
+export interface UseDragSortReturn<T> {
+  items: T[]
+  dragState: DragSortState
+  /** Attach to the draggable container element */
+  getItemProps: (index: number) => {
+    draggable: true
+    onDragStart: (e: React.DragEvent) => void
+    onDragOver: (e: React.DragEvent) => void
+    onDragEnter: (e: React.DragEvent) => void
+    onDragLeave: (e: React.DragEvent) => void
+    onDrop: (e: React.DragEvent) => void
+    onDragEnd: (e: React.DragEvent) => void
+    'aria-grabbed': boolean
+    'data-drag-index': number
+  }
+}
+
+/**
+ * Hook for drag-and-drop reordering of a list.
+ *
+ * Manages drag state internally and calls `onReorder` with the reordered array
+ * when a drop is completed. Uses the HTML5 drag-and-drop API — no extra
+ * dependencies needed.
+ *
+ * @param initialItems - The list to reorder
+ * @param onReorder - Called with the reordered array after a successful drop
+ */
+export function useDragSort<T>(
+  initialItems: T[],
+  onReorder: (reordered: T[]) => void,
+): UseDragSortReturn<T> {
+  const [items, setItems] = useState<T[]>(initialItems)
+  const [dragState, setDragState] = useState<DragSortState>({ dragIndex: null, overIndex: null })
+  const dragIndexRef = useRef<number | null>(null)
+
+  // Keep items in sync when the upstream list changes (e.g. initial load)
+  // by replacing items only when the list identity changes length or keys.
+  // We do this via a ref comparison to avoid a render loop.
+  const prevItemsRef = useRef<T[]>(initialItems)
+  if (prevItemsRef.current !== initialItems && initialItems.length !== items.length) {
+    prevItemsRef.current = initialItems
+    setItems(initialItems)
+  }
+
+  const onDragStart = useCallback((e: React.DragEvent, index: number) => {
+    dragIndexRef.current = index
+    setDragState({ dragIndex: index, overIndex: null })
+    // Set drag data so the browser's ghost image works
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', String(index))
+  }, [])
+
+  const onDragOver = useCallback((e: React.DragEvent, overIndex: number) => {
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    const dragIndex = dragIndexRef.current
+    if (dragIndex === null || dragIndex === overIndex) return
+    setDragState((prev) => (prev.overIndex === overIndex ? prev : { ...prev, overIndex }))
+  }, [])
+
+  const onDragEnter = useCallback((e: React.DragEvent, overIndex: number) => {
+    e.preventDefault()
+    const dragIndex = dragIndexRef.current
+    if (dragIndex === null || dragIndex === overIndex) return
+    setDragState((prev) => ({ ...prev, overIndex }))
+  }, [])
+
+  const onDragLeave = useCallback((_e: React.DragEvent, _index: number) => {
+    // Only clear overIndex; keep dragIndex so visual state is stable
+    // We don't clear here to avoid flickering between adjacent items
+  }, [])
+
+  const onDrop = useCallback(
+    (e: React.DragEvent, dropIndex: number) => {
+      e.preventDefault()
+      const dragIndex = dragIndexRef.current
+      if (dragIndex === null || dragIndex === dropIndex) {
+        setDragState({ dragIndex: null, overIndex: null })
+        dragIndexRef.current = null
+        return
+      }
+
+      const reordered = [...items]
+      const [removed] = reordered.splice(dragIndex, 1)
+      reordered.splice(dropIndex, 0, removed)
+
+      setItems(reordered)
+      setDragState({ dragIndex: null, overIndex: null })
+      dragIndexRef.current = null
+      onReorder(reordered)
+    },
+    [items, onReorder],
+  )
+
+  const onDragEnd = useCallback((_e: React.DragEvent) => {
+    setDragState({ dragIndex: null, overIndex: null })
+    dragIndexRef.current = null
+  }, [])
+
+  const getItemProps = useCallback(
+    (index: number) => ({
+      draggable: true as const,
+      onDragStart: (e: React.DragEvent) => onDragStart(e, index),
+      onDragOver: (e: React.DragEvent) => onDragOver(e, index),
+      onDragEnter: (e: React.DragEvent) => onDragEnter(e, index),
+      onDragLeave: (e: React.DragEvent) => onDragLeave(e, index),
+      onDrop: (e: React.DragEvent) => onDrop(e, index),
+      onDragEnd: (e: React.DragEvent) => onDragEnd(e),
+      'aria-grabbed': dragState.dragIndex === index,
+      'data-drag-index': index,
+    }),
+    [dragState.dragIndex, onDragStart, onDragOver, onDragEnter, onDragLeave, onDrop, onDragEnd],
+  )
+
+  return { items, dragState, getItemProps }
+}

--- a/src/hooks/usePullToRefresh.ts
+++ b/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export interface PullToRefreshOptions {
+  /** Distance in px the user must pull before a refresh is triggered. Defaults to 80. */
+  threshold?: number
+  /** Maximum visual pull distance in px. Defaults to 120. */
+  maxPull?: number
+  /** Called when the pull distance exceeds the threshold and the user releases. */
+  onRefresh: () => void | Promise<void>
+  /** Whether the gesture is disabled (e.g. already refreshing, or reducedMotion). */
+  disabled?: boolean
+}
+
+export interface PullToRefreshState {
+  /** Current pull distance in pixels (0 = no pull). */
+  pullDistance: number
+  /** Whether the user has pulled far enough to trigger on release. */
+  readyToRefresh: boolean
+  /** Whether an async refresh is in progress. */
+  refreshing: boolean
+}
+
+export interface PullToRefreshHandlers {
+  onTouchStart: (e: React.TouchEvent) => void
+  onTouchMove: (e: React.TouchEvent) => void
+  onTouchEnd: (e: React.TouchEvent) => void
+}
+
+/**
+ * Implements pull-to-refresh behaviour for a scrollable container.
+ *
+ * Only fires when the target element is scrolled to the top (scrollTop === 0),
+ * so normal scrolling still works.
+ *
+ * Usage:
+ * ```tsx
+ * const { state, handlers } = usePullToRefresh({ onRefresh: refetch })
+ * return (
+ *   <div {...handlers}>
+ *     {state.pullDistance > 0 && <PullIndicator {...state} />}
+ *     {children}
+ *   </div>
+ * )
+ * ```
+ */
+export function usePullToRefresh(
+  containerRef: React.RefObject<HTMLElement | null>,
+  options: PullToRefreshOptions,
+): { state: PullToRefreshState; handlers: PullToRefreshHandlers } {
+  const { threshold = 80, maxPull = 120, onRefresh, disabled = false } = options
+
+  const [pullDistance, setPullDistance] = useState(0)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const startYRef = useRef<number | null>(null)
+  const isPullingRef = useRef(false)
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (disabled || refreshing) return
+      const el = containerRef.current
+      // Only start a pull when the container is scrolled to the very top
+      if (el && el.scrollTop > 0) return
+      startYRef.current = e.touches[0].clientY
+      isPullingRef.current = false
+    },
+    [disabled, refreshing, containerRef],
+  )
+
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (disabled || refreshing || startYRef.current === null) return
+
+      const dy = e.touches[0].clientY - startYRef.current
+      if (dy <= 0) {
+        // User scrolling up, not pulling down
+        setPullDistance(0)
+        isPullingRef.current = false
+        return
+      }
+
+      isPullingRef.current = true
+      // Apply resistance: slower pull as distance increases
+      const resistance = 0.4
+      const clamped = Math.min(dy * resistance, maxPull)
+      setPullDistance(clamped)
+
+      // Prevent default page scroll when actively pulling
+      if (clamped > 10) {
+        e.preventDefault()
+      }
+    },
+    [disabled, refreshing, maxPull],
+  )
+
+  const onTouchEnd = useCallback(async () => {
+    if (!isPullingRef.current || startYRef.current === null) {
+      startYRef.current = null
+      return
+    }
+
+    startYRef.current = null
+    isPullingRef.current = false
+
+    if (pullDistance >= threshold) {
+      setRefreshing(true)
+      setPullDistance(0)
+      try {
+        await onRefresh()
+      } finally {
+        setRefreshing(false)
+      }
+    } else {
+      setPullDistance(0)
+    }
+  }, [pullDistance, threshold, onRefresh])
+
+  // Reset when disabled externally
+  useEffect(() => {
+    if (disabled) {
+      setPullDistance(0)
+      startYRef.current = null
+      isPullingRef.current = false
+    }
+  }, [disabled])
+
+  return {
+    state: {
+      pullDistance,
+      readyToRefresh: pullDistance >= threshold,
+      refreshing,
+    },
+    handlers: {
+      onTouchStart,
+      onTouchMove,
+      onTouchEnd: onTouchEnd as unknown as (e: React.TouchEvent) => void,
+    },
+  }
+}

--- a/src/hooks/useSwipeGesture.ts
+++ b/src/hooks/useSwipeGesture.ts
@@ -1,0 +1,101 @@
+import { useCallback, useRef } from 'react'
+
+export type SwipeDirection = 'left' | 'right' | 'up' | 'down'
+
+export interface SwipeGestureOptions {
+  /** Minimum distance in pixels to count as a swipe. Defaults to 50. */
+  threshold?: number
+  /** Maximum allowed perpendicular movement as a ratio (0–1). Defaults to 0.5. */
+  directionLock?: number
+  /** Whether touch events are disabled (e.g. reducedMotion). Defaults to false. */
+  disabled?: boolean
+  onSwipeLeft?: () => void
+  onSwipeRight?: () => void
+  onSwipeUp?: () => void
+  onSwipeDown?: () => void
+}
+
+export interface SwipeGestureHandlers {
+  onTouchStart: (e: React.TouchEvent) => void
+  onTouchMove: (e: React.TouchEvent) => void
+  onTouchEnd: (e: React.TouchEvent) => void
+}
+
+/**
+ * Returns touch event handlers that detect swipe gestures on an element.
+ *
+ * Usage:
+ * ```tsx
+ * const handlers = useSwipeGesture({ onSwipeLeft: () => navigate(-1) })
+ * return <div {...handlers}>…</div>
+ * ```
+ */
+export function useSwipeGesture(options: SwipeGestureOptions): SwipeGestureHandlers {
+  const {
+    threshold = 50,
+    directionLock = 0.5,
+    disabled = false,
+    onSwipeLeft,
+    onSwipeRight,
+    onSwipeUp,
+    onSwipeDown,
+  } = options
+
+  const startRef = useRef<{ x: number; y: number } | null>(null)
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (disabled) return
+      const touch = e.changedTouches[0]
+      startRef.current = { x: touch.clientX, y: touch.clientY }
+    },
+    [disabled],
+  )
+
+  const onTouchMove = useCallback(
+    (_e: React.TouchEvent) => {
+      // No-op: we only need start + end points
+    },
+    [],
+  )
+
+  const onTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (disabled || !startRef.current) return
+
+      const touch = e.changedTouches[0]
+      const dx = touch.clientX - startRef.current.x
+      const dy = touch.clientY - startRef.current.y
+      startRef.current = null
+
+      const absDx = Math.abs(dx)
+      const absDy = Math.abs(dy)
+
+      // Neither axis meets the threshold — too short, ignore
+      if (absDx < threshold && absDy < threshold) return
+
+      if (absDx >= absDy) {
+        // Horizontal swipe
+        const lockRatio = absDx > 0 ? absDy / absDx : 1
+        if (lockRatio > directionLock) return // too diagonal
+        if (dx < 0) {
+          onSwipeLeft?.()
+        } else {
+          onSwipeRight?.()
+        }
+      } else {
+        // Vertical swipe
+        const lockRatio = absDy > 0 ? absDx / absDy : 1
+        if (lockRatio > directionLock) return
+        if (dy < 0) {
+          onSwipeUp?.()
+        } else {
+          onSwipeDown?.()
+        }
+      }
+    },
+    [disabled, threshold, directionLock, onSwipeLeft, onSwipeRight, onSwipeUp, onSwipeDown],
+  )
+
+  return { onTouchStart, onTouchMove, onTouchEnd }
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,6 +1,7 @@
 const en = {
   // ── Layout ──────────────────────────────────────────────────────────────
   nav: {
+    home: 'Home',
     dashboard: 'Dashboard',
     apiDocs: 'API Docs',
     toggleMenu: 'Toggle menu',
@@ -53,6 +54,12 @@ const en = {
     },
     loadingAriaLabel: 'Loading price cards',
     feedsAriaLabel: 'Price feeds',
+    // ── Touch gestures / Pull-to-refresh (#293) ─────────────────────────
+    pullToRefresh: {
+      pull: 'Pull down to refresh',
+      release: 'Release to refresh',
+      refreshing: 'Refreshing…',
+    },
   },
 
   // ── FilterPanel ──────────────────────────────────────────────────────────
@@ -412,6 +419,48 @@ const en = {
       'Reflector is a Stellar-native oracle that publishes asset prices directly on the Stellar network.',
     defaultTooltip: '{{source}} contributed a price feed to this aggregated value.',
   },
+
+  // ── Landing / Hero (#297) ─────────────────────────────────────────────────
+  landing: {
+    hero: {
+      ariaLabel: 'Market overview hero section',
+      liveStatus: 'Live · All oracles active',
+      title: 'Stellar Unified Price Oracle',
+      subtitle:
+        'Aggregated, real-time asset prices from Chainlink, Redstone, Band, and Reflector — streamed directly to your app via REST & WebSocket.',
+      cta: 'Open Dashboard',
+      ctaAriaLabel: 'Open the price oracle dashboard',
+      apiDocs: 'API Docs',
+    },
+    stats: {
+      totalPairs: 'Tracked Pairs',
+      totalPairsDetail: 'asset pairs monitored',
+      activeSources: 'Oracle Sources',
+      activeSourcesDetail: 'active data providers',
+      avgConfidence: 'Avg Confidence',
+      avgConfidenceDetail: 'across all pairs',
+      highConfidence: 'High Confidence',
+      highConfidenceDetail: 'pairs above 90%',
+    },
+    topPairs: {
+      title: 'Top Pairs by Confidence',
+      pairAriaLabel: 'View price details for {{pair}}',
+      sources: 'sources',
+      confidence: 'conf.',
+    },
+    powered: {
+      label: 'Powered by',
+    },
+  },
+
+  // ── Drag-and-drop reordering (#294) ───────────────────────────────────────
+  draggableGrid: {
+    dragHint: 'Drag to reorder',
+    ariaLabel: 'Drag to reorder price cards',
+    dropTarget: 'Drop here',
+  },
+
+  // ── Touch gestures / Pull-to-refresh (#293) ───────────────────────────────
 } as const
 
 export default en

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1,5 +1,6 @@
 const es = {
   nav: {
+    home: 'Inicio',
     dashboard: 'Panel de control',
     apiDocs: 'Documentación API',
     toggleMenu: 'Alternar menú',
@@ -51,6 +52,12 @@ const es = {
     },
     loadingAriaLabel: 'Cargando tarjetas de precios',
     feedsAriaLabel: 'Feeds de precios',
+    // ── Touch gestures / Pull-to-refresh (#293) ─────────────────────────
+    pullToRefresh: {
+      pull: 'Desliza hacia abajo para actualizar',
+      release: 'Suelta para actualizar',
+      refreshing: 'Actualizando…',
+    },
   },
 
   filter: {
@@ -386,6 +393,48 @@ const es = {
       'Reflector es un oráculo nativo de Stellar que publica precios de activos directamente en la red Stellar.',
     defaultTooltip: '{{source}} contribuyó un feed de precios a este valor agregado.',
   },
+
+  // ── Landing / Hero (#297) ─────────────────────────────────────────────────
+  landing: {
+    hero: {
+      ariaLabel: 'Sección de presentación del mercado',
+      liveStatus: 'En vivo · Todos los oráculos activos',
+      title: 'Stellar Unified Price Oracle',
+      subtitle:
+        'Precios de activos en tiempo real y agregados de Chainlink, Redstone, Band y Reflector — transmitidos a tu aplicación vía REST y WebSocket.',
+      cta: 'Abrir Panel',
+      ctaAriaLabel: 'Abrir el panel del oráculo de precios',
+      apiDocs: 'Docs API',
+    },
+    stats: {
+      totalPairs: 'Pares seguidos',
+      totalPairsDetail: 'pares de activos monitoreados',
+      activeSources: 'Fuentes oracle',
+      activeSourcesDetail: 'proveedores de datos activos',
+      avgConfidence: 'Confianza media',
+      avgConfidenceDetail: 'entre todos los pares',
+      highConfidence: 'Alta confianza',
+      highConfidenceDetail: 'pares por encima del 90%',
+    },
+    topPairs: {
+      title: 'Principales pares por confianza',
+      pairAriaLabel: 'Ver detalles de precio para {{pair}}',
+      sources: 'fuentes',
+      confidence: 'conf.',
+    },
+    powered: {
+      label: 'Impulsado por',
+    },
+  },
+
+  // ── Drag-and-drop reordering (#294) ───────────────────────────────────────
+  draggableGrid: {
+    dragHint: 'Arrastra para reordenar',
+    ariaLabel: 'Arrastra para reordenar las tarjetas de precios',
+    dropTarget: 'Soltar aquí',
+  },
+
+  // ── Touch gestures / Pull-to-refresh (#293) ───────────────────────────────
 } as const
 
 export default es

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -1,5 +1,6 @@
 const fr = {
   nav: {
+    home: 'Accueil',
     dashboard: 'Tableau de bord',
     apiDocs: 'Documentation API',
     toggleMenu: 'Basculer le menu',
@@ -51,6 +52,12 @@ const fr = {
     },
     loadingAriaLabel: 'Chargement des cartes de prix',
     feedsAriaLabel: 'Flux de prix',
+    // ── Touch gestures / Pull-to-refresh (#293) ─────────────────────────
+    pullToRefresh: {
+      pull: 'Tirer vers le bas pour actualiser',
+      release: 'Relâcher pour actualiser',
+      refreshing: 'Actualisation…',
+    },
   },
 
   filter: {
@@ -310,6 +317,48 @@ const fr = {
     copy: 'Copier',
     copied: 'Copié !',
   },
+
+  // ── Landing / Hero (#297) ─────────────────────────────────────────────────
+  landing: {
+    hero: {
+      ariaLabel: 'Section héro de présentation du marché',
+      liveStatus: 'En direct · Tous les oracles actifs',
+      title: 'Stellar Unified Price Oracle',
+      subtitle:
+        'Prix d\'actifs en temps réel agrégés depuis Chainlink, Redstone, Band et Reflector — diffusés vers votre application via REST & WebSocket.',
+      cta: 'Ouvrir le tableau de bord',
+      ctaAriaLabel: 'Ouvrir le tableau de bord de l\'oracle de prix',
+      apiDocs: 'Docs API',
+    },
+    stats: {
+      totalPairs: 'Paires suivies',
+      totalPairsDetail: 'paires d\'actifs surveillées',
+      activeSources: 'Sources oracle',
+      activeSourcesDetail: 'fournisseurs de données actifs',
+      avgConfidence: 'Confiance moy.',
+      avgConfidenceDetail: 'sur toutes les paires',
+      highConfidence: 'Haute confiance',
+      highConfidenceDetail: 'paires au-dessus de 90%',
+    },
+    topPairs: {
+      title: 'Meilleures paires par confiance',
+      pairAriaLabel: 'Voir les détails de prix pour {{pair}}',
+      sources: 'sources',
+      confidence: 'conf.',
+    },
+    powered: {
+      label: 'Propulsé par',
+    },
+  },
+
+  // ── Drag-and-drop reordering (#294) ───────────────────────────────────────
+  draggableGrid: {
+    dragHint: 'Glisser pour réorganiser',
+    ariaLabel: 'Glisser pour réorganiser les cartes de prix',
+    dropTarget: 'Déposer ici',
+  },
+
+  // ── Touch gestures / Pull-to-refresh (#293) ───────────────────────────────
 } as const
 
 export default fr

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -1,5 +1,6 @@
 const ja = {
   nav: {
+    home: 'ホーム',
     dashboard: 'ダッシュボード',
     apiDocs: 'APIドキュメント',
     toggleMenu: 'メニューを切り替え',
@@ -51,6 +52,12 @@ const ja = {
     },
     loadingAriaLabel: '価格カードを読み込み中',
     feedsAriaLabel: '価格フィード',
+    // ── Touch gestures / Pull-to-refresh (#293) ─────────────────────────
+    pullToRefresh: {
+      pull: '下に引いて更新',
+      release: '離して更新',
+      refreshing: '更新中…',
+    },
   },
 
   filter: {
@@ -310,6 +317,48 @@ const ja = {
     copy: 'コピー',
     copied: 'コピーしました！',
   },
+
+  // ── Landing / Hero (#297) ─────────────────────────────────────────────────
+  landing: {
+    hero: {
+      ariaLabel: 'マーケット概要ヒーローセクション',
+      liveStatus: 'ライブ · 全オラクル稼働中',
+      title: 'Stellar Unified Price Oracle',
+      subtitle:
+        'Chainlink、Redstone、Band、Reflectorから集計されたリアルタイム資産価格 — REST・WebSocket経由でアプリに直接配信。',
+      cta: 'ダッシュボードを開く',
+      ctaAriaLabel: '価格オラクルダッシュボードを開く',
+      apiDocs: 'APIドキュメント',
+    },
+    stats: {
+      totalPairs: '追跡ペア数',
+      totalPairsDetail: '監視中の資産ペア',
+      activeSources: 'オラクルソース',
+      activeSourcesDetail: '稼働中のデータプロバイダー',
+      avgConfidence: '平均信頼度',
+      avgConfidenceDetail: '全ペアの平均',
+      highConfidence: '高信頼度',
+      highConfidenceDetail: '90%超のペア',
+    },
+    topPairs: {
+      title: '信頼度上位ペア',
+      pairAriaLabel: '{{pair}}の価格詳細を見る',
+      sources: 'ソース',
+      confidence: '信頼度',
+    },
+    powered: {
+      label: '提供元',
+    },
+  },
+
+  // ── Drag-and-drop reordering (#294) ───────────────────────────────────────
+  draggableGrid: {
+    dragHint: 'ドラッグして並べ替え',
+    ariaLabel: '価格カードをドラッグして並べ替え',
+    dropTarget: 'ここにドロップ',
+  },
+
+  // ── Touch gestures / Pull-to-refresh (#293) ───────────────────────────────
 } as const
 
 export default ja

--- a/src/index.css
+++ b/src/index.css
@@ -91,3 +91,111 @@ body {
 .large-text .text-xs {
   font-size: 0.875rem !important;
 }
+
+/* ── Print Styles (#296) ────────────────────────────────────────── */
+@media print {
+  /* Reset page */
+  * {
+    color-adjust: exact !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+
+  body {
+    background: #ffffff !important;
+    color: #000000 !important;
+    font-size: 11pt;
+    margin: 0;
+  }
+
+  /* Hide interactive and decorative chrome */
+  nav,
+  footer,
+  .print\:hidden,
+  [role="status"],
+  [aria-live],
+  button,
+  .ConnectionBadge,
+  .AlertPanel,
+  .FilterPanel,
+  .PairSearchBar {
+    display: none !important;
+  }
+
+  /* Reset backgrounds and shadows for ink efficiency */
+  .bg-gray-900,
+  .bg-gray-950,
+  .dark\:bg-gray-900,
+  .dark\:bg-gray-950,
+  .dark\:bg-gray-800 {
+    background: #ffffff !important;
+  }
+
+  /* Price cards: readable border layout */
+  [class*='rounded-xl'],
+  [class*='rounded-lg'] {
+    border-radius: 4px !important;
+    border: 1px solid #d1d5db !important;
+    box-shadow: none !important;
+  }
+
+  /* Text color normalisation */
+  .text-white,
+  .text-gray-100,
+  .text-gray-200,
+  .dark\:text-white,
+  .dark\:text-gray-100 {
+    color: #111827 !important;
+  }
+
+  .text-gray-400,
+  .text-gray-500,
+  .dark\:text-gray-400,
+  .dark\:text-gray-500 {
+    color: #6b7280 !important;
+  }
+
+  .text-cyan-400,
+  .dark\:text-cyan-400 {
+    color: #0891b2 !important;
+  }
+
+  /* Grid: 3 columns on print */
+  .grid.grid-cols-1 {
+    display: grid !important;
+    grid-template-columns: repeat(3, 1fr) !important;
+    gap: 8pt !important;
+  }
+
+  /* Page breaks */
+  h1, h2 {
+    page-break-after: avoid;
+  }
+
+  section {
+    page-break-inside: avoid;
+  }
+
+  /* Print header: show URL */
+  @page {
+    margin: 1.5cm;
+  }
+
+  /* Utility: explicitly show print-only elements */
+  .print\:block {
+    display: block !important;
+  }
+
+  .print\:flex {
+    display: flex !important;
+  }
+
+  .print\:table {
+    display: table !important;
+  }
+
+  /* Ensure font-mono prices are rendered clearly */
+  .font-mono {
+    font-family: 'Courier New', Courier, monospace !important;
+  }
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,12 +1,16 @@
-import { useCallback, useMemo, useState, useTransition, useOptimistic } from 'react'
+import { useCallback, useMemo, useRef, useState, useTransition, useOptimistic } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { usePriceContext } from '../context/PriceContext'
 import { useAlerts } from '../hooks/useAlerts'
 import { useExport } from '../hooks/useExport'
+import { usePreferences } from '../preferences/PreferencesContext'
+import { useSwipeGesture } from '../hooks/useSwipeGesture'
+import { usePullToRefresh } from '../hooks/usePullToRefresh'
 import { PriceCard } from '../components/PriceCard'
 import { PriceCardSkeleton } from '../components/PriceCardSkeleton'
 import { PriceTableView } from '../components/PriceTableView'
+import { DraggablePriceGrid } from '../components/DraggablePriceGrid'
 import { AlertModal } from '../components/AlertModal'
 import { AlertBadge } from '../components/AlertBadge'
 import { ConnectionBadge } from '../components/ConnectionBadge'
@@ -41,11 +45,13 @@ export function Dashboard() {
     wsStatus,
     rateLimitStatus,
     rateLimitRetryAfterMs,
+    refetchPrices,
   } = usePriceContext()
   const navigate = useNavigate()
   const { t } = useTranslation()
   const { alerts, addAlert, removeAlert, hasAlertsForPair, activeCount, reEnableAlert } = useAlerts()
   const { exportCSV } = useExport()
+  const { preferences, updatePreference } = usePreferences()
   const [searchParams] = useSearchParams()
 
   const [modalOpen, setModalOpen] = useState(false)
@@ -54,6 +60,20 @@ export function Dashboard() {
   const [notifModalOpen, setNotifModalOpen] = useState(false)
   const [filterPanelOpen, setFilterPanelOpen] = useState(false)
   const [isPending, startTransition] = useTransition()
+
+  // Pull-to-refresh: allow the user to drag the page down to force a refetch
+  const mainRef = useRef<HTMLDivElement>(null)
+  const { state: pullState, handlers: pullHandlers } = usePullToRefresh(mainRef, {
+    onRefresh: refetchPrices,
+    disabled: pricesLoading || preferences.reducedMotion,
+  })
+
+  // Swipe left/right on the dashboard to switch between card/table views
+  const swipeHandlers = useSwipeGesture({
+    onSwipeLeft: () => startTransition(() => setDashboardView('table')),
+    onSwipeRight: () => startTransition(() => setDashboardView('card')),
+    disabled: preferences.reducedMotion,
+  })
 
   const [selectMode, setSelectMode] = useState(false)
   const [selected, setSelected] = useState<Set<string>>(new Set())
@@ -178,7 +198,33 @@ export function Dashboard() {
   }, [])
 
   return (
-    <div>
+    <div
+      ref={mainRef}
+      {...pullHandlers}
+      {...swipeHandlers}
+    >
+      {/* Pull-to-refresh indicator */}
+      {(pullState.pullDistance > 0 || pullState.refreshing) && (
+        <div
+          className="flex items-center justify-center gap-2 text-xs text-cyan-400 mb-2 transition-all"
+          style={{ height: `${Math.max(pullState.pullDistance, pullState.refreshing ? 32 : 0)}px` }}
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {pullState.refreshing ? (
+            <>
+              <svg className="w-4 h-4 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+              {t('dashboard.pullToRefresh.refreshing')}
+            </>
+          ) : pullState.readyToRefresh ? (
+            t('dashboard.pullToRefresh.release')
+          ) : (
+            t('dashboard.pullToRefresh.pull')
+          )}
+        </div>
+      )}
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
@@ -367,21 +413,17 @@ export function Dashboard() {
         </ErrorBoundary>
       ) : (
         <ErrorBoundary boundaryId="price-card-grid" featureLabel="Price Cards">
-          <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4" aria-label="Price feeds">
-            {filtered.map((p) => (
-              <PriceCard
-                key={p.assetPair}
-                price={p}
-                isLive={livePrices.has(p.assetPair)}
-                isStale={pricesValidating}
-                hasAlert={hasAlertsForPair(p.assetPair)}
-                onClick={() => handleCardClick(p.assetPair)}
-                onAlertClick={(e) => handleAlertClick(e, p.assetPair)}
-                selectMode={selectMode}
-                isSelected={selected.has(p.assetPair)}
-              />
-            ))}
-          </section>
+          <DraggablePriceGrid
+            items={filtered}
+            livePairs={new Set(livePrices.keys())}
+            isStale={pricesValidating}
+            hasAlertFn={hasAlertsForPair}
+            onCardClick={handleCardClick}
+            onAlertClick={handleAlertClick}
+            selectMode={selectMode}
+            selected={selected}
+            onReorder={(orderedPairs) => updatePreference('cardOrder', orderedPairs)}
+          />
         </ErrorBoundary>
       )}
 

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,0 +1,24 @@
+import { useNavigate } from 'react-router-dom'
+import { usePriceContext } from '../context/PriceContext'
+import { LandingHero } from '../components/LandingHero'
+
+/**
+ * Landing page (route: `/`).
+ *
+ * Shows the {@link LandingHero} market overview so new users get context before
+ * entering the full dashboard. The hero's "Open Dashboard" CTA navigates to `/dashboard`.
+ */
+export function Landing() {
+  const { prices, pricesLoading } = usePriceContext()
+  const navigate = useNavigate()
+
+  return (
+    <div>
+      <LandingHero
+        prices={prices}
+        loading={pricesLoading}
+        onEnterDashboard={() => navigate('/dashboard')}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
#297 — Add LandingHero component and Landing page at route /
  - LandingHero: market overview with live stats, top pairs, oracle badges
  - /dashboard route added for main price dashboard
  - Nav updated with Home + Dashboard + API Docs links
  - i18n keys: landing.hero, landing.stats, landing.topPairs, landing.powered

#296 — Add printable stylesheet for price data
  - Full @media print block in index.css
  - Hides interactive chrome (nav, buttons, filters)
  - Ink-efficient layout: white backgrounds, border cards, 3-col grid
  - print:hidden / print:block utility hooks

#294 — Add drag-and-drop reordering for price cards
  - useDragSort hook: HTML5 drag API, no extra dependencies
  - DraggablePriceGrid component wired to Dashboard card view
  - onReorder persists new order to preferences.cardOrder via IndexedDB

#293 — Add touch gesture support
  - useSwipeGesture hook: swipe left/right switches card/table view
  - usePullToRefresh hook: pull-down triggers refetchPrices
  - Both respect preferences.reducedMotion
  - i18n keys: dashboard.pullToRefresh, draggableGrid

chore: update .gitignore (snapshots, logs, tmp files)
Closes #297 
closes #296 
Closes #294 
Closes #293 