### PR TITLE
Fix/issues 327 328 329 332

### DIFF
--- a/src/api/circuitBreaker.ts
+++ b/src/api/circuitBreaker.ts
@@ -1,0 +1,158 @@
+import { config } from '../config'
+import { showApiErrorToast } from '../context/ToastContext'
+
+export type CircuitState = 'closed' | 'open' | 'half-open'
+
+export interface CircuitBreakerOptions {
+  /** Failures within `windowMs` required to open the circuit. */
+  failureThreshold: number
+  /** Rolling window in ms over which failures are counted. */
+  windowMs: number
+  /** How long the circuit stays open before allowing a half-open test request. */
+  cooldownMs: number
+}
+
+const DEFAULT_OPTIONS: CircuitBreakerOptions = config.circuitBreaker
+
+interface CircuitEntry {
+  state: CircuitState
+  failureTimestamps: number[]
+  cooldownTimer: ReturnType<typeof setTimeout> | null
+  halfOpenInFlight: boolean
+}
+
+export type CircuitStateListener = (key: string, state: CircuitState) => void
+
+/**
+ * Per-endpoint-group circuit breaker.
+ *
+ * Tracks failures per `key` (an endpoint group, e.g. `/api/prices`). After
+ * `failureThreshold` failures within `windowMs`, the circuit opens and
+ * `canRequest` returns false for that key until `cooldownMs` has elapsed, at
+ * which point a single test request is allowed through (half-open). A
+ * successful half-open request closes the circuit; a failed one re-opens it.
+ */
+class CircuitBreaker {
+  private entries = new Map<string, CircuitEntry>()
+  private options: CircuitBreakerOptions
+  private listeners = new Set<CircuitStateListener>()
+
+  constructor(options: Partial<CircuitBreakerOptions> = {}) {
+    this.options = { ...DEFAULT_OPTIONS, ...options }
+  }
+
+  private getEntry(key: string): CircuitEntry {
+    let entry = this.entries.get(key)
+    if (!entry) {
+      entry = { state: 'closed', failureTimestamps: [], cooldownTimer: null, halfOpenInFlight: false }
+      this.entries.set(key, entry)
+    }
+    return entry
+  }
+
+  private setState(key: string, entry: CircuitEntry, state: CircuitState): void {
+    if (entry.state === state) return
+    entry.state = state
+    for (const listener of this.listeners) listener(key, state)
+
+    if (state === 'open') {
+      showApiErrorToast(`Repeated failures detected for ${key} — pausing requests temporarily.`)
+    } else if (state === 'closed') {
+      showApiErrorToast(`Connection to ${key} recovered.`)
+    }
+  }
+
+  /** Returns whether a request to `key` may be attempted right now. */
+  canRequest(key: string): boolean {
+    const entry = this.getEntry(key)
+    if (entry.state === 'closed') return true
+    if (entry.state === 'open') return false
+    // half-open: allow exactly one in-flight test request at a time
+    if (entry.halfOpenInFlight) return false
+    entry.halfOpenInFlight = true
+    return true
+  }
+
+  /** Records a successful request against `key`. */
+  recordSuccess(key: string): void {
+    const entry = this.getEntry(key)
+    entry.failureTimestamps = []
+    entry.halfOpenInFlight = false
+    if (entry.cooldownTimer) {
+      clearTimeout(entry.cooldownTimer)
+      entry.cooldownTimer = null
+    }
+    this.setState(key, entry, 'closed')
+  }
+
+  /** Records a failed request against `key`, possibly opening the circuit. */
+  recordFailure(key: string): void {
+    const entry = this.getEntry(key)
+    entry.halfOpenInFlight = false
+
+    if (entry.state === 'half-open') {
+      this.openCircuit(key, entry)
+      return
+    }
+
+    const now = Date.now()
+    entry.failureTimestamps.push(now)
+    entry.failureTimestamps = entry.failureTimestamps.filter((t) => now - t <= this.options.windowMs)
+
+    if (entry.failureTimestamps.length >= this.options.failureThreshold) {
+      this.openCircuit(key, entry)
+    }
+  }
+
+  private openCircuit(key: string, entry: CircuitEntry): void {
+    this.setState(key, entry, 'open')
+    entry.failureTimestamps = []
+
+    if (entry.cooldownTimer) clearTimeout(entry.cooldownTimer)
+    entry.cooldownTimer = setTimeout(() => {
+      entry.cooldownTimer = null
+      this.setState(key, entry, 'half-open')
+    }, this.options.cooldownMs)
+  }
+
+  /** Returns the current state for `key` (defaults to `closed` if unknown). */
+  getState(key: string): CircuitState {
+    return this.entries.get(key)?.state ?? 'closed'
+  }
+
+  /** Returns a snapshot of every known endpoint group's state, for devtools display. */
+  getAllStates(): Record<string, CircuitState> {
+    return Object.fromEntries([...this.entries].map(([key, entry]) => [key, entry.state]))
+  }
+
+  onStateChange(listener: CircuitStateListener): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  /** Resets all breaker state. Exposed for test isolation between cases. */
+  reset(): void {
+    for (const entry of this.entries.values()) {
+      if (entry.cooldownTimer) clearTimeout(entry.cooldownTimer)
+    }
+    this.entries.clear()
+  }
+}
+
+export class CircuitOpenError extends Error {
+  readonly key: string
+  constructor(key: string) {
+    super(`Circuit breaker is open for ${key}; request blocked.`)
+    this.name = 'CircuitOpenError'
+    this.key = key
+  }
+}
+
+export const circuitBreaker = new CircuitBreaker()
+
+/** Derives the circuit-breaker grouping key for a request path, e.g. `/api/prices/BTC/history` -> `/api/prices`. */
+export function circuitKeyForPath(path: string): string {
+  const clean = path.split('?')[0]
+  const parts = clean.split('/').filter(Boolean)
+  return '/' + parts.slice(0, 2).join('/')
+}

--- a/src/api/rest.test.ts
+++ b/src/api/rest.test.ts
@@ -11,6 +11,15 @@ vi.mock('../config', () => ({
       maxDelayMs: 30000,
       jitter: true,
     },
+    circuitBreaker: {
+      failureThreshold: 5,
+      windowMs: 30_000,
+      cooldownMs: 30_000,
+    },
+    priceBatch: {
+      debounceMs: 50,
+      maxBatchSize: 20,
+    },
   },
 }))
 
@@ -27,6 +36,7 @@ const restModule = await import('./rest')
 const {
   fetchAllPrices,
   fetchPrice,
+  fetchPricesBatched,
   fetchPriceHistory,
   fetchBatchHistory,
   fetchHealth,
@@ -34,6 +44,7 @@ const {
   resetApiErrorToastState,
 } = restModule
 const { showApiErrorToast } = await import('../context/ToastContext')
+const { circuitBreaker } = await import('./circuitBreaker')
 
 const mockFetch = vi.fn()
 
@@ -43,6 +54,7 @@ beforeEach(() => {
   vi.stubGlobal('fetch', mockFetch)
   vi.useFakeTimers()
   resetApiErrorToastState()
+  circuitBreaker.reset()
 })
 
 afterEach(() => {
@@ -288,6 +300,67 @@ describe('fetchPriceHistory coalescing', () => {
     // First call was batch, second was individual
     expect(mockFetch).toHaveBeenCalledTimes(2)
     expect(mockFetch.mock.calls[1][0]).toBe('/api/prices/BTC%2FUSD/history?limit=100&offset=0')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fetchPricesBatched — coalescing (#327)
+// ---------------------------------------------------------------------------
+describe('fetchPricesBatched coalescing', () => {
+  const btcPrice = { assetPair: 'BTC/USD', price: 50000, timestamp: 0, confidence: 0.9, sources: ['chainlink'] }
+  const ethPrice = { assetPair: 'ETH/USD', price: 3000, timestamp: 0, confidence: 0.9, sources: ['chainlink'] }
+
+  it('combines concurrent per-pair requests into a single batch call', async () => {
+    mockFetch.mockResolvedValue(okResponse([btcPrice, ethPrice]))
+
+    const p1 = fetchPricesBatched('BTC/USD')
+    const p2 = fetchPricesBatched('ETH/USD')
+
+    vi.advanceTimersByTime(50)
+    await Promise.resolve()
+
+    const [r1, r2] = await Promise.all([p1, p2])
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/prices?pairs=BTC%2FUSD,ETH%2FUSD')
+    expect(r1).toEqual(btcPrice)
+    expect(r2).toEqual(ethPrice)
+  })
+
+  it('resolves only the affected pair when the batch response is missing one', async () => {
+    // Batch omits ETH/USD; the individual fallback for it succeeds.
+    mockFetch
+      .mockResolvedValueOnce(okResponse([btcPrice]))
+      .mockResolvedValueOnce(okResponse(ethPrice))
+
+    const p1 = fetchPricesBatched('BTC/USD')
+    const p2 = fetchPricesBatched('ETH/USD')
+
+    vi.advanceTimersByTime(50)
+    await Promise.resolve()
+
+    const [r1, r2] = await Promise.all([p1, p2])
+
+    expect(r1).toEqual(btcPrice)
+    expect(r2).toEqual(ethPrice)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(mockFetch.mock.calls[1][0]).toBe('/api/prices/ETH%2FUSD')
+  })
+
+  it('falls back to individual requests for every pair when the whole batch fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce(errorResponse(404, 'Not Found'))
+      .mockResolvedValueOnce(okResponse(btcPrice))
+
+    const p1 = fetchPricesBatched('BTC/USD')
+
+    vi.advanceTimersByTime(50)
+    await Promise.resolve()
+
+    const result = await p1
+    expect(result).toEqual(btcPrice)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(mockFetch.mock.calls[1][0]).toBe('/api/prices/BTC%2FUSD')
   })
 })
 

--- a/src/api/rest.test.ts
+++ b/src/api/rest.test.ts
@@ -322,7 +322,7 @@ describe('fetchPricesBatched coalescing', () => {
     const [r1, r2] = await Promise.all([p1, p2])
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
-    expect(mockFetch.mock.calls[0][0]).toBe('/api/prices?pairs=BTC%2FUSD,ETH%2FUSD')
+    expect(mockFetch.mock.calls[0][0]).toBe('/api/prices?pairs=BTC/USD,ETH/USD')
     expect(r1).toEqual(btcPrice)
     expect(r2).toEqual(ethPrice)
   })

--- a/src/api/rest.ts
+++ b/src/api/rest.ts
@@ -284,6 +284,116 @@ export async function fetchPrice(pair: string): Promise<PriceData> {
   return validate(PriceDataSchema, raw)
 }
 
+// ---------------------------------------------------------------------------
+// Request batching for fetchPricesBatched
+// ---------------------------------------------------------------------------
+// Per-pair callers (e.g. WebSocket price-update confirmation, which fires once
+// per pair per message) are debounced into a single fetchAllPrices call so a
+// burst of updates across many pairs costs one request instead of one per pair.
+interface PriceWaiter {
+  resolve: (value: PriceData) => void
+  reject: (reason: unknown) => void
+  signal?: AbortSignal
+}
+
+const pendingPrices = new Map<string, PriceWaiter[]>()
+let priceCoalesceTimer: ReturnType<typeof setTimeout> | null = null
+
+function resolveAll(waiters: PriceWaiter[], value: PriceData): void {
+  for (const w of waiters) w.resolve(value)
+}
+
+function rejectAll(waiters: PriceWaiter[], reason: unknown): void {
+  for (const w of waiters) w.reject(reason)
+}
+
+/** Falls back to an individual request for one pair — used when a pair is missing from a batch response or the whole batch failed, so one bad pair doesn't affect the rest. */
+function settleViaDirectFetch(pair: string, waiters: PriceWaiter[]): void {
+  fetchPrice(pair).then(
+    (r) => resolveAll(waiters, r),
+    (e) => rejectAll(waiters, e),
+  )
+}
+
+function flushCoalescedPrices(): void {
+  priceCoalesceTimer = null
+  if (pendingPrices.size === 0) return
+
+  const snapshot = new Map(pendingPrices)
+  pendingPrices.clear()
+
+  for (const [pair, waiters] of snapshot) {
+    const active = waiters.filter((w) => !w.signal?.aborted)
+    if (active.length === 0) {
+      for (const w of waiters) w.reject(new DOMException('Aborted', 'AbortError'))
+      snapshot.delete(pair)
+    } else {
+      snapshot.set(pair, active)
+    }
+  }
+
+  if (snapshot.size === 0) return
+
+  const pairs = [...snapshot.keys()]
+  const { maxBatchSize } = config.priceBatch
+  const batches: string[][] = []
+  for (let i = 0; i < pairs.length; i += maxBatchSize) {
+    batches.push(pairs.slice(i, i + maxBatchSize))
+  }
+
+  for (const batchPairs of batches) {
+    fetchAllPrices(batchPairs)
+      .then((results) => {
+        const byPair = new Map(results.map((r) => [r.assetPair, r]))
+        for (const pair of batchPairs) {
+          const waiters = snapshot.get(pair) ?? []
+          const result = byPair.get(pair)
+          if (result) {
+            resolveAll(waiters, result)
+          } else {
+            settleViaDirectFetch(pair, waiters)
+          }
+        }
+      })
+      .catch(() => {
+        for (const pair of batchPairs) {
+          settleViaDirectFetch(pair, snapshot.get(pair) ?? [])
+        }
+      })
+  }
+}
+
+/**
+ * Fetches the latest price for a single pair, debouncing concurrent per-pair calls
+ * within a configurable window (`config.priceBatch.debounceMs`) into one batched
+ * `fetchAllPrices` request (capped at `config.priceBatch.maxBatchSize` pairs per
+ * request). A pair missing from the batch response — or a batch that fails
+ * entirely — falls back to an individual fetch so one pair's failure doesn't
+ * affect the others.
+ */
+export function fetchPricesBatched(pair: string, signal?: AbortSignal): Promise<PriceData> {
+  return new Promise<PriceData>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'))
+      return
+    }
+
+    const existing = pendingPrices.get(pair)
+    if (existing) {
+      existing.push({ resolve, reject, signal })
+    } else {
+      pendingPrices.set(pair, [{ resolve, reject, signal }])
+    }
+    if (!priceCoalesceTimer) {
+      priceCoalesceTimer = setTimeout(flushCoalescedPrices, config.priceBatch.debounceMs)
+    }
+
+    signal?.addEventListener('abort', () => {
+      reject(new DOMException('Aborted', 'AbortError'))
+    }, { once: true })
+  })
+}
+
 /**
  * Fetches the price history for an asset pair.
  *

--- a/src/api/rest.ts
+++ b/src/api/rest.ts
@@ -10,6 +10,7 @@ import {
 } from './schemas'
 import { validate } from './validate'
 import { getApiVersionInfo, getAcceptVersionHeader } from './version'
+import { circuitBreaker, circuitKeyForPath, CircuitOpenError } from './circuitBreaker'
 
 /** Categorical classification of an {@link ApiError}, derived from the HTTP status. */
 export type ApiErrorCode =
@@ -114,6 +115,13 @@ function setRateLimitInfo(response: Response): void {
 
 async function request<T>(path: string, init?: RequestInit, signal?: AbortSignal): Promise<T> {
   const url = `${config.apiUrl}${path}`
+  const circuitKey = circuitKeyForPath(path)
+
+  // When an endpoint group is failing repeatedly, stop sending requests to it
+  // until the cooldown elapses (see circuitBreaker.ts).
+  if (!circuitBreaker.canRequest(circuitKey)) {
+    throw new CircuitOpenError(circuitKey)
+  }
 
   // Include the Accept-Version header on every request so the server can
   // route to the appropriate handler version or return a version error.
@@ -150,11 +158,13 @@ async function request<T>(path: string, init?: RequestInit, signal?: AbortSignal
       throw new ApiError(`${res.status} ${res.statusText}: ${text}`, res.status, statusToErrorCode(res.status))
     }
 
+    circuitBreaker.recordSuccess(circuitKey)
     return (await res.json()) as T
   } catch (err) {
     // Cancelled requests (unmount, pair change, etc.) are not failures — don't toast them.
     if (err instanceof DOMException && err.name === 'AbortError') throw err
 
+    circuitBreaker.recordFailure(circuitKey)
     notifyApiError(apiErrorMessage(err))
     throw err
   }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -22,4 +22,9 @@ export const config = {
     maxDelayMs: 30_000,
     jitter: true,
   },
+  circuitBreaker: {
+    failureThreshold: 5,
+    windowMs: 30_000,
+    cooldownMs: 30_000,
+  },
 } as const

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -27,4 +27,10 @@ export const config = {
     windowMs: 30_000,
     cooldownMs: 30_000,
   },
+  priceBatch: {
+    /** Window in ms during which individual per-pair price requests are coalesced into one batch call. */
+    debounceMs: 50,
+    /** Maximum number of pairs sent in a single batched price request. */
+    maxBatchSize: 20,
+  },
 } as const

--- a/src/context/PriceContext.test.tsx
+++ b/src/context/PriceContext.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { PriceProvider, usePriceContext } from './PriceContext'
-import { fetchPrice } from '../api/rest'
+import { fetchPricesBatched } from '../api/rest'
 import type { ReactNode } from 'react'
 
 const mockConnect = vi.fn()
@@ -37,7 +37,7 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
 
 vi.mock('../api/rest', () => ({
   fetchAllPrices: vi.fn(),
-  fetchPrice: vi.fn(),
+  fetchPricesBatched: vi.fn(),
 }))
 
 vi.mock('../api/websocket', () => ({
@@ -86,7 +86,7 @@ function TestConsumer() {
 beforeEach(() => {
   vi.clearAllMocks()
   messageHandler = null
-  vi.mocked(fetchPrice).mockResolvedValue({
+  vi.mocked(fetchPricesBatched).mockResolvedValue({
     assetPair: 'BTC/USD',
     price: 50010,
     timestamp: 1700000001000,
@@ -143,7 +143,7 @@ describe('PriceProvider', () => {
   })
 
   it('rolls back when REST revalidation conflicts with the optimistic update', async () => {
-    vi.mocked(fetchPrice).mockResolvedValueOnce({
+    vi.mocked(fetchPricesBatched).mockResolvedValueOnce({
       assetPair: 'BTC/USD',
       price: 49990,
       timestamp: 1700000002000,

--- a/src/context/PriceContext.tsx
+++ b/src/context/PriceContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { WebSocketClient, type ConnectionStatus } from '../api/websocket'
-import { fetchAllPrices, fetchPrice } from '../api/rest'
+import { fetchAllPrices, fetchPricesBatched } from '../api/rest'
 import { rateLimitManager, type RateLimitStatus } from '../api/rateLimit'
 import { config } from '../config'
 import type { LivePriceEntry, PriceData } from '../types'
@@ -108,7 +108,7 @@ export function PriceProvider({ children }: { children: ReactNode }) {
 
     const revalidatePair = async (pair: string, requestId: number) => {
       try {
-        const restPrice = await fetchPrice(pair)
+        const restPrice = await fetchPricesBatched(pair)
 
         if (requestIds.get(pair) !== requestId) return
 

--- a/src/hooks/useAlerts.tsx
+++ b/src/hooks/useAlerts.tsx
@@ -5,6 +5,9 @@ import { AlertsArraySchema } from '../api/schemas'
 import { readJson, writeJson, STORAGE_KEYS } from '../utils/storage'
 import { useRateLimit } from './useRateLimit'
 
+/** Cap on the fired-alert history log (#309), oldest entries dropped first. */
+const HISTORY_LIMIT = 500
+
 // ---------------------------------------------------------------------------
 // #315 – Notification channel types (mirrors NotificationChannelsModal)
 // ---------------------------------------------------------------------------

--- a/src/hooks/usePriceHistory.ts
+++ b/src/hooks/usePriceHistory.ts
@@ -42,6 +42,7 @@ export function usePriceHistory(
   const loadingMoreRef = useRef(false)
   const hasMoreRef = useRef(true)
   const hasFetchedRef = useRef(false)
+  const abortRef = useRef<AbortController | null>(null)
 
   // Track page visibility
   const isVisibleRef = useRef(
@@ -52,14 +53,20 @@ export function usePriceHistory(
   const refetch = useCallback(async () => {
     if (!pair) return
 
+    // Cancel any in-flight request for this pair (duplicate call, e.g. from a
+    // refresh interval firing before the previous fetch settled).
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
     try {
       setLoading(true)
       setError(null)
       offsetRef.current = 0
 
-      const res = await fetchPriceHistory(pair, pageSize, 0)
+      const res = await fetchPriceHistory(pair, pageSize, 0, undefined, undefined, controller.signal)
 
-      if (!isMountedRef.current) return
+      if (!isMountedRef.current || controller.signal.aborted) return
 
       setHistory(res.history)
       const hasMore = res.history.length === pageSize
@@ -68,12 +75,13 @@ export function usePriceHistory(
       offsetRef.current = pageSize
       hasFetchedRef.current = true
     } catch (err) {
-      if (!isMountedRef.current) return
+      if (!isMountedRef.current || controller.signal.aborted) return
+      if (err instanceof DOMException && err.name === 'AbortError') return
       const error = err instanceof Error ? err : new Error(String(err))
       setError(error)
       onError?.(error)
     } finally {
-      if (isMountedRef.current) {
+      if (isMountedRef.current && !controller.signal.aborted) {
         setLoading(false)
       }
     }
@@ -86,14 +94,18 @@ export function usePriceHistory(
       return
     }
 
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
     try {
       loadingMoreRef.current = true
       setLoadingMore(true)
       setError(null)
 
-      const res = await fetchPriceHistory(pair, pageSize, offsetRef.current)
+      const res = await fetchPriceHistory(pair, pageSize, offsetRef.current, undefined, undefined, controller.signal)
 
-      if (!isMountedRef.current) return
+      if (!isMountedRef.current || controller.signal.aborted) return
 
       if (res.history.length === 0) {
         hasMoreRef.current = false
@@ -106,12 +118,13 @@ export function usePriceHistory(
         offsetRef.current += res.history.length
       }
     } catch (err) {
-      if (!isMountedRef.current) return
+      if (!isMountedRef.current || controller.signal.aborted) return
+      if (err instanceof DOMException && err.name === 'AbortError') return
       const error = err instanceof Error ? err : new Error(String(err))
       setError(error)
       onError?.(error)
     } finally {
-      if (isMountedRef.current) {
+      if (isMountedRef.current && !controller.signal.aborted) {
         loadingMoreRef.current = false
         setLoadingMore(false)
       }
@@ -167,6 +180,7 @@ export function usePriceHistory(
   useEffect(() => {
     return () => {
       isMountedRef.current = false
+      abortRef.current?.abort()
     }
   }, [])
 

--- a/src/integration/contextHookIntegration.test.tsx
+++ b/src/integration/contextHookIntegration.test.tsx
@@ -53,19 +53,23 @@ vi.mock('../api/rest', () => ({
 }))
 
 vi.mock('../api/websocket', () => ({
-  WebSocketClient: vi.fn(() => ({
-    status: 'connected',
-    connect: vi.fn(),
-    disconnect: vi.fn(),
-    onMessage: vi.fn((handler) => {
-      messageHandler = handler
-      return vi.fn()
-    }),
-    onStatusChange: vi.fn(() => vi.fn()),
-    subscribe: vi.fn(),
-    unsubscribe: vi.fn(),
-    send: vi.fn(),
-  })),
+  // A real `function`, not an arrow function, so vitest's mock can be invoked
+  // with `new` (PriceProvider does `new WebSocketClient()`).
+  WebSocketClient: vi.fn(function WebSocketClient() {
+    return {
+      status: 'connected',
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      onMessage: vi.fn((handler: typeof messageHandler) => {
+        messageHandler = handler
+        return vi.fn()
+      }),
+      onStatusChange: vi.fn(() => vi.fn()),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      send: vi.fn(),
+    }
+  }),
 }))
 
 function makeQueryClient() {

--- a/src/integration/contextHookIntegration.test.tsx
+++ b/src/integration/contextHookIntegration.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { PriceProvider } from '../context/PriceContext'
+import { AlertsProvider, useAlerts } from '../hooks/useAlerts'
+import { PreferencesProvider, usePreferences } from '../preferences/PreferencesContext'
+import type { ReactNode } from 'react'
+
+// ---------------------------------------------------------------------------
+// PriceContext + useAlerts + WebSocket integration (#329)
+// ---------------------------------------------------------------------------
+// Unlike useAlerts.test.ts (which mocks usePriceContext entirely) and
+// PriceContext.test.tsx (which never mounts a consumer of livePrices beyond a
+// bare test component), this exercises the real cross-module wiring: a
+// WebSocket price_update flows through the real PriceProvider into real
+// AlertsProvider's alert-evaluation effect, driving a real fired-alert entry.
+
+let messageHandler: ((msg: {
+  type: 'price_update'
+  assetPair: string
+  price: number
+  timestamp: number
+  confidence: number
+  sources: string[]
+}) => void) | null = null
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
+  return {
+    ...actual,
+    useQuery: vi.fn(() => ({
+      data: [
+        { assetPair: 'BTC/USD', price: 50000, timestamp: Date.now(), confidence: 0.99, sources: ['chainlink'] },
+      ],
+      isLoading: false,
+      error: null,
+      isFetching: false,
+      refetch: vi.fn(),
+    })),
+  }
+})
+
+vi.mock('../api/rest', () => ({
+  fetchAllPrices: vi.fn(),
+  // Resolve with data matching the optimistic WS update so the sync state
+  // settles to 'confirmed' rather than rolling back — irrelevant to alert
+  // firing (which reacts to the optimistic livePrices update directly) but
+  // keeps the provider's own confirmation flow from throwing unhandled errors.
+  fetchPricesBatched: vi.fn((pair: string) =>
+    Promise.resolve({ assetPair: pair, price: 56000, timestamp: 1700000001000, confidence: 0.99, sources: ['chainlink'] }),
+  ),
+}))
+
+vi.mock('../api/websocket', () => ({
+  WebSocketClient: vi.fn(() => ({
+    status: 'connected',
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    onMessage: vi.fn((handler) => {
+      messageHandler = handler
+      return vi.fn()
+    }),
+    onStatusChange: vi.fn(() => vi.fn()),
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    send: vi.fn(),
+  })),
+}))
+
+function makeQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function AlertsWrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={makeQueryClient()}>
+      <PriceProvider>
+        <AlertsProvider>{children}</AlertsProvider>
+      </PriceProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('PriceContext + useAlerts + WebSocket integration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    messageHandler = null
+  })
+
+  afterEach(cleanup)
+
+  it('fires an alert and records history when a live WebSocket update crosses the threshold', async () => {
+    const { result } = renderHook(() => useAlerts(), { wrapper: AlertsWrapper })
+
+    act(() => {
+      result.current.addAlert({
+        assetPair: 'BTC/USD',
+        upperThreshold: 55000,
+        lowerThreshold: null,
+        triggerOnce: true,
+        active: true,
+      })
+    })
+    expect(result.current.alerts).toHaveLength(1)
+
+    act(() => {
+      messageHandler?.({
+        type: 'price_update',
+        assetPair: 'BTC/USD',
+        price: 56000,
+        timestamp: 1700000001000,
+        confidence: 0.99,
+        sources: ['chainlink'],
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.alertHistory).toHaveLength(1)
+    })
+    expect(result.current.alertHistory[0].assetPair).toBe('BTC/USD')
+    expect(result.current.alertHistory[0].price).toBe(56000)
+    // One-time alert: fired once then auto-disabled.
+    expect(result.current.alerts[0].fireCount).toBe(1)
+    expect(result.current.alerts[0].active).toBe(false)
+
+    // Persisted to localStorage as part of the same real-hook flow.
+    const storedHistory = JSON.parse(localStorage.getItem('alert-history') ?? '[]')
+    expect(storedHistory).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PreferencesContext + useLocalStorage persistence (#329)
+// ---------------------------------------------------------------------------
+// PreferencesContext.test.tsx exercises the real useLocalStorage-backed
+// provider within a single mount, but never verifies the value actually
+// survives a remount (i.e. that it round-trips through localStorage rather
+// than just living in React state).
+
+function PreferencesWrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={['/']}>
+      <PreferencesProvider>{children}</PreferencesProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('PreferencesContext + useLocalStorage integration', () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(cleanup)
+
+  it('persists a preference change to localStorage and reloads it on remount', () => {
+    const { result, unmount } = renderHook(() => usePreferences(), { wrapper: PreferencesWrapper })
+
+    act(() => result.current.updatePreference('refreshInterval', 30000))
+    expect(result.current.preferences.refreshInterval).toBe(30000)
+
+    unmount()
+
+    const { result: remounted } = renderHook(() => usePreferences(), { wrapper: PreferencesWrapper })
+    expect(remounted.current.preferences.refreshInterval).toBe(30000)
+  })
+})

--- a/src/integration/contextHookIntegration.test.tsx
+++ b/src/integration/contextHookIntegration.test.tsx
@@ -131,12 +131,29 @@ describe('PriceContext + useAlerts + WebSocket integration', () => {
 })
 
 // ---------------------------------------------------------------------------
-// PreferencesContext + useLocalStorage persistence (#329)
+// PreferencesContext + IndexedDB persistence (#329)
 // ---------------------------------------------------------------------------
-// PreferencesContext.test.tsx exercises the real useLocalStorage-backed
-// provider within a single mount, but never verifies the value actually
-// survives a remount (i.e. that it round-trips through localStorage rather
-// than just living in React state).
+// PreferencesContext.test.tsx mocks idbCache.get to always resolve `null`, so
+// it never exercises the actual persist-then-reload round trip (preferences
+// are persisted to IndexedDB via `idbCache`, not `useLocalStorage` — despite
+// the hook's name, `useLocalStorage` is unused by this provider). This test
+// backs the mock with a real in-memory store so a value written by one
+// mount is genuinely read back by the next.
+const idbStore = new Map<string, unknown>()
+
+vi.mock('../hooks/useIndexedDB', () => ({
+  idbCache: {
+    get: vi.fn((_store: string, key: string) => Promise.resolve(idbStore.get(key) ?? null)),
+    set: vi.fn((_store: string, key: string, value: unknown) => {
+      idbStore.set(key, value)
+      return Promise.resolve()
+    }),
+    delete: vi.fn(),
+    clear: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+    fetchWithCache: vi.fn(),
+  },
+}))
 
 function PreferencesWrapper({ children }: { children: ReactNode }) {
   return (
@@ -146,19 +163,22 @@ function PreferencesWrapper({ children }: { children: ReactNode }) {
   )
 }
 
-describe('PreferencesContext + useLocalStorage integration', () => {
-  beforeEach(() => localStorage.clear())
+describe('PreferencesContext + IndexedDB integration', () => {
+  beforeEach(() => idbStore.clear())
   afterEach(cleanup)
 
-  it('persists a preference change to localStorage and reloads it on remount', () => {
+  it('persists a preference change and reloads it on remount', async () => {
     const { result, unmount } = renderHook(() => usePreferences(), { wrapper: PreferencesWrapper })
 
     act(() => result.current.updatePreference('refreshInterval', 30000))
     expect(result.current.preferences.refreshInterval).toBe(30000)
 
+    // Wait for the persist-on-change effect to write to the (fake) IndexedDB store.
+    await waitFor(() => expect(idbStore.get('user-preferences')).toBeTruthy())
+
     unmount()
 
     const { result: remounted } = renderHook(() => usePreferences(), { wrapper: PreferencesWrapper })
-    expect(remounted.current.preferences.refreshInterval).toBe(30000)
+    await waitFor(() => expect(remounted.current.preferences.refreshInterval).toBe(30000))
   })
 })

--- a/src/preferences/PreferencesContext.tsx
+++ b/src/preferences/PreferencesContext.tsx
@@ -23,16 +23,7 @@ const PreferencesContext = createContext<PreferencesContextValue | null>(null)
 export function PreferencesProvider({ children }: { children: ReactNode }) {
   const location = useLocation()
   const prevPathRef = useRef(location.pathname)
-  const [initialPrefs, setInitialPrefs] = useState<Preferences>(DEFAULT_PREFERENCES)
   const [idbLoaded, setIdbLoaded] = useState(false)
-
-  // Load persisted preferences from IndexedDB on mount
-  useEffect(() => {
-    idbCache.get<Preferences>('preferences', PREFS_IDB_KEY, Infinity).then((saved) => {
-      if (saved) setInitialPrefs({ ...DEFAULT_PREFERENCES, ...saved })
-      setIdbLoaded(true)
-    })
-  }, [])
 
   const {
     state: preferences,
@@ -42,7 +33,20 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
     canUndo,
     canRedo,
     clear,
-  } = useUndoRedo<Preferences>(initialPrefs, MAX_UNDO_DEPTH)
+    reset,
+  } = useUndoRedo<Preferences>(DEFAULT_PREFERENCES, MAX_UNDO_DEPTH)
+
+  // Load persisted preferences from IndexedDB on mount. `reset` (rather than
+  // the initial state passed to useUndoRedo) is required here since that
+  // initial value is only ever read on the very first render — by the time
+  // this async load resolves, useUndoRedo's own state already exists and
+  // won't re-sync to a later change in the value it was constructed with.
+  useEffect(() => {
+    idbCache.get<Preferences>('preferences', PREFS_IDB_KEY, Infinity).then((saved) => {
+      if (saved) reset({ ...DEFAULT_PREFERENCES, ...saved })
+      setIdbLoaded(true)
+    })
+  }, [reset])
 
   // Persist to IndexedDB whenever preferences change
   useEffect(() => {


### PR DESCRIPTION
Summary
Addresses four open issues around API resilience, request efficiency, and test coverage:

#328 – Request cancellation: usePriceHistory now cancels its own in-flight request when a new one starts (interval fire, loadMore, pair change) or the component unmounts, instead of only guarding state updates after the fact.
#332 – Circuit breaker: adds a per-endpoint-group circuit breaker (src/api/circuitBreaker.ts) wired into the REST client. After repeated failures it opens (blocking further requests to that group), notifies via toast, and half-opens after a cooldown to test recovery. Thresholds/window/cooldown are configurable in config.circuitBreaker.
#327 – Batch price fetching: per-pair WebSocket price confirmations (previously one fetchPrice call per pair per message) are now debounced into a single batched fetchAllPrices call (fetchPricesBatched), capped at a configurable batch size, with per-pair fallback on partial or total batch failure. Config in config.priceBatch.
#329 – Integration tests: adds src/integration/contextHookIntegration.test.tsx covering two previously-untested cross-module flows: a real WebSocket price update flowing through PriceContext into useAlerts' alert-evaluation effect (asset pair crossing a threshold → fired alert + history entry), and PreferencesContext's IndexedDB-backed persistence surviving a provider remount.
Writing the integration test for #329 surfaced two pre-existing bugs that made the flows it covers non-functional, so they're fixed here as well (both are one/two-line, low-risk fixes directly required for the new tests to be meaningful rather than passing against broken code):

useAlerts.tsx referenced an undefined HISTORY_LIMIT constant — any alert firing threw a ReferenceError and crashed the alert history log.
PreferencesContext loaded persisted preferences from IndexedDB into a useState that was only ever read on first render, so the async load never actually applied — restored via useUndoRedo's reset().
Closes
Closes #327
Closes #328
Closes #329
Closes #332

Test plan
 npx vitest run for all touched/added files (rest.test.ts, usePriceHistory.test.ts, PriceContext.test.tsx, PreferencesContext.test.tsx, useAlerts.test.ts, new integration/contextHookIntegration.test.tsx) — all pass except pre-existing failures confirmed present on main before this branch (verified via a clean worktree diff), unrelated to these changes.
 tsc -b / eslint could not be validated end-to-end — this repo's pinned ESLint 10 conflicts with its @typescript-eslint peer deps, and tsc -b has substantial pre-existing errors across unrelated files, independent of this branch.
