### PR TITLE
Feature/issues visual regression perf api versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,59 @@ jobs:
       - run: npx playwright install --with-deps chromium firefox webkit
 
       - run: npm run test:e2e
+
+  # ── Visual regression ───────────────────────────────────────────────────────
+  # Compares screenshots against baselines stored in e2e/snapshots/.
+  # The job fails if any screenshot differs beyond the configured threshold.
+  #
+  # To update baselines locally:
+  #   npm run test:e2e:visual:update
+  #   git add e2e/snapshots/ && git commit -m "chore: update visual baselines"
+  visual-regression:
+    needs: [frontend]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    # Treat as advisory on PRs — screenshot diffs require manual review and a
+    # deliberate baseline update commit, not an automatic failure gate.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: dist/
+
+      # Only install Chromium — visual baselines are browser-specific and we
+      # intentionally generate/compare against Chromium only for consistency.
+      - run: npx playwright install --with-deps chromium
+
+      - name: Run visual regression tests
+        run: npm run test:e2e:visual
+        env:
+          CI: 'true'
+
+      # Upload the HTML report so reviewers can inspect pixel diffs in the
+      # GitHub Actions UI even when the job succeeds.
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: visual-regression-report
+          path: reports/playwright/
+          retention-days: 14
+
+      # Upload any diff screenshots Playwright generated for failed comparisons.
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: visual-regression-diffs
+          path: test-results/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,34 @@ jobs:
           name: visual-regression-diffs
           path: test-results/
           retention-days: 7
+
+  # ── API version compatibility check ────────────────────────────────────────
+  # Verifies the frontend's declared version range is compatible with the
+  # running backend. Skips gracefully when no backend is available (e.g. on
+  # frontend-only PRs). Set BACKEND_API_URL to point at a live/staging backend.
+  #
+  # To run locally:
+  #   VITE_API_URL=http://localhost:3000 npm run check:api-version
+  api-version-check:
+    needs: [frontend]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    # Non-blocking: backend may not be running in every CI environment.
+    # The script already exits 0 when the server is unreachable.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Check API version compatibility
+        run: node scripts/check-api-version.js
+        env:
+          # Override with a real backend URL in repository secrets when available.
+          VITE_API_URL: ${{ vars.BACKEND_API_URL || 'http://localhost:3000' }}

--- a/.gitignore
+++ b/.gitignore
@@ -41,27 +41,22 @@ vite.config.*.timestamp-*
 # ── E2E test artifacts ────────────────────────────────────────────────────────
 e2e/results
 e2e/test-results
-test-results/
-playwright-report
 playwright/.cache
 
 # ── Vitest cache ──────────────────────────────────────────────────────────────
 .vitest-cache/
 .vite/
 
-# ── Test snapshot files (auto-generated, must not be committed) ───────────────
-**/__snapshots__/
+# ── Test snapshot files ────────────────────────────────────────────────────────
+# Vitest/Jest inline snapshots — auto-generated, not committed
 src/**/__snapshots__/
 **/*.snap
-test/visual/baselines/
-test/visual/diffs/
-test/visual/reports/
-e2e/visual/__snapshots__/
 
-# Test snapshots (Vitest / Jest)
-src/**/__snapshots__/
-**/*.snap
-src/**/__snapshots__/
+# Playwright visual-regression baselines (e2e/snapshots/) ARE committed to git
+# so CI can detect regressions. Only exclude the diff/actual artifacts:
+test-results/
+playwright-report/
+# Do NOT add e2e/snapshots/ here — those are the approved baselines
 
 # ── IDE / editor ──────────────────────────────────────────────────────────────
 .vscode/

--- a/e2e/snapshots/README.md
+++ b/e2e/snapshots/README.md
@@ -1,0 +1,47 @@
+# Visual Regression Baselines
+
+This directory contains the approved baseline screenshots used by the Playwright
+visual regression tests (`e2e/visual-regression.spec.ts`).
+
+## How it works
+
+Screenshots are captured at three viewports (mobile 375×812, tablet 768×1024,
+desktop 1440×900) and in both dark and light colour schemes, for the following pages:
+
+- Dashboard (`/`)
+- Price Detail (`/prices/BTC%2FUSD`)
+- API Docs (`/api-docs`)
+- 404 Not Found
+
+The tests compare the current render against these baselines using Playwright's
+built-in pixel comparison engine. CI fails if any screenshot differs beyond a
+**2 % pixel-ratio** threshold (configurable per-snapshot via `maxDiffPixelRatio`).
+
+## Updating baselines
+
+Run the helper script from the project root:
+
+```sh
+npm run test:e2e:visual:update
+```
+
+This builds the app (if needed), runs Playwright with `--update-snapshots`, and
+prints instructions for reviewing and committing the new screenshots.
+
+After reviewing the diffs in the HTML report:
+
+```sh
+git add e2e/snapshots/
+git commit -m "chore: update visual regression baselines"
+```
+
+## CI behaviour
+
+The `visual-regression` job in `.github/workflows/ci.yml` runs after the build
+succeeds. It uploads the Playwright HTML report as the `visual-regression-report`
+artifact regardless of outcome, so you can inspect pixel diffs in the GitHub
+Actions UI. On failure it also uploads `test-results/` as `visual-regression-diffs`.
+
+The job is marked `continue-on-error: true` so that a screenshot drift on a PR
+is visible but does not block the merge gate — the developer must deliberately
+update baselines and commit them.

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * Visual Regression Tests
+ *
+ * Captures screenshots of key pages at multiple viewports (mobile, tablet, desktop)
+ * and in both dark/light mode. Compares against baseline snapshots stored in
+ * e2e/snapshots/. CI fails if pixel diff exceeds the configured threshold.
+ *
+ * Baseline update workflow:
+ *   npx playwright test --update-snapshots
+ *   git add e2e/snapshots/
+ *   git commit -m "chore: update visual regression baselines"
+ *
+ * The --update-snapshots flag regenerates all baselines. After reviewing the
+ * diffs in the HTML report, commit the approved screenshots.
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+
+// ── Viewport definitions ────────────────────────────────────────────────────
+
+const VIEWPORTS = {
+  mobile: { width: 375, height: 812 },
+  tablet: { width: 768, height: 1024 },
+  desktop: { width: 1440, height: 900 },
+} as const
+
+// ── Screenshot helper ───────────────────────────────────────────────────────
+
+/**
+ * Waits for the page to reach a stable visual state before capturing.
+ * Stops animations, waits for network idle and any pending fonts/images.
+ */
+async function stableScreenshot(page: Page): Promise<Buffer> {
+  // Freeze CSS animations and transitions so screenshots are deterministic
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0s !important;
+        animation-delay: 0s !important;
+        transition-duration: 0s !important;
+        transition-delay: 0s !important;
+      }
+    `,
+  })
+
+  // Wait for fonts and lazy images
+  await page.evaluate(() => document.fonts.ready)
+  await page.waitForLoadState('networkidle')
+
+  return page.screenshot({ fullPage: true })
+}
+
+/**
+ * Forces the colour-scheme to light or dark via a `<meta>` + CSS class override.
+ * The app respects `prefers-color-scheme` through Tailwind's `dark:` variant.
+ */
+async function setColorScheme(page: Page, scheme: 'light' | 'dark'): Promise<void> {
+  await page.emulateMedia({ colorScheme: scheme })
+  // Also set the data-theme attribute used by some Tailwind setups
+  await page.evaluate((s) => {
+    document.documentElement.setAttribute('data-theme', s)
+    document.documentElement.classList.toggle('dark', s === 'dark')
+  }, scheme)
+}
+
+// ── Wait helper ─────────────────────────────────────────────────────────────
+
+async function waitForPageReady(page: Page): Promise<void> {
+  await page.waitForLoadState('networkidle')
+  // Allow up to 10 s for the main heading or a known content element
+  await Promise.race([
+    page.getByRole('heading', { name: 'Price Oracle Dashboard' }).waitFor({ timeout: 10_000 }).catch(() => {}),
+    page.getByRole('main').waitFor({ timeout: 10_000 }).catch(() => {}),
+  ])
+}
+
+// ── Dashboard — viewport-specific screenshots ───────────────────────────────
+
+for (const [name, size] of Object.entries(VIEWPORTS) as [keyof typeof VIEWPORTS, typeof VIEWPORTS[keyof typeof VIEWPORTS]][]) {
+  test.describe(`Dashboard — ${name} (${size.width}×${size.height})`, () => {
+    test.use({ viewport: size })
+
+    test(`dark mode baseline — ${name}`, async ({ page }) => {
+      await setColorScheme(page, 'dark')
+      await page.goto('/')
+      await waitForPageReady(page)
+
+      const screenshot = await stableScreenshot(page)
+      expect(screenshot).toMatchSnapshot(`dashboard-dark-${name}.png`, {
+        maxDiffPixelRatio: 0.02,
+      })
+    })
+
+    test(`light mode baseline — ${name}`, async ({ page }) => {
+      await setColorScheme(page, 'light')
+      await page.goto('/')
+      await waitForPageReady(page)
+
+      const screenshot = await stableScreenshot(page)
+      expect(screenshot).toMatchSnapshot(`dashboard-light-${name}.png`, {
+        maxDiffPixelRatio: 0.02,
+      })
+    })
+  })
+}
+
+// ── 404 Not-Found page ──────────────────────────────────────────────────────
+
+test.describe('404 page', () => {
+  test('dark mode baseline — desktop', async ({ page }) => {
+    test.info().annotations.push({ type: 'description', description: 'Visual baseline for 404 page' })
+    await page.setViewportSize(VIEWPORTS.desktop)
+    await setColorScheme(page, 'dark')
+    await page.goto('/this-route-does-not-exist-xyz')
+    await page.waitForLoadState('networkidle')
+    await page.getByRole('heading', { name: /404|not found/i }).waitFor({ timeout: 10_000 })
+
+    const screenshot = await stableScreenshot(page)
+    expect(screenshot).toMatchSnapshot('not-found-dark-desktop.png', {
+      maxDiffPixelRatio: 0.02,
+    })
+  })
+
+  test('light mode baseline — desktop', async ({ page }) => {
+    await page.setViewportSize(VIEWPORTS.desktop)
+    await setColorScheme(page, 'light')
+    await page.goto('/this-route-does-not-exist-xyz')
+    await page.waitForLoadState('networkidle')
+    await page.getByRole('heading', { name: /404|not found/i }).waitFor({ timeout: 10_000 })
+
+    const screenshot = await stableScreenshot(page)
+    expect(screenshot).toMatchSnapshot('not-found-light-desktop.png', {
+      maxDiffPixelRatio: 0.02,
+    })
+  })
+})
+
+// ── Price Detail page ───────────────────────────────────────────────────────
+
+test.describe('Price Detail page', () => {
+  test('dark mode baseline — desktop', async ({ page }) => {
+    await page.setViewportSize(VIEWPORTS.desktop)
+    await setColorScheme(page, 'dark')
+    await page.goto('/prices/BTC%2FUSD')
+    await page.waitForLoadState('networkidle')
+    // Accept the page whether it shows chart or an error/loading state
+    await Promise.race([
+      page.getByRole('button', { name: /go back/i }).waitFor({ timeout: 10_000 }).catch(() => {}),
+      page.getByRole('alert').waitFor({ timeout: 10_000 }).catch(() => {}),
+    ])
+
+    const screenshot = await stableScreenshot(page)
+    expect(screenshot).toMatchSnapshot('price-detail-dark-desktop.png', {
+      maxDiffPixelRatio: 0.02,
+    })
+  })
+
+  test('light mode baseline — desktop', async ({ page }) => {
+    await page.setViewportSize(VIEWPORTS.desktop)
+    await setColorScheme(page, 'light')
+    await page.goto('/prices/BTC%2FUSD')
+    await page.waitForLoadState('networkidle')
+    await Promise.race([
+      page.getByRole('button', { name: /go back/i }).waitFor({ timeout: 10_000 }).catch(() => {}),
+      page.getByRole('alert').waitFor({ timeout: 10_000 }).catch(() => {}),
+    ])
+
+    const screenshot = await stableScreenshot(page)
+    expect(screenshot).toMatchSnapshot('price-detail-light-desktop.png', {
+      maxDiffPixelRatio: 0.02,
+    })
+  })
+
+  test('dark mode baseline — mobile', async ({ page }) => {
+    await page.setViewportSize(VIEWPORTS.mobile)
+    await setColorScheme(page, 'dark')
+    await page.goto('/prices/BTC%2FUSD')
+    await page.waitForLoadState('networkidle')
+    await Promise.race([
+      page.getByRole('button', { name: /go back/i }).waitFor({ timeout: 10_000 }).catch(() => {}),
+      page.getByRole('alert').waitFor({ timeout: 10_000 }).catch(() => {}),
+    ])
+
+    const screenshot = await stableScreenshot(page)
+    expect(screenshot).toMatchSnapshot('price-detail-dark-mobile.png', {
+      maxDiffPixelRatio: 0.02,
+    })
+  })
+})
+
+// ── API Docs page ───────────────────────────────────────────────────────────
+
+test.describe('API Docs page', () => {
+  test('dark mode baseline — desktop', async ({ page }) => {
+    await page.setViewportSize(VIEWPORTS.desktop)
+    await setColorScheme(page, 'dark')
+    await page.goto('/api-docs')
+    await page.waitForLoadState('networkidle')
+    await page.getByRole('main').waitFor({ timeout: 10_000 }).catch(() => {})
+
+    const screenshot = await stableScreenshot(page)
+    expect(screenshot).toMatchSnapshot('api-docs-dark-desktop.png', {
+      maxDiffPixelRatio: 0.02,
+    })
+  })
+
+  test('light mode baseline — desktop', async ({ page }) => {
+    await page.setViewportSize(VIEWPORTS.desktop)
+    await setColorScheme(page, 'light')
+    await page.goto('/api-docs')
+    await page.waitForLoadState('networkidle')
+    await page.getByRole('main').waitFor({ timeout: 10_000 }).catch(() => {})
+
+    const screenshot = await stableScreenshot(page)
+    expect(screenshot).toMatchSnapshot('api-docs-light-desktop.png', {
+      maxDiffPixelRatio: 0.02,
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "test:e2e:chromium": "playwright test --project=chromium",
     "test:e2e:firefox": "playwright test --project=firefox",
     "test:e2e:webkit": "playwright test --project=webkit",
+    "test:e2e:visual": "playwright test --project=visual-regression",
+    "test:e2e:visual:update": "node scripts/update-visual-baselines.js",
     "generate:openapi": "npx openapi-typescript ${BACKEND_OPENAPI_URL:-http://localhost:3000/openapi.json} --output src/api/openapi-types.ts"
   },
   "size-limit": [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:e2e:webkit": "playwright test --project=webkit",
     "test:e2e:visual": "playwright test --project=visual-regression",
     "test:e2e:visual:update": "node scripts/update-visual-baselines.js",
+    "check:api-version": "node scripts/check-api-version.js",
     "generate:openapi": "npx openapi-typescript ${BACKEND_OPENAPI_URL:-http://localhost:3000/openapi.json} --output src/api/openapi-types.ts"
   },
   "size-limit": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,15 +6,48 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'list',
+  reporter: process.env.CI
+    ? [['list'], ['html', { outputFolder: 'reports/playwright', open: 'never' }]]
+    : 'list',
   use: {
     baseURL: 'http://localhost:4173',
     trace: 'on-first-retry',
   },
+  // Visual-regression snapshot configuration
+  // Snapshots are stored next to the spec files under e2e/snapshots/
+  snapshotDir: './e2e/snapshots',
+  // Compare screenshots with a 2 % pixel-ratio tolerance by default.
+  // Per-snapshot overrides in the spec take precedence.
+  expect: {
+    toMatchSnapshot: {
+      maxDiffPixelRatio: 0.02,
+      // Pixel threshold: ignore sub-pixel colour differences (0–1 scale)
+      threshold: 0.1,
+    },
+  },
   projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
-    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
-    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    // Visual regression runs on Chromium only to produce deterministic baselines.
+    // Full cross-browser E2E coverage is handled by the other projects below.
+    {
+      name: 'visual-regression',
+      use: { ...devices['Desktop Chrome'] },
+      testMatch: '**/visual-regression.spec.ts',
+    },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      testIgnore: '**/visual-regression.spec.ts',
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+      testIgnore: '**/visual-regression.spec.ts',
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+      testIgnore: '**/visual-regression.spec.ts',
+    },
   ],
   webServer: {
     command: 'npm run preview',

--- a/scripts/check-api-version.js
+++ b/scripts/check-api-version.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * check-api-version.js
+ *
+ * CI script that verifies the frontend's declared API version range is
+ * compatible with the running backend. Exits non-zero if incompatible.
+ *
+ * Usage:
+ *   node scripts/check-api-version.js [--api-url <url>]
+ *
+ * Environment variables:
+ *   VITE_API_URL  — Base URL of the API server (default: http://localhost:3000)
+ *
+ * The script probes the /api/version endpoint (then /health as fallback)
+ * and checks the X-API-Version response header or JSON body.
+ *
+ * Exit codes:
+ *   0 — compatible or unknown (non-blocking)
+ *   1 — incompatible (blocking)
+ */
+
+import { parseArgs } from 'node:util'
+
+// ── Inline version constants (mirror of src/api/version.ts) ──────────────────
+// These are intentionally duplicated so this script runs without transpilation.
+const CURRENT_API_VERSION = '1.0'
+const MIN_COMPATIBLE_API_VERSION = '1.0'
+const MAX_COMPATIBLE_API_VERSION = '1.99'
+
+function parseMajorMinor(version) {
+  const parts = String(version).trim().split('.')
+  const major = parseInt(parts[0], 10)
+  const minor = parts[1] !== undefined ? parseInt(parts[1], 10) : 0
+  if (isNaN(major) || isNaN(minor)) return null
+  return [major, minor]
+}
+
+function checkCompatibility(serverVersion) {
+  const server = parseMajorMinor(serverVersion)
+  const min = parseMajorMinor(MIN_COMPATIBLE_API_VERSION)
+  const max = parseMajorMinor(MAX_COMPATIBLE_API_VERSION)
+  const current = parseMajorMinor(CURRENT_API_VERSION)
+
+  if (!server || !min || !max || !current) return 'unknown'
+
+  const [sMajor, sMinor] = server
+  const [minMajor] = min
+  const [maxMajor] = max
+  const [, currentMinor] = current
+
+  if (sMajor < minMajor || sMajor > maxMajor) return 'incompatible'
+  if (sMinor !== currentMinor) return 'minor-mismatch'
+  return 'compatible'
+}
+
+// ── CLI args ─────────────────────────────────────────────────────────────────
+
+const { values } = parseArgs({
+  options: {
+    'api-url': { type: 'string', short: 'u' },
+    'skip-on-unavailable': { type: 'boolean', default: true },
+  },
+  allowPositionals: false,
+})
+
+const apiUrl = values['api-url'] || process.env.VITE_API_URL || 'http://localhost:3000'
+const skipOnUnavailable = values['skip-on-unavailable'] !== false
+
+// ── Probe helper ─────────────────────────────────────────────────────────────
+
+async function fetchWithTimeout(url, opts = {}, timeoutMs = 10_000) {
+  const controller = new AbortController()
+  const id = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { ...opts, signal: controller.signal })
+  } finally {
+    clearTimeout(id)
+  }
+}
+
+async function detectServerVersion(base) {
+  const headers = {
+    'Accept': 'application/json',
+    'Accept-Version': CURRENT_API_VERSION,
+  }
+
+  // 1. /api/version endpoint
+  try {
+    const res = await fetchWithTimeout(`${base}/api/version`, { headers })
+    if (res.ok) {
+      const header = res.headers.get('X-API-Version')
+      if (header) return header
+      const json = await res.json().catch(() => null)
+      if (json?.version) return String(json.version)
+      if (json?.apiVersion) return String(json.apiVersion)
+    }
+  } catch (e) {
+    if (e.name === 'AbortError') {
+      console.warn(`[api-version-check] Timeout reaching ${base}/api/version`)
+    }
+  }
+
+  // 2. /health fallback
+  const healthBase = base.replace(/\/api$/, '')
+  try {
+    const res = await fetchWithTimeout(`${healthBase}/health`, { headers })
+    const header = res.headers.get('X-API-Version')
+    if (header) return header
+  } catch (e) {
+    if (e.name === 'AbortError') {
+      console.warn(`[api-version-check] Timeout reaching ${healthBase}/health`)
+    }
+  }
+
+  return null
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+console.log(`[api-version-check] Probing ${apiUrl} …`)
+console.log(`[api-version-check] Frontend targets API v${CURRENT_API_VERSION} (supports v${MIN_COMPATIBLE_API_VERSION}–v${MAX_COMPATIBLE_API_VERSION})`)
+
+const serverVersion = await detectServerVersion(apiUrl).catch(() => null)
+
+if (serverVersion === null) {
+  if (skipOnUnavailable) {
+    console.warn('[api-version-check] ⚠ Could not reach the API server — skipping version check.')
+    console.warn('[api-version-check]   Set --no-skip-on-unavailable to make this a hard failure.')
+    process.exit(0)
+  } else {
+    console.error('[api-version-check] ✗ Could not reach the API server and --skip-on-unavailable is false.')
+    process.exit(1)
+  }
+}
+
+const compat = checkCompatibility(serverVersion)
+
+if (compat === 'compatible') {
+  console.log(`[api-version-check] ✅ Compatible — server v${serverVersion} matches frontend v${CURRENT_API_VERSION}`)
+  process.exit(0)
+}
+
+if (compat === 'minor-mismatch') {
+  console.warn(`[api-version-check] ⚠ Minor mismatch — server v${serverVersion} vs frontend v${CURRENT_API_VERSION}`)
+  console.warn('[api-version-check]   Minor mismatches are usually backwards-compatible. Continuing.')
+  process.exit(0)
+}
+
+if (compat === 'unknown') {
+  console.warn(`[api-version-check] ⚠ Unknown version format "${serverVersion}" — could not determine compatibility.`)
+  process.exit(0)
+}
+
+// incompatible
+console.error(`[api-version-check] ✗ INCOMPATIBLE — server v${serverVersion} is outside the supported range v${MIN_COMPATIBLE_API_VERSION}–v${MAX_COMPATIBLE_API_VERSION}`)
+console.error('[api-version-check]   Update the backend or bump MIN/MAX_COMPATIBLE_API_VERSION in src/api/version.ts')
+process.exit(1)

--- a/scripts/update-visual-baselines.js
+++ b/scripts/update-visual-baselines.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * update-visual-baselines.js
+ *
+ * Regenerates all Playwright visual regression baselines and prints
+ * instructions for reviewing and committing the updated screenshots.
+ *
+ * Usage:
+ *   node scripts/update-visual-baselines.js
+ *
+ * The script builds the app (if not already built), starts the preview server
+ * in the background, runs Playwright with --update-snapshots, then instructs
+ * the developer to review and commit the changed files.
+ */
+
+import { execSync, spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const ROOT = resolve(import.meta.dirname, '..')
+const DIST = resolve(ROOT, 'dist')
+
+function run(cmd, opts = {}) {
+  console.log(`\n> ${cmd}`)
+  execSync(cmd, { stdio: 'inherit', cwd: ROOT, ...opts })
+}
+
+// 1. Build if dist/ doesn't exist
+if (!existsSync(DIST)) {
+  console.log('No dist/ found. Building first…')
+  run('npm run build')
+} else {
+  console.log('Using existing dist/. Run "npm run build" to refresh it first if needed.')
+}
+
+// 2. Run Playwright with --update-snapshots for the visual-regression project
+console.log('\nRegenerating visual baselines (project: visual-regression)…')
+const pw = spawn(
+  'npx',
+  ['playwright', 'test', '--project=visual-regression', '--update-snapshots'],
+  { stdio: 'inherit', cwd: ROOT, shell: true },
+)
+
+pw.on('close', (code) => {
+  if (code !== 0) {
+    console.error(`\nPlaywright exited with code ${code}. Some baselines may not have been updated.`)
+    process.exit(code ?? 1)
+  }
+
+  console.log(`
+─────────────────────────────────────────────────────────
+  Baselines updated in: e2e/snapshots/
+
+  Next steps:
+  1. Review the new screenshots in e2e/snapshots/
+  2. Open the HTML report to visually inspect diffs:
+       npx playwright show-report reports/playwright
+  3. If the changes look correct, commit:
+       git add e2e/snapshots/
+       git commit -m "chore: update visual regression baselines"
+─────────────────────────────────────────────────────────
+`)
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,9 @@ import { useWebVitals } from './hooks/useWebVitals'
 import { useAccessibility } from './hooks/useAccessibility'
 import { initAnalytics, trackPageview } from './hooks/useAnalytics'
 import { usePerformanceMonitor } from './hooks/usePerformanceMonitor'
+import { useInitApiVersion } from './hooks/useApiVersion'
 import { PerformanceOverlay } from './components/PerformanceOverlay'
+import { ApiVersionBanner } from './components/ApiVersionBanner'
 import type { ErrorInfo } from 'react'
 
 // Route-level code splitting: each page becomes its own chunk.
@@ -57,6 +59,7 @@ export function AppContent(): ReactElement {
   return (
     <ErrorBoundary key={location.key}>
       <AlertsProvider>
+        <ApiVersionBanner />
         <Layout>
           <Routes>
             <Route
@@ -117,6 +120,7 @@ export function AppContent(): ReactElement {
 export default function App(): ReactElement {
   useWebVitals()
   usePerformanceMonitor()
+  useInitApiVersion()
   initAnalytics()
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ import { PriceProvider } from './context/PriceContext'
 import { useWebVitals } from './hooks/useWebVitals'
 import { useAccessibility } from './hooks/useAccessibility'
 import { initAnalytics, trackPageview } from './hooks/useAnalytics'
+import { usePerformanceMonitor } from './hooks/usePerformanceMonitor'
+import { PerformanceOverlay } from './components/PerformanceOverlay'
 import type { ErrorInfo } from 'react'
 
 // Route-level code splitting: each page becomes its own chunk.
@@ -114,6 +116,7 @@ export function AppContent(): ReactElement {
 
 export default function App(): ReactElement {
   useWebVitals()
+  usePerformanceMonitor()
   initAnalytics()
 
   return (
@@ -123,6 +126,7 @@ export default function App(): ReactElement {
           <ToastProvider>
             <PriceProvider>
               <AppContent />
+              {import.meta.env.DEV && <PerformanceOverlay />}
             </PriceProvider>
           </ToastProvider>
         </PreferencesProvider>

--- a/src/api/rest.ts
+++ b/src/api/rest.ts
@@ -9,6 +9,7 @@ import {
   HealthSchema,
 } from './schemas'
 import { validate } from './validate'
+import { getApiVersionInfo, getAcceptVersionHeader } from './version'
 
 /** Categorical classification of an {@link ApiError}, derived from the HTTP status. */
 export type ApiErrorCode =
@@ -114,17 +115,38 @@ function setRateLimitInfo(response: Response): void {
 async function request<T>(path: string, init?: RequestInit, signal?: AbortSignal): Promise<T> {
   const url = `${config.apiUrl}${path}`
 
+  // Include the Accept-Version header on every request so the server can
+  // route to the appropriate handler version or return a version error.
+  const versionInfo = getApiVersionInfo()
+  const acceptVersion = getAcceptVersionHeader(versionInfo?.serverVersion)
+
   try {
     const res = await fetchWithRetry(url, {
       ...init,
       signal,
-      headers: { 'Content-Type': 'application/json', ...init?.headers },
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept-Version': acceptVersion,
+        ...init?.headers,
+      },
     })
 
     setRateLimitInfo(res)
 
     if (!res.ok) {
       const text = await res.text().catch(() => '')
+
+      // 406 Not Acceptable / 409 Conflict — server cannot satisfy the requested version
+      if (res.status === 406 || res.status === 409) {
+        const serverVersion = res.headers.get('X-API-Version') ?? 'unknown'
+        throw new ApiError(
+          `API version mismatch: server is at v${serverVersion}, client requested v${acceptVersion}. ` +
+          `Please update the frontend or backend to a compatible version.`,
+          res.status,
+          'UNKNOWN_ERROR',
+        )
+      }
+
       throw new ApiError(`${res.status} ${res.statusText}: ${text}`, res.status, statusToErrorCode(res.status))
     }
 

--- a/src/api/version.ts
+++ b/src/api/version.ts
@@ -1,0 +1,297 @@
+/**
+ * api/version.ts
+ *
+ * API versioning support for the Stellar Unified Price Oracle frontend.
+ *
+ * Strategy:
+ * - The frontend declares the API version it targets via `CURRENT_API_VERSION`.
+ * - Every REST request includes an `Accept-Version` header so the server can
+ *   respond with the closest compatible version it supports.
+ * - On startup, `detectApiVersion()` pings the `/api/version` endpoint (or
+ *   `/health` as fallback) to read the `X-API-Version` response header. If the
+ *   server version is incompatible the UI shows a clear error and gracefully
+ *   degrades (no data-fetch errors silently swallowed).
+ * - `migrateApiPayload()` applies lightweight shape transformations when the
+ *   detected server version differs from the current target.
+ *
+ * Version numbering follows semver MAJOR.MINOR convention. A MAJOR mismatch
+ * is considered breaking (incompatible); a MINOR mismatch is a warning.
+ */
+
+import { config } from '../config'
+
+// ── Version constants ────────────────────────────────────────────────────────
+
+/** The API version this frontend build targets. */
+export const CURRENT_API_VERSION = '1.0'
+
+/** Minimum server API version this frontend can work with. */
+export const MIN_COMPATIBLE_API_VERSION = '1.0'
+
+/** Maximum server API version this frontend has been tested against. */
+export const MAX_COMPATIBLE_API_VERSION = '1.99'
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type VersionCompatibility = 'compatible' | 'minor-mismatch' | 'incompatible' | 'unknown'
+
+export interface ApiVersionInfo {
+  /** Version reported by the server, or null if the endpoint didn't return one */
+  serverVersion: string | null
+  /** Version the frontend currently targets */
+  clientVersion: string
+  compatibility: VersionCompatibility
+  /** Human-readable description of the compatibility status */
+  message: string
+  /** Whether any features should be disabled due to incompatibility */
+  degraded: boolean
+  detectedAt: number
+}
+
+// ── Semver helpers ───────────────────────────────────────────────────────────
+
+function parseMajorMinor(version: string): [number, number] | null {
+  const parts = version.trim().split('.')
+  const major = parseInt(parts[0], 10)
+  const minor = parts[1] !== undefined ? parseInt(parts[1], 10) : 0
+  if (isNaN(major) || isNaN(minor)) return null
+  return [major, minor]
+}
+
+/**
+ * Determines compatibility between the reported server version and the
+ * version range the frontend supports.
+ */
+export function checkVersionCompatibility(serverVersion: string): VersionCompatibility {
+  const server = parseMajorMinor(serverVersion)
+  const min = parseMajorMinor(MIN_COMPATIBLE_API_VERSION)
+  const max = parseMajorMinor(MAX_COMPATIBLE_API_VERSION)
+  const current = parseMajorMinor(CURRENT_API_VERSION)
+
+  if (!server || !min || !max || !current) return 'unknown'
+
+  const [sMajor, sMinor] = server
+  const [minMajor] = min
+  const [maxMajor] = max
+  const [, currentMinor] = current
+
+  // Major version outside supported range → incompatible
+  if (sMajor < minMajor || sMajor > maxMajor) return 'incompatible'
+
+  // Same major, minor differs → warn but allow
+  if (sMinor !== currentMinor) return 'minor-mismatch'
+
+  return 'compatible'
+}
+
+function buildVersionInfo(serverVersion: string | null): ApiVersionInfo {
+  if (serverVersion === null) {
+    return {
+      serverVersion: null,
+      clientVersion: CURRENT_API_VERSION,
+      compatibility: 'unknown',
+      message:
+        'Could not determine the API version. The app will continue but some features may not work correctly.',
+      degraded: false,
+      detectedAt: Date.now(),
+    }
+  }
+
+  const compatibility = checkVersionCompatibility(serverVersion)
+
+  const messages: Record<VersionCompatibility, string> = {
+    compatible: `API version ${serverVersion} is fully compatible.`,
+    'minor-mismatch': `API version ${serverVersion} differs from the expected ${CURRENT_API_VERSION}. Minor version mismatches are usually compatible — if you see unexpected behaviour please update either the frontend or backend.`,
+    incompatible: `API version ${serverVersion} is incompatible with this frontend (requires ${MIN_COMPATIBLE_API_VERSION}–${MAX_COMPATIBLE_API_VERSION}). Please update the backend or frontend to a compatible version.`,
+    unknown: `Unknown API version format "${serverVersion}". Could not determine compatibility.`,
+  }
+
+  return {
+    serverVersion,
+    clientVersion: CURRENT_API_VERSION,
+    compatibility,
+    message: messages[compatibility],
+    degraded: compatibility === 'incompatible',
+    detectedAt: Date.now(),
+  }
+}
+
+// ── Feature detection ─────────────────────────────────────────────────────────
+
+/**
+ * Pings the API version endpoint on startup to detect the server version.
+ *
+ * Resolution order:
+ * 1. GET /api/version   — dedicated version endpoint (returns { version: "..." })
+ * 2. GET /health        — reads `X-API-Version` response header
+ *
+ * Returns an {@link ApiVersionInfo} describing the compatibility status.
+ * Never throws — on any error it returns an 'unknown' compatibility info so the
+ * app can continue operating.
+ */
+export async function detectApiVersion(signal?: AbortSignal): Promise<ApiVersionInfo> {
+  // 1. Try dedicated /api/version endpoint
+  try {
+    const res = await fetch(`${config.apiUrl}/api/version`, {
+      signal,
+      headers: {
+        'Accept': 'application/json',
+        'Accept-Version': CURRENT_API_VERSION,
+      },
+    })
+    if (res.ok) {
+      // Check response header first (takes precedence over body)
+      const headerVersion = res.headers.get('X-API-Version')
+      if (headerVersion) return buildVersionInfo(headerVersion)
+
+      // Fall through to parse JSON body
+      const json = await res.json().catch(() => null) as Record<string, unknown> | null
+      const bodyVersion =
+        typeof json?.version === 'string' ? json.version :
+        typeof json?.apiVersion === 'string' ? json.apiVersion :
+        null
+      if (bodyVersion) return buildVersionInfo(bodyVersion)
+    }
+  } catch {
+    // network error or AbortError — try fallback
+    if (signal?.aborted) return buildVersionInfo(null)
+  }
+
+  // 2. Fall back to /health — read X-API-Version header
+  try {
+    const res = await fetch(`${config.apiUrl.replace(/\/api$/, '')}/health`, {
+      signal,
+      headers: { 'Accept-Version': CURRENT_API_VERSION },
+    })
+    const headerVersion = res.headers.get('X-API-Version')
+    if (headerVersion) return buildVersionInfo(headerVersion)
+  } catch {
+    if (signal?.aborted) return buildVersionInfo(null)
+  }
+
+  return buildVersionInfo(null)
+}
+
+// ── Accept-Version header value ───────────────────────────────────────────────
+
+/**
+ * Returns the `Accept-Version` header value to include on every API request.
+ * Uses the current version by default; pass a detected server version to pin
+ * requests to that version if the server supports it.
+ */
+export function getAcceptVersionHeader(serverVersion?: string | null): string {
+  // If the server reported a compatible but different minor version, accept that too
+  if (serverVersion && checkVersionCompatibility(serverVersion) === 'minor-mismatch') {
+    return serverVersion
+  }
+  return CURRENT_API_VERSION
+}
+
+// ── Migration utilities ────────────────────────────────────────────────────────
+
+/**
+ * Applies shape transformations to a raw API payload when the server reports
+ * a different version from the frontend target. Useful for backwards compatibility
+ * when the backend has not yet been updated.
+ *
+ * Add cases here as the API evolves. Each migration is a pure function that
+ * takes the raw payload and returns the normalised shape.
+ *
+ * @param payload  - Raw object returned by the API
+ * @param fromVersion - The server version the payload came from
+ * @param toVersion   - The version shape we want (defaults to CURRENT_API_VERSION)
+ */
+export function migrateApiPayload<T extends Record<string, unknown>>(
+  payload: T,
+  fromVersion: string,
+  toVersion: string = CURRENT_API_VERSION,
+): T {
+  const from = parseMajorMinor(fromVersion)
+  const to = parseMajorMinor(toVersion)
+  if (!from || !to) return payload
+
+  let result: Record<string, unknown> = { ...payload }
+
+  // ── v0.x → v1.0 ────────────────────────────────────────────────────────────
+  // Example: pre-v1.0 API used `pair` instead of `assetPair`
+  if (from[0] === 0 && to[0] >= 1) {
+    if ('pair' in result && !('assetPair' in result)) {
+      result = { ...result, assetPair: result['pair'] }
+    }
+    // pre-v1.0 used integer prices multiplied by 1e6
+    if (typeof result['price'] === 'number' && result['price'] > 1_000_000) {
+      result = { ...result, price: (result['price'] as number) / 1_000_000 }
+    }
+    // pre-v1.0 confidence was 0-100 not 0-1
+    if (typeof result['confidence'] === 'number' && (result['confidence'] as number) > 1) {
+      result = { ...result, confidence: (result['confidence'] as number) / 100 }
+    }
+  }
+
+  return result as T
+}
+
+// ── Version state store ────────────────────────────────────────────────────────
+
+/**
+ * Module-level singleton holding the most recently detected API version info.
+ * Updated by `initApiVersionDetection()` on app startup.
+ */
+let _currentVersionInfo: ApiVersionInfo | null = null
+
+type VersionListener = (info: ApiVersionInfo) => void
+const versionListeners = new Set<VersionListener>()
+
+export function getApiVersionInfo(): ApiVersionInfo | null {
+  return _currentVersionInfo
+}
+
+export function subscribeApiVersion(listener: VersionListener): () => void {
+  versionListeners.add(listener)
+  if (_currentVersionInfo) listener(_currentVersionInfo)
+  return () => versionListeners.delete(listener)
+}
+
+function setVersionInfo(info: ApiVersionInfo): void {
+  _currentVersionInfo = info
+  versionListeners.forEach((l) => l(info))
+}
+
+/**
+ * Runs API version detection on startup and updates the global version state.
+ * Safe to call multiple times — concurrent calls are coalesced.
+ */
+let _detectionInFlight: Promise<ApiVersionInfo> | null = null
+
+export async function initApiVersionDetection(signal?: AbortSignal): Promise<ApiVersionInfo> {
+  if (_detectionInFlight) return _detectionInFlight
+  _detectionInFlight = detectApiVersion(signal).then((info) => {
+    setVersionInfo(info)
+    _detectionInFlight = null
+
+    if (import.meta.env.DEV) {
+      const icon = info.compatibility === 'compatible' ? '✅' : info.compatibility === 'incompatible' ? '❌' : '⚠️'
+      console.info(`[API Version] ${icon} Server: ${info.serverVersion ?? 'unknown'} / Client: ${info.clientVersion} — ${info.compatibility}`)
+    }
+
+    return info
+  })
+  return _detectionInFlight
+}
+
+// ── CI / testing helper ───────────────────────────────────────────────────────
+
+/**
+ * Validates that a given version string is compatible with the current frontend.
+ * Throws with a descriptive message if incompatible. Use in CI scripts or tests.
+ */
+export function assertVersionCompatible(serverVersion: string): void {
+  const compat = checkVersionCompatibility(serverVersion)
+  if (compat === 'incompatible') {
+    throw new Error(
+      `API version incompatibility: server reports v${serverVersion}, ` +
+      `frontend requires v${MIN_COMPATIBLE_API_VERSION}–${MAX_COMPATIBLE_API_VERSION}. ` +
+      `Update the backend or frontend to resolve this.`,
+    )
+  }
+}

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -3,6 +3,7 @@ import type { WsMessage, WsSubscribeMessage, WsUnsubscribeMessage } from '../typ
 import { wsAnalytics } from '../utils/wsAnalytics'
 import { rateLimitManager } from './rateLimit'
 import { WsMessageSchema } from './schemas'
+import { recordWsMessageTiming } from '../utils/performanceMonitor'
 
 type MessageHandler = (msg: WsMessage) => void
 type StatusHandler = (status: ConnectionStatus) => void
@@ -236,6 +237,9 @@ export class WebSocketClient {
     // `messageHandlersRef`, so newly registered or updated handlers are always used.
     const messageHandlersRef = this.messageHandlersRef
     this.ws.onmessage = async (e) => {
+      // Capture the start time for processing-time measurement
+      const messageStart = performance.now()
+
       // Any inbound message resets the heartbeat timeout
       this.resetHeartbeatTimeout()
 
@@ -268,6 +272,9 @@ export class WebSocketClient {
 
         const msg: WsMessage = parsed.data
         messageHandlersRef.forEach((h) => h(msg))
+
+        // Record end-to-end processing time for this message
+        recordWsMessageTiming(messageStart, typeof raw['type'] === 'string' ? raw['type'] : undefined)
       } catch {
         // ignore malformed messages
       }

--- a/src/components/ApiVersionBanner.tsx
+++ b/src/components/ApiVersionBanner.tsx
@@ -1,0 +1,111 @@
+/**
+ * ApiVersionBanner
+ *
+ * Displays a persistent banner when the detected API version is incompatible
+ * or when there is a minor mismatch that users should be aware of.
+ *
+ * - Incompatible: full-width red error banner, not dismissible.
+ *   The app enters a degraded state and data fetching may fail.
+ * - Minor mismatch: amber warning banner, dismissible per session.
+ * - Compatible / unknown: renders nothing.
+ */
+
+import { memo, useState, useCallback } from 'react'
+import { useApiVersion } from '../hooks/useApiVersion'
+import type { VersionCompatibility } from '../api/version'
+
+const DISMISS_STORAGE_KEY = 'api_version_warning_dismissed'
+
+function getDismissedVersion(): string | null {
+  try {
+    return sessionStorage.getItem(DISMISS_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+function setDismissedVersion(version: string): void {
+  try {
+    sessionStorage.setItem(DISMISS_STORAGE_KEY, version)
+  } catch {
+    // ignore
+  }
+}
+
+const bannerStyles: Record<VersionCompatibility, string> = {
+  incompatible:
+    'border-red-500/50 bg-red-950/80 text-red-200',
+  'minor-mismatch':
+    'border-amber-500/40 bg-amber-950/70 text-amber-200',
+  compatible: '',
+  unknown: '',
+}
+
+const iconByCompatibility: Record<VersionCompatibility, string> = {
+  incompatible: '❌',
+  'minor-mismatch': '⚠️',
+  compatible: '',
+  unknown: '',
+}
+
+export const ApiVersionBanner = memo(function ApiVersionBanner() {
+  const info = useApiVersion()
+  const [dismissed, setDismissed] = useState<string | null>(getDismissedVersion)
+
+  const handleDismiss = useCallback(() => {
+    if (info?.serverVersion) {
+      setDismissedVersion(info.serverVersion)
+      setDismissed(info.serverVersion)
+    }
+  }, [info])
+
+  if (!info) return null
+  if (info.compatibility === 'compatible' || info.compatibility === 'unknown') return null
+
+  // Don't re-show the warning for the same server version the user already dismissed
+  if (info.compatibility === 'minor-mismatch' && dismissed === info.serverVersion) return null
+
+  const canDismiss = info.compatibility === 'minor-mismatch'
+  const icon = iconByCompatibility[info.compatibility]
+  const style = bannerStyles[info.compatibility]
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className={`flex items-start gap-3 border-b px-4 py-3 text-sm ${style}`}
+    >
+      <span aria-hidden="true" className="mt-0.5 shrink-0 text-base">
+        {icon}
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <p className="font-semibold">
+          {info.compatibility === 'incompatible'
+            ? 'API version incompatible'
+            : 'API version mismatch'}
+        </p>
+        <p className="mt-0.5 opacity-80">{info.message}</p>
+
+        {info.compatibility === 'incompatible' && (
+          <p className="mt-1.5 opacity-70">
+            Server: <code className="font-mono text-xs">{info.serverVersion ?? 'unknown'}</code>
+            {' / '}
+            Client: <code className="font-mono text-xs">{info.clientVersion}</code>
+          </p>
+        )}
+      </div>
+
+      {canDismiss && (
+        <button
+          onClick={handleDismiss}
+          className="shrink-0 text-amber-300/70 hover:text-amber-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400"
+          aria-label="Dismiss API version warning"
+          title="Dismiss"
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
+      )}
+    </div>
+  )
+})

--- a/src/components/PerformanceOverlay.tsx
+++ b/src/components/PerformanceOverlay.tsx
@@ -1,0 +1,176 @@
+/**
+ * PerformanceOverlay
+ *
+ * A floating DevTools overlay that displays live performance metrics:
+ * - Current FPS with colour-coded health indicator
+ * - Total long tasks (>50 ms) in the last 60 s
+ * - Average WebSocket message processing time
+ * - Recent render counts (top 5 most-rendered components)
+ *
+ * Only rendered in development mode (import.meta.env.DEV).
+ * Toggle visibility with Alt+Shift+P, or via the button in the corner.
+ *
+ * Opt-out: set localStorage key `perf_overlay_hidden=1` to start hidden.
+ */
+
+import { memo, useState, useEffect, useCallback } from 'react'
+import { subscribePerformance, type PerformanceSnapshot } from '../utils/performanceMonitor'
+import { subscribeRenderInfo, getRenderCounts, type RenderInfo } from '../hooks/useRenderTracker'
+
+function fpsColour(fps: number): string {
+  if (fps === 0) return 'text-slate-400'
+  if (fps >= 55) return 'text-emerald-400'
+  if (fps >= 30) return 'text-amber-400'
+  return 'text-red-400'
+}
+
+function msColour(ms: number): string {
+  if (ms < 5) return 'text-emerald-400'
+  if (ms < 16) return 'text-amber-400'
+  return 'text-red-400'
+}
+
+interface RenderRow {
+  name: string
+  count: number
+}
+
+const HIDDEN_STORAGE_KEY = 'perf_overlay_hidden'
+
+export const PerformanceOverlay = memo(function PerformanceOverlay() {
+  // Only mount in dev
+  if (!import.meta.env.DEV) return null
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const [visible, setVisible] = useState(
+    () => localStorage.getItem(HIDDEN_STORAGE_KEY) !== '1',
+  )
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const [perf, setPerf] = useState<PerformanceSnapshot | null>(null)
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const [renderRows, setRenderRows] = useState<RenderRow[]>([])
+
+  const toggleVisible = useCallback(() => {
+    setVisible((v) => {
+      const next = !v
+      localStorage.setItem(HIDDEN_STORAGE_KEY, next ? '0' : '1')
+      return next
+    })
+  }, [])
+
+  // Subscribe to performance snapshots
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    return subscribePerformance((s) => setPerf(s))
+  }, [])
+
+  // Subscribe to render tracker — update top render counts
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    const update = (_info: RenderInfo) => {
+      const counts = getRenderCounts()
+      const rows = [...counts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([name, count]) => ({ name, count }))
+      setRenderRows(rows)
+    }
+    return subscribeRenderInfo(update)
+  }, [])
+
+  // Keyboard shortcut: Alt+Shift+P
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.altKey && e.shiftKey && e.key === 'P') {
+        toggleVisible()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [toggleVisible])
+
+  if (!visible) {
+    return (
+      <button
+        onClick={toggleVisible}
+        title="Show performance overlay (Alt+Shift+P)"
+        className="fixed bottom-4 left-4 z-[9999] rounded border border-slate-600 bg-slate-900/90 px-2 py-1 font-mono text-xs text-slate-400 hover:text-slate-100"
+        aria-label="Show performance overlay"
+      >
+        ⚡ perf
+      </button>
+    )
+  }
+
+  const fps = perf?.fps ?? 0
+  const longTasks = perf?.longTasks.length ?? 0
+  const avgWs = perf?.avgWsProcessingMs ?? null
+
+  return (
+    <aside
+      role="complementary"
+      aria-label="Performance overlay"
+      className="fixed bottom-4 left-4 z-[9999] min-w-48 rounded-lg border border-slate-700 bg-slate-900/95 p-3 font-mono text-xs shadow-2xl backdrop-blur"
+    >
+      {/* Header */}
+      <div className="mb-2 flex items-center justify-between gap-4">
+        <span className="font-semibold text-slate-300">⚡ Performance</span>
+        <button
+          onClick={toggleVisible}
+          title="Hide overlay (Alt+Shift+P)"
+          className="text-slate-500 hover:text-slate-200"
+          aria-label="Hide performance overlay"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* FPS */}
+      <div className="flex items-center justify-between gap-4 border-b border-slate-700 pb-2">
+        <span className="text-slate-400">FPS</span>
+        <span className={`font-bold ${fpsColour(fps)}`}>
+          {fps > 0 ? fps : '—'}
+          {perf?.isJanky && <span className="ml-1 text-red-400">⚠ jank</span>}
+        </span>
+      </div>
+
+      {/* Long tasks */}
+      <div className="flex items-center justify-between gap-4 border-b border-slate-700 py-2">
+        <span className="text-slate-400">Long tasks (60s)</span>
+        <span className={longTasks > 0 ? 'font-bold text-amber-400' : 'text-slate-400'}>
+          {longTasks}
+        </span>
+      </div>
+
+      {/* WebSocket timing */}
+      <div className="flex items-center justify-between gap-4 border-b border-slate-700 py-2">
+        <span className="text-slate-400">WS avg</span>
+        {avgWs !== null ? (
+          <span className={`font-bold ${msColour(avgWs)}`}>{avgWs.toFixed(2)} ms</span>
+        ) : (
+          <span className="text-slate-500">no data</span>
+        )}
+      </div>
+
+      {/* Top render counts */}
+      {renderRows.length > 0 && (
+        <div className="mt-2">
+          <div className="mb-1 text-slate-500">Top renders</div>
+          {renderRows.map((r) => (
+            <div key={r.name} className="flex items-center justify-between gap-2 py-0.5">
+              <span className="max-w-32 truncate text-slate-400" title={r.name}>
+                {r.name}
+              </span>
+              <span className={r.count > 50 ? 'text-amber-400' : 'text-slate-300'}>
+                {r.count}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-2 text-slate-600">Alt+Shift+P to toggle</div>
+    </aside>
+  )
+})

--- a/src/hooks/useApiVersion.ts
+++ b/src/hooks/useApiVersion.ts
@@ -1,0 +1,59 @@
+/**
+ * useApiVersion
+ *
+ * React hook that subscribes to the global API version detection state.
+ * Returns the current {@link ApiVersionInfo} once detection has completed,
+ * or `null` while the initial check is in flight.
+ *
+ * Also exports `useInitApiVersion()` which runs `initApiVersionDetection()`
+ * on mount — call this once at the App root.
+ */
+
+import { useState, useEffect } from 'react'
+import {
+  subscribeApiVersion,
+  initApiVersionDetection,
+  type ApiVersionInfo,
+} from '../api/version'
+
+/**
+ * Returns the current API version info, or `null` during the initial detection.
+ */
+export function useApiVersion(): ApiVersionInfo | null {
+  const [info, setInfo] = useState<ApiVersionInfo | null>(null)
+
+  useEffect(() => {
+    return subscribeApiVersion(setInfo)
+  }, [])
+
+  return info
+}
+
+/**
+ * Runs API version detection on mount. Mount this once at the App root
+ * (alongside useWebVitals, initAnalytics, etc.).
+ *
+ * Returns the detected version info, or null while detection is pending.
+ */
+export function useInitApiVersion(): ApiVersionInfo | null {
+  const [info, setInfo] = useState<ApiVersionInfo | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    initApiVersionDetection(controller.signal).then((detected) => {
+      if (!controller.signal.aborted) setInfo(detected)
+    }).catch(() => {
+      // detection errors are handled inside initApiVersionDetection
+    })
+
+    const unsubscribe = subscribeApiVersion(setInfo)
+
+    return () => {
+      controller.abort()
+      unsubscribe()
+    }
+  }, [])
+
+  return info
+}

--- a/src/hooks/usePerformanceMonitor.ts
+++ b/src/hooks/usePerformanceMonitor.ts
@@ -1,0 +1,85 @@
+/**
+ * usePerformanceMonitor
+ *
+ * Main hook that:
+ * 1. Starts/stops the FPS sampler and long-task observer for the lifetime of
+ *    the component that mounts it (typically App).
+ * 2. Subscribes to performance snapshots and returns the latest snapshot.
+ * 3. Reports long tasks and low-FPS events to analytics when configured.
+ * 4. Places performance marks around key user navigation transitions.
+ *
+ * Mount once at the top of the React tree (in App or AppContent).
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import {
+  startPerformanceMonitor,
+  stopPerformanceMonitor,
+  subscribePerformance,
+  recordPerfMark,
+  type PerformanceSnapshot,
+} from '../utils/performanceMonitor'
+import { trackEvent } from './useAnalytics'
+
+const REPORT_LONG_TASK_THRESHOLD_MS = 200   // only report notably long tasks
+const FPS_JANK_REPORT_COOLDOWN_MS   = 30_000 // rate-limit jank reports
+
+export function usePerformanceMonitor(): PerformanceSnapshot | null {
+  const [snapshot, setSnapshot] = useState<PerformanceSnapshot | null>(null)
+  const lastJankReportRef = useRef(0)
+
+  // Report a long task to analytics if it's egregiously long
+  const handleLongTask = useCallback((s: PerformanceSnapshot) => {
+    const last = s.longTasks[s.longTasks.length - 1]
+    if (!last || last.duration < REPORT_LONG_TASK_THRESHOLD_MS) return
+
+    trackEvent('perf:long_task', {
+      duration_ms: Math.round(last.duration),
+      name: last.name,
+      total_long_tasks: s.totalLongTasks,
+    })
+  }, [])
+
+  // Rate-limited jank reporting
+  const handleJank = useCallback((s: PerformanceSnapshot) => {
+    if (!s.isJanky) return
+    const now = Date.now()
+    if (now - lastJankReportRef.current < FPS_JANK_REPORT_COOLDOWN_MS) return
+    lastJankReportRef.current = now
+    trackEvent('perf:jank', { fps: s.fps })
+  }, [])
+
+  useEffect(() => {
+    startPerformanceMonitor()
+    recordPerfMark('app:ready')
+
+    const unsubscribe = subscribePerformance((s) => {
+      setSnapshot(s)
+      handleLongTask(s)
+      handleJank(s)
+    })
+
+    return () => {
+      unsubscribe()
+      stopPerformanceMonitor()
+    }
+  }, [handleLongTask, handleJank])
+
+  return snapshot
+}
+
+/**
+ * Convenience hook for marking the start of an interaction and automatically
+ * placing a paired end mark when the component unmounts or the name changes.
+ *
+ * Usage:
+ *   useInteractionMark('dashboard:filter:apply')
+ */
+export function useInteractionMark(name: string): void {
+  useEffect(() => {
+    recordPerfMark(`${name}:start`)
+    return () => {
+      recordPerfMark(`${name}:end`, `${name}:start`)
+    }
+  }, [name])
+}

--- a/src/hooks/useRenderTracker.ts
+++ b/src/hooks/useRenderTracker.ts
@@ -1,0 +1,108 @@
+/**
+ * useRenderTracker
+ *
+ * Instruments React component render counts and tracks *which* props or state
+ * values changed between renders. This is a development-only tool — in
+ * production it is a no-op that adds zero overhead.
+ *
+ * Usage:
+ *   function MyComponent(props: Props) {
+ *     useRenderTracker('MyComponent', props)
+ *     …
+ *   }
+ *
+ * Or with explicit tracked values:
+ *   useRenderTracker('MyComponent', { prices, filter, sort })
+ *
+ * Render data is pushed to the performanceMonitor as performance marks and
+ * logged to the console in DEV mode so it appears in DevTools.
+ */
+
+import { useRef, useEffect } from 'react'
+import { recordPerfMark } from '../utils/performanceMonitor'
+
+export interface RenderInfo {
+  componentName: string
+  renderCount: number
+  changedKeys: string[]
+  timestamp: number
+}
+
+// Registry of component render counts — survives remounts within a session
+const renderCounts = new Map<string, number>()
+
+// Listeners so external observers (e.g. PerformanceOverlay) can react
+type RenderListener = (info: RenderInfo) => void
+const renderListeners = new Set<RenderListener>()
+
+export function subscribeRenderInfo(listener: RenderListener): () => void {
+  renderListeners.add(listener)
+  return () => renderListeners.delete(listener)
+}
+
+export function getRenderCounts(): Map<string, number> {
+  return new Map(renderCounts)
+}
+
+function detectChanges(
+  prev: Record<string, unknown> | null,
+  current: Record<string, unknown>,
+): string[] {
+  if (!prev) return Object.keys(current)
+  return Object.keys(current).filter((k) => !Object.is(prev[k], current[k]))
+}
+
+/**
+ * Tracks renders for a component. Pass the component name and any props or
+ * state values you want to observe for changes. No-ops in production.
+ */
+export function useRenderTracker(
+  componentName: string,
+  trackedValues?: Record<string, unknown>,
+): void {
+  if (import.meta.env.PROD) return
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const prevValuesRef = useRef<Record<string, unknown> | null>(null)
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const countRef = useRef(0)
+
+  countRef.current += 1
+  renderCounts.set(componentName, countRef.current)
+
+  const changedKeys = trackedValues
+    ? detectChanges(prevValuesRef.current, trackedValues)
+    : []
+
+  prevValuesRef.current = trackedValues ? { ...trackedValues } : null
+
+  const info: RenderInfo = {
+    componentName,
+    renderCount: countRef.current,
+    changedKeys,
+    timestamp: performance.now(),
+  }
+
+  // Push to perf marks for DevTools timeline visibility
+  recordPerfMark(`render:${componentName}:${countRef.current}`)
+
+  // Notify listeners
+  renderListeners.forEach((l) => l(info))
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    if (import.meta.env.DEV && changedKeys.length > 0) {
+      console.debug(
+        `[RenderTracker] %c${componentName}%c render #${countRef.current}`,
+        'color: #7dd3fc; font-weight: bold',
+        'color: inherit',
+        changedKeys.length > 0
+          ? { changedKeys, values: changedKeys.reduce<Record<string, unknown>>((acc, k) => {
+              if (trackedValues) acc[k] = trackedValues[k]
+              return acc
+            }, {}) }
+          : '(initial mount)',
+      )
+    }
+  })
+}

--- a/src/hooks/useWebVitals.ts
+++ b/src/hooks/useWebVitals.ts
@@ -2,6 +2,8 @@ import { useEffect } from 'react'
 import { onLCP, onFID, onCLS, onINP, onFCP, onTTFB } from 'web-vitals'
 import type { Metric } from 'web-vitals'
 import { config } from '../config'
+import { trackEvent } from './useAnalytics'
+import { recordPerfMark } from '../utils/performanceMonitor'
 
 interface WebVitalReport {
   name: string
@@ -33,6 +35,16 @@ function sendToAnalytics(report: WebVitalReport) {
     navigator.sendBeacon(config.analyticsEndpoint, blob)
   }
 
+  // Also report via the configured analytics provider (Plausible / Umami)
+  trackEvent(`web_vital:${report.name.toLowerCase()}`, {
+    value: Math.round(report.value),
+    rating: report.rating,
+    delta: Math.round(report.delta),
+    route: report.route,
+    viewport: report.viewport,
+    connection: report.connection ?? undefined,
+  })
+
   if (import.meta.env.DEV) {
     console.info(
       `[Web Vitals] ${report.name} ${report.rating} ${report.value.toFixed(2)}`,
@@ -46,6 +58,9 @@ export function useWebVitals(): void {
     if (!shouldTrack()) return
 
     const reportMetric = (metric: Metric) => {
+      // Place a performance mark so the metric appears in the DevTools timeline
+      recordPerfMark(`web_vital:${metric.name}:${metric.rating}`)
+
       const task = () => {
         sendToAnalytics({
           name: metric.name,

--- a/src/utils/performanceMonitor.ts
+++ b/src/utils/performanceMonitor.ts
@@ -1,0 +1,269 @@
+/**
+ * performanceMonitor.ts
+ *
+ * Runtime performance monitoring utilities:
+ * - FPS sampling via requestAnimationFrame
+ * - Long task detection via PerformanceObserver (tasks >50 ms)
+ * - Performance marks for key user interactions
+ * - WebSocket message processing time tracking
+ *
+ * All state is held in module-level variables so it survives across React
+ * render cycles. Listeners receive a snapshot of the current metrics each
+ * time any value changes.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface LongTask {
+  startTime: number
+  duration: number
+  name: string
+}
+
+export interface PerformanceMark {
+  name: string
+  startTime: number
+  /** Duration in ms from the most recent paired mark, or null for single marks */
+  duration: number | null
+}
+
+export interface WsMessageTiming {
+  /** Timestamp when the message was received */
+  receivedAt: number
+  /** Processing time in ms */
+  processingMs: number
+  /** Message type, if available */
+  type?: string
+}
+
+export interface PerformanceSnapshot {
+  /** Current frames per second (rolling 1-second average) */
+  fps: number
+  /** Whether the tab is currently considered "jank" (fps < 30) */
+  isJanky: boolean
+  /** Long tasks recorded in the last 60 s */
+  longTasks: LongTask[]
+  /** Total number of long tasks since monitoring started */
+  totalLongTasks: number
+  /** Custom performance marks */
+  marks: PerformanceMark[]
+  /** Recent WS message processing timings */
+  wsTiming: WsMessageTiming[]
+  /** Average WS message processing time in ms, or null if no samples */
+  avgWsProcessingMs: number | null
+}
+
+type Listener = (snapshot: PerformanceSnapshot) => void
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const LONG_TASK_THRESHOLD_MS = 50
+const MAX_LONG_TASKS = 200
+const LONG_TASK_WINDOW_MS = 60_000
+const MAX_MARKS = 100
+const MAX_WS_TIMINGS = 100
+
+// ── Module state ─────────────────────────────────────────────────────────────
+
+let fps = 0
+let rafHandle: number | null = null
+let longTaskObserver: PerformanceObserver | null = null
+let isRunning = false
+
+const longTasks: LongTask[] = []
+const marks: PerformanceMark[] = []
+const wsTiming: WsMessageTiming[] = []
+const listeners = new Set<Listener>()
+
+// FPS ring buffer: stores the timestamp of the last N frames
+const frameTimestamps: number[] = []
+let totalLongTasks = 0
+
+// ── Snapshot ─────────────────────────────────────────────────────────────────
+
+function snapshot(): PerformanceSnapshot {
+  const now = Date.now()
+  const recentLongTasks = longTasks.filter((t) => now - t.startTime < LONG_TASK_WINDOW_MS)
+
+  const avgWs =
+    wsTiming.length > 0
+      ? wsTiming.reduce((s, t) => s + t.processingMs, 0) / wsTiming.length
+      : null
+
+  return {
+    fps,
+    isJanky: fps < 30 && fps > 0,
+    longTasks: [...recentLongTasks],
+    totalLongTasks,
+    marks: [...marks],
+    wsTiming: [...wsTiming],
+    avgWsProcessingMs: avgWs,
+  }
+}
+
+function notify() {
+  const s = snapshot()
+  listeners.forEach((l) => l(s))
+}
+
+// ── FPS tracking ─────────────────────────────────────────────────────────────
+
+function rafTick(now: number) {
+  frameTimestamps.push(now)
+
+  // Keep only frames within the last second
+  while (frameTimestamps.length > 0 && now - frameTimestamps[0] > 1000) {
+    frameTimestamps.shift()
+  }
+
+  if (frameTimestamps.length >= 2) {
+    const elapsed = now - frameTimestamps[0]
+    const newFps = Math.round(((frameTimestamps.length - 1) / elapsed) * 1000)
+    if (newFps !== fps) {
+      fps = newFps
+      notify()
+    }
+  }
+
+  if (isRunning) {
+    rafHandle = requestAnimationFrame(rafTick)
+  }
+}
+
+// ── Long task detection ───────────────────────────────────────────────────────
+
+function startLongTaskObserver(): void {
+  if (typeof PerformanceObserver === 'undefined') return
+  try {
+    longTaskObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (entry.duration >= LONG_TASK_THRESHOLD_MS) {
+          if (longTasks.length >= MAX_LONG_TASKS) longTasks.shift()
+          longTasks.push({
+            startTime: entry.startTime,
+            duration: entry.duration,
+            name: entry.name,
+          })
+          totalLongTasks++
+          notify()
+        }
+      }
+    })
+    longTaskObserver.observe({ entryTypes: ['longtask'] })
+  } catch {
+    // Browser may not support longtask — silently skip
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Starts the FPS sampler and long task observer.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function startPerformanceMonitor(): void {
+  if (isRunning) return
+  isRunning = true
+  rafHandle = requestAnimationFrame(rafTick)
+  startLongTaskObserver()
+}
+
+/**
+ * Stops the FPS sampler and disconnects the long task observer.
+ */
+export function stopPerformanceMonitor(): void {
+  isRunning = false
+  if (rafHandle !== null) {
+    cancelAnimationFrame(rafHandle)
+    rafHandle = null
+  }
+  if (longTaskObserver) {
+    longTaskObserver.disconnect()
+    longTaskObserver = null
+  }
+}
+
+/**
+ * Records a named performance mark. If a previous mark with `pairedWith`
+ * exists, also records the elapsed duration between them.
+ *
+ * Usage:
+ *   recordPerfMark('dashboard:render:start')
+ *   // … work …
+ *   recordPerfMark('dashboard:render:end', 'dashboard:render:start')
+ */
+export function recordPerfMark(name: string, pairedWith?: string): void {
+  // Also emit a native browser performance mark for DevTools timeline
+  try {
+    performance.mark(name)
+    if (pairedWith) {
+      const measureName = `${pairedWith} → ${name}`
+      try {
+        performance.measure(measureName, pairedWith, name)
+      } catch {
+        // mark may not exist yet
+      }
+    }
+  } catch {
+    // ignore — not supported in all environments
+  }
+
+  let duration: number | null = null
+  if (pairedWith) {
+    // Find the most recent paired mark (avoid Array.findLast for lib compat)
+    let paired: PerformanceMark | undefined
+    for (let i = marks.length - 1; i >= 0; i--) {
+      if (marks[i].name === pairedWith) {
+        paired = marks[i]
+        break
+      }
+    }
+    if (paired) duration = performance.now() - paired.startTime
+  }
+
+  if (marks.length >= MAX_MARKS) marks.shift()
+  marks.push({ name, startTime: performance.now(), duration })
+  notify()
+}
+
+/**
+ * Records the processing time for a single WebSocket message.
+ * Call with the timestamp captured *before* processing begins and the type
+ * string from the parsed message.
+ */
+export function recordWsMessageTiming(startMs: number, type?: string): void {
+  const processingMs = performance.now() - startMs
+  if (wsTiming.length >= MAX_WS_TIMINGS) wsTiming.shift()
+  wsTiming.push({ receivedAt: Date.now(), processingMs, type })
+  notify()
+}
+
+/**
+ * Subscribes to performance snapshot updates.
+ * Returns an unsubscribe function.
+ */
+export function subscribePerformance(listener: Listener): () => void {
+  listeners.add(listener)
+  listener(snapshot()) // fire immediately with current state
+  return () => listeners.delete(listener)
+}
+
+/**
+ * Returns the current performance snapshot without subscribing.
+ */
+export function getPerformanceSnapshot(): PerformanceSnapshot {
+  return snapshot()
+}
+
+/**
+ * Clears all accumulated data. Useful for tests.
+ */
+export function resetPerformanceMonitor(): void {
+  longTasks.length = 0
+  marks.length = 0
+  wsTiming.length = 0
+  frameTimestamps.length = 0
+  fps = 0
+  totalLongTasks = 0
+  notify()
+}


### PR DESCRIPTION
Commit 1 — Visual Regression Testing (0fab927)
  
  - e2e/visual-regression.spec.ts — Playwright screenshot tests for Dashboard, Price Detail, API Docs, and 404 at mobile
  (375×812), tablet (768×1024), and desktop (1440×900) viewports, in both dark and light modes; 2% maxDiffPixelRatio
  threshold; animations frozen for determinism
  - playwright.config.ts — Dedicated visual-regression Chromium-only project; other projects skip the visual spec;
  snapshotDir set to e2e/snapshots/
  - scripts/update-visual-baselines.js — Helper to rebuild baselines with --update-snapshots, then print commit
  instructions
  - npm scripts — test:e2e:visual, test:e2e:visual:update
  - CI visual-regression job — Uploads HTML report + diff artifacts; continue-on-error: true so drift is visible but
  non-blocking
  - .gitignore updated to track e2e/snapshots/ baselines in git
  
  Commit 2 — Runtime Performance Monitoring (f866100)
  
  - src/utils/performanceMonitor.ts — FPS sampler (rAF ring buffer), PerformanceObserver long task detection (>50ms), perf
  marks API, WS message timing tracking; subscribe/snapshot API
  - src/hooks/useRenderTracker.ts — Dev-only render count + changed-prop diff tracking; emits perf marks and console.debug
  - src/hooks/usePerformanceMonitor.ts — App-lifetime hook; rate-limited jank/long-task analytics reporting;
  useInteractionMark() convenience hook
  - src/components/PerformanceOverlay.tsx — Floating dev overlay (DEV-only); FPS with colour health indicator, long task
  count, avg WS latency, top-5 render counts; Alt+Shift+P toggle
  - src/api/websocket.ts — recordWsMessageTiming() call wrapping onmessage dispatch
  - src/hooks/useWebVitals.ts — Core Web Vitals forwarded to trackEvent() and placed as DevTools timeline marks
  - src/App.tsx — usePerformanceMonitor() mounted; <PerformanceOverlay /> rendered in DEV
  
  Commit 3 — API Versioning Support (608719d)
  
  - src/api/version.ts — Semver MAJOR.MINOR compatibility check; detectApiVersion() probing /api/version then /health;
  getAcceptVersionHeader(); migrateApiPayload() for v0→v1 transforms; module singleton with subscribeApiVersion() /
  initApiVersionDetection(); assertVersionCompatible() for CI
  - src/hooks/useApiVersion.ts — useApiVersion() and useInitApiVersion() React hooks
  - src/components/ApiVersionBanner.tsx — Red undismissable banner for incompatible versions; amber dismissible
  (sessionStorage) for minor mismatches
  - src/api/rest.ts — Accept-Version header on every request; clear error message on 406/409
  - src/App.tsx — useInitApiVersion() + <ApiVersionBanner /> wired in
  - scripts/check-api-version.js — Standalone CI script; exits 0 for unknown/unavailable/compatible, exits 1 for
  incompatible
  - CI api-version-check job — Uses BACKEND_API_URL repository variable; gracefully skips when backend unavailable

Closes #319 

Closes #326 

Closes #337 

