### PR TITLE
Feature/export enhancements 311 316 317 318

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "comlink": "4.4.2",
         "i18next": "24.2.3",
         "i18next-browser-languagedetector": "8.0.5",
+        "jspdf": "^4.2.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-i18next": "15.5.1",
@@ -2056,6 +2057,19 @@
         "undici-types": "~8.3.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -2092,6 +2106,13 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -3004,6 +3025,16 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
@@ -3064,6 +3095,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/chai": {
@@ -3275,6 +3326,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
@@ -3343,6 +3406,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -3628,6 +3701,16 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -4033,6 +4116,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -4076,6 +4170,12 @@
       "dependencies": {
         "fast-string-width": "^3.0.2"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -4311,6 +4411,20 @@
         "void-elements": "3.1.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4514,6 +4628,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -4861,6 +4981,23 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -5882,6 +6019,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5960,6 +6113,13 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6117,6 +6277,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
       }
     },
     "node_modules/react": {
@@ -6286,6 +6456,13 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6368,6 +6545,16 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rolldown": {
       "version": "1.1.5",
@@ -6650,6 +6837,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -6770,6 +6967,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -6822,6 +7029,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/through": {
@@ -7127,6 +7344,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/victory-vendor": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "comlink": "4.4.2",
     "i18next": "24.2.3",
     "i18next-browser-languagedetector": "8.0.5",
+    "jspdf": "^4.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-i18next": "15.5.1",

--- a/src/components/ColumnSelectorModal.tsx
+++ b/src/components/ColumnSelectorModal.tsx
@@ -1,0 +1,168 @@
+import { useState, type ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useDragSort } from '../hooks/useDragSort'
+import {
+  COLUMN_PRESETS,
+  EXPORT_COLUMNS,
+  type ColumnPresetName,
+  type ExportColumnKey,
+} from '../utils/exportColumns'
+
+const PRESET_NAMES: ColumnPresetName[] = ['minimal', 'standard', 'full']
+const LABELS = Object.fromEntries(EXPORT_COLUMNS.map((c) => [c.key, c.label])) as Record<ExportColumnKey, string>
+
+interface DraggableColumnListProps {
+  columns: ExportColumnKey[]
+  onChange: (columns: ExportColumnKey[]) => void
+  onRemove: (key: ExportColumnKey) => void
+}
+
+function DraggableColumnList({ columns, onChange, onRemove }: DraggableColumnListProps): ReactElement {
+  const { items, dragState, getItemProps } = useDragSort<ExportColumnKey>(columns, onChange)
+
+  return (
+    <ul className="space-y-1" aria-label="Selected export columns, drag to reorder">
+      {items.map((key, i) => (
+        <li
+          key={key}
+          {...getItemProps(i)}
+          className={`flex items-center gap-2 px-2 py-1.5 rounded-lg border text-sm cursor-move bg-gray-800 text-gray-200 transition-colors ${
+            dragState.dragIndex === i ? 'opacity-40' : ''
+          } ${dragState.overIndex === i ? 'border-cyan-500' : 'border-gray-700'}`}
+        >
+          <svg className="w-3.5 h-3.5 text-gray-500 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <path d="M7 4a1 1 0 100 2 1 1 0 000-2zM7 9a1 1 0 100 2 1 1 0 000-2zM7 14a1 1 0 100 2 1 1 0 000-2zM13 4a1 1 0 100 2 1 1 0 000-2zM13 9a1 1 0 100 2 1 1 0 000-2zM13 14a1 1 0 100 2 1 1 0 000-2z" />
+          </svg>
+          <span className="flex-1">{LABELS[key]}</span>
+          <button
+            type="button"
+            onClick={() => onRemove(key)}
+            className="text-gray-500 hover:text-red-400 transition-colors"
+            aria-label={`Remove ${LABELS[key]} column`}
+          >
+            ×
+          </button>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+interface ColumnSelectorModalProps {
+  format: string
+  columns: ExportColumnKey[]
+  onChange: (columns: ExportColumnKey[]) => void
+  onApplyPreset: (preset: ColumnPresetName) => void
+  onClose: () => void
+}
+
+export function ColumnSelectorModal({
+  format,
+  columns,
+  onChange,
+  onApplyPreset,
+  onClose,
+}: ColumnSelectorModalProps): ReactElement {
+  const { t } = useTranslation()
+  const [search, setSearch] = useState('')
+
+  const filtered = EXPORT_COLUMNS.filter((c) => c.label.toLowerCase().includes(search.toLowerCase()))
+
+  const toggle = (key: ExportColumnKey) => {
+    if (columns.includes(key)) {
+      if (columns.length === 1) return
+      onChange(columns.filter((c) => c !== key))
+    } else {
+      onChange([...columns, key])
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('export.columns.title', { defaultValue: 'Select export columns' }) as string}
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-gray-900 border border-gray-700 rounded-2xl w-full max-w-md p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-100">
+            {t('export.columns.title', { defaultValue: 'Select export columns' })}{' '}
+            <span className="text-gray-500 font-normal">({format.toUpperCase()})</span>
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-300"
+            aria-label={t('common.close', { defaultValue: 'Close' }) as string}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex gap-2">
+          {PRESET_NAMES.map((preset) => (
+            <button
+              key={preset}
+              type="button"
+              onClick={() => onApplyPreset(preset)}
+              className={`px-2.5 py-1 text-xs rounded-lg border capitalize transition-colors ${
+                columns.length === COLUMN_PRESETS[preset].length &&
+                columns.every((c, i) => c === COLUMN_PRESETS[preset][i])
+                  ? 'bg-cyan-500/20 border-cyan-500/40 text-cyan-400'
+                  : 'border-gray-700 text-gray-300 hover:bg-gray-800'
+              }`}
+            >
+              {t(`export.columns.preset.${preset}`, { defaultValue: preset })}
+            </button>
+          ))}
+        </div>
+
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={t('export.columns.search', { defaultValue: 'Filter columns…' }) as string}
+          className="w-full px-3 py-1.5 text-sm rounded-lg bg-gray-800 border border-gray-700 text-gray-200 placeholder-gray-500 focus:outline-none focus:border-cyan-500"
+        />
+
+        <div>
+          <p className="text-xs text-gray-500 mb-1.5">{t('export.columns.available', { defaultValue: 'Available' })}</p>
+          <div className="flex flex-wrap gap-1.5">
+            {filtered.map((c) => (
+              <label
+                key={c.key}
+                className="flex items-center gap-1.5 px-2 py-1 rounded-lg border border-gray-700 text-xs text-gray-300 cursor-pointer hover:bg-gray-800"
+              >
+                <input type="checkbox" checked={columns.includes(c.key)} onChange={() => toggle(c.key)} className="accent-cyan-500" />
+                {c.label}
+              </label>
+            ))}
+            {filtered.length === 0 && <p className="text-xs text-gray-600">{t('export.columns.noMatches', { defaultValue: 'No matching columns' })}</p>}
+          </div>
+        </div>
+
+        <div>
+          <p className="text-xs text-gray-500 mb-1.5">{t('export.columns.selectedOrder', { defaultValue: 'Selected (drag to reorder)' })}</p>
+          <DraggableColumnList key={columns.join(',')} columns={columns} onChange={onChange} onRemove={toggle} />
+        </div>
+
+        <div className="pt-2 border-t border-gray-800">
+          <p className="text-xs text-gray-500 mb-1">{t('export.columns.preview', { defaultValue: 'Preview' })}</p>
+          <p className="text-xs font-mono text-gray-400 truncate">{columns.map((k) => LABELS[k]).join(', ')}</p>
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-1.5 text-sm rounded-lg bg-cyan-600 hover:bg-cyan-500 text-white transition-colors"
+          >
+            {t('common.done', { defaultValue: 'Done' })}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ExportProgressPanel.tsx
+++ b/src/components/ExportProgressPanel.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState, type ReactElement } from 'react'
+import type { ExportTask } from '../hooks/useExportQueue'
+
+interface ExportProgressPanelProps {
+  tasks: ExportTask[]
+  onCancel: (id: string) => void
+  onDismiss: (id: string) => void
+}
+
+const STATUS_LABEL: Record<ExportTask['status'], string> = {
+  processing: 'Exporting…',
+  done: 'Complete',
+  error: 'Failed',
+  cancelled: 'Cancelled',
+}
+
+function estimateRemainingMs(task: ExportTask, now: number): number | null {
+  if (task.status !== 'processing' || task.total === 0 || task.processed === 0) return null
+  const elapsed = now - task.startedAt
+  const rate = task.processed / elapsed
+  if (!Number.isFinite(rate) || rate <= 0) return null
+  return Math.max(0, Math.round((task.total - task.processed) / rate))
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) return '<1s'
+  const sec = Math.round(ms / 1000)
+  if (sec < 60) return `${sec}s`
+  return `${Math.floor(sec / 60)}m ${sec % 60}s`
+}
+
+/** Fixed-position panel showing queued/active export tasks with progress, cancellation, and status (#311). */
+export function ExportProgressPanel({ tasks, onCancel, onDismiss }: ExportProgressPanelProps): ReactElement | null {
+  const [now, setNow] = useState(() => Date.now())
+
+  const hasActive = tasks.some((t) => t.status === 'processing')
+  useEffect(() => {
+    if (!hasActive) return
+    const interval = setInterval(() => setNow(Date.now()), 250)
+    return () => clearInterval(interval)
+  }, [hasActive])
+
+  if (tasks.length === 0) return null
+
+  return (
+    <div
+      className="fixed bottom-4 right-4 z-40 w-80 max-w-[calc(100vw-2rem)] space-y-2"
+      role="region"
+      aria-label="Export progress"
+    >
+      {tasks.map((task) => {
+        const pct = task.total === 0 ? 100 : Math.round((task.processed / task.total) * 100)
+        const remaining = estimateRemainingMs(task, now)
+        return (
+          <div
+            key={task.id}
+            className="bg-gray-900 border border-gray-700 rounded-xl p-3 shadow-lg text-xs text-gray-300"
+          >
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="font-medium truncate">{task.label}</span>
+              <span
+                className={
+                  task.status === 'error'
+                    ? 'text-red-400'
+                    : task.status === 'done'
+                      ? 'text-green-400'
+                      : 'text-gray-500'
+                }
+              >
+                {STATUS_LABEL[task.status]}
+              </span>
+            </div>
+
+            <div className="h-1.5 rounded-full bg-gray-800 overflow-hidden" role="progressbar" aria-valuenow={pct} aria-valuemin={0} aria-valuemax={100}>
+              <div
+                className={`h-full rounded-full transition-all ${task.status === 'error' ? 'bg-red-500' : task.status === 'cancelled' ? 'bg-gray-600' : 'bg-cyan-500'}`}
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+
+            <div className="flex items-center justify-between mt-1.5 text-gray-500">
+              <span>
+                {task.processed}/{task.total} · {pct}%
+                {remaining !== null && ` · ~${formatMs(remaining)} left`}
+              </span>
+              {task.status === 'processing' ? (
+                <button
+                  type="button"
+                  onClick={() => onCancel(task.id)}
+                  className="text-gray-400 hover:text-red-400 transition-colors"
+                >
+                  Cancel
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => onDismiss(task.id)}
+                  className="text-gray-400 hover:text-gray-200 transition-colors"
+                  aria-label={`Dismiss ${task.label} export`}
+                >
+                  Dismiss
+                </button>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -15,7 +15,8 @@ import {
 import type { TooltipProps } from 'recharts'
 import type { PriceHistoryEntry } from '../types'
 import { formatChartTimeWithTz, formatPriceShort, formatTimestamp, getTimezoneAbbr } from '../utils/format'
-import { exportChartAsPng, exportChartAsSvg } from '../utils/chartExport'
+import { exportChartAsPng, exportChartAsSvg, rasterizeChartToDataUrl } from '../utils/chartExport'
+import { exportPriceHistoryPdf } from '../utils/pdfExport'
 
 // ---------------------------------------------------------------------------
 // #305 – Chart annotation types
@@ -428,7 +429,7 @@ function ChartContent({
       : null
 
   const handleExport = useCallback(
-    async (format: 'png' | 'svg') => {
+    async (format: 'png' | 'svg' | 'pdf') => {
       const container = chartWrapperRef.current
       if (!container) return
       setExportMenuOpen(false)
@@ -439,6 +440,9 @@ function ChartContent({
         const filename = `${safePair}_${timeRange}.${format}`
         if (format === 'svg') {
           exportChartAsSvg(container, filename, bgColor)
+        } else if (format === 'pdf') {
+          const chart = await rasterizeChartToDataUrl(container, bgColor)
+          exportPriceHistoryPdf({ pair, history: data, chart, filename })
         } else {
           await exportChartAsPng(container, filename, bgColor)
         }
@@ -446,7 +450,7 @@ function ChartContent({
         setExporting(false)
       }
     },
-    [dark, pair, timeRange],
+    [dark, pair, timeRange, data],
   )
 
   // Check if user scrolled near the start to trigger load more
@@ -583,6 +587,14 @@ function ChartContent({
                   className="w-full text-left px-3 py-2 text-xs text-gray-300 hover:bg-gray-700 transition-colors"
                 >
                   Export as SVG
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => handleExport('pdf')}
+                  className="w-full text-left px-3 py-2 text-xs text-gray-300 hover:bg-gray-700 transition-colors"
+                >
+                  Export as PDF
                 </button>
               </div>
             )}

--- a/src/components/ScheduledExportsPanel.tsx
+++ b/src/components/ScheduledExportsPanel.tsx
@@ -1,0 +1,183 @@
+import { useState, type ReactElement } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { ExportFormat } from '../hooks/useExport'
+import type { ExportFrequency, UseScheduledExportsReturn } from '../hooks/useScheduledExports'
+
+interface ScheduledExportsPanelProps extends UseScheduledExportsReturn {
+  isOpen: boolean
+  onClose: () => void
+  availablePairs: string[]
+}
+
+const FREQUENCIES: ExportFrequency[] = ['daily', 'weekly', 'monthly']
+const FORMATS: ExportFormat[] = ['csv', 'json', 'xlsx']
+
+function formatDateTime(ts: number): string {
+  return new Date(ts).toLocaleString()
+}
+
+export function ScheduledExportsPanel({
+  isOpen,
+  onClose,
+  availablePairs,
+  schedules,
+  history,
+  createSchedule,
+  deleteSchedule,
+  runNow,
+}: ScheduledExportsPanelProps): ReactElement | null {
+  const { t } = useTranslation()
+  const [label, setLabel] = useState('')
+  const [format, setFormat] = useState<ExportFormat>('csv')
+  const [frequency, setFrequency] = useState<ExportFrequency>('weekly')
+  const [selectedPairs, setSelectedPairs] = useState<Set<string>>(new Set())
+
+  if (!isOpen) return null
+
+  const togglePair = (pair: string) => {
+    setSelectedPairs((prev) => {
+      const next = new Set(prev)
+      if (next.has(pair)) next.delete(pair)
+      else next.add(pair)
+      return next
+    })
+  }
+
+  const handleCreate = () => {
+    createSchedule({ label, pairs: [...selectedPairs], format, frequency })
+    setLabel('')
+    setSelectedPairs(new Set())
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('scheduledExports.title', { defaultValue: 'Scheduled exports' }) as string}
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-gray-900 border border-gray-700 rounded-2xl w-full max-w-lg max-h-[85vh] overflow-y-auto p-5 space-y-5">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-100">{t('scheduledExports.title', { defaultValue: 'Scheduled exports' })}</h2>
+          <button type="button" onClick={onClose} className="text-gray-500 hover:text-gray-300" aria-label={t('common.close', { defaultValue: 'Close' }) as string}>
+            ✕
+          </button>
+        </div>
+
+        <section className="space-y-2.5">
+          <h3 className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+            {t('scheduledExports.newSchedule', { defaultValue: 'New schedule' })}
+          </h3>
+
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder={t('scheduledExports.labelPlaceholder', { defaultValue: 'Schedule name' }) as string}
+            className="w-full px-3 py-1.5 text-sm rounded-lg bg-gray-800 border border-gray-700 text-gray-200 placeholder-gray-500 focus:outline-none focus:border-cyan-500"
+          />
+
+          <div className="flex gap-2">
+            <select
+              value={frequency}
+              onChange={(e) => setFrequency(e.target.value as ExportFrequency)}
+              className="flex-1 px-2 py-1.5 text-sm rounded-lg bg-gray-800 border border-gray-700 text-gray-200"
+              aria-label={t('scheduledExports.frequency', { defaultValue: 'Frequency' }) as string}
+            >
+              {FREQUENCIES.map((f) => (
+                <option key={f} value={f}>
+                  {t(`scheduledExports.frequencies.${f}`, { defaultValue: f })}
+                </option>
+              ))}
+            </select>
+            <select
+              value={format}
+              onChange={(e) => setFormat(e.target.value as ExportFormat)}
+              className="flex-1 px-2 py-1.5 text-sm rounded-lg bg-gray-800 border border-gray-700 text-gray-200"
+              aria-label={t('scheduledExports.format', { defaultValue: 'Format' }) as string}
+            >
+              {FORMATS.map((f) => (
+                <option key={f} value={f}>
+                  {f.toUpperCase()}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <p className="text-xs text-gray-500 mb-1.5">
+              {t('scheduledExports.pairs', { defaultValue: 'Pairs (none selected = all pairs)' })}
+            </p>
+            <div className="flex flex-wrap gap-1.5 max-h-28 overflow-y-auto">
+              {availablePairs.map((pair) => (
+                <label key={pair} className="flex items-center gap-1.5 px-2 py-1 rounded-lg border border-gray-700 text-xs text-gray-300 cursor-pointer hover:bg-gray-800">
+                  <input type="checkbox" checked={selectedPairs.has(pair)} onChange={() => togglePair(pair)} className="accent-cyan-500" />
+                  {pair}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={handleCreate}
+            className="w-full px-3 py-1.5 text-sm rounded-lg bg-cyan-600 hover:bg-cyan-500 text-white transition-colors"
+          >
+            {t('scheduledExports.create', { defaultValue: 'Create schedule' })}
+          </button>
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+            {t('scheduledExports.active', { defaultValue: 'Active schedules' })}
+          </h3>
+          {schedules.length === 0 ? (
+            <p className="text-xs text-gray-600">{t('scheduledExports.none', { defaultValue: 'No schedules yet.' })}</p>
+          ) : (
+            <ul className="space-y-1.5">
+              {schedules.map((s) => (
+                <li key={s.id} className="flex items-center justify-between gap-2 px-2.5 py-2 rounded-lg bg-gray-800 border border-gray-700 text-xs">
+                  <div className="min-w-0">
+                    <p className="text-gray-200 font-medium truncate">{s.label}</p>
+                    <p className="text-gray-500">
+                      {t(`scheduledExports.frequencies.${s.frequency}`, { defaultValue: s.frequency })} · {s.format.toUpperCase()} ·{' '}
+                      {s.pairs.length > 0 ? `${s.pairs.length} pair${s.pairs.length === 1 ? '' : 's'}` : t('scheduledExports.allPairs', { defaultValue: 'all pairs' })}
+                    </p>
+                    <p className="text-gray-600">{t('scheduledExports.next', { defaultValue: 'Next' })}: {formatDateTime(s.nextRunAt)}</p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <button type="button" onClick={() => runNow(s.id)} className="text-cyan-400 hover:text-cyan-300 transition-colors">
+                      {t('scheduledExports.runNow', { defaultValue: 'Run now' })}
+                    </button>
+                    <button type="button" onClick={() => deleteSchedule(s.id)} className="text-gray-500 hover:text-red-400 transition-colors">
+                      {t('scheduledExports.delete', { defaultValue: 'Delete' })}
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          <h3 className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+            {t('scheduledExports.history', { defaultValue: 'History' })}
+          </h3>
+          {history.length === 0 ? (
+            <p className="text-xs text-gray-600">{t('scheduledExports.noHistory', { defaultValue: 'No exports have run yet.' })}</p>
+          ) : (
+            <ul className="space-y-1 max-h-40 overflow-y-auto">
+              {[...history].reverse().map((h) => (
+                <li key={h.id} className="flex items-center justify-between text-xs text-gray-500 px-2.5 py-1.5 rounded-lg bg-gray-800/60">
+                  <span className="truncate">{h.scheduleLabel} · {h.format.toUpperCase()} · {h.pairCount} pairs</span>
+                  <span className="shrink-0">{formatDateTime(h.ranAt)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useColumnSelection.ts
+++ b/src/hooks/useColumnSelection.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useIdbQuery, useIdbMutation } from './useIdbQuery'
+import {
+  COLUMN_PRESETS,
+  EXPORT_COLUMN_KEYS,
+  sanitizeColumns,
+  type ColumnPresetName,
+  type ExportColumnKey,
+} from '../utils/exportColumns'
+
+export interface UseColumnSelectionReturn {
+  columns: ExportColumnKey[]
+  setColumns: (columns: ExportColumnKey[]) => void
+  applyPreset: (preset: ColumnPresetName) => void
+  loading: boolean
+}
+
+/**
+ * Persists the user's selected/ordered export columns per export format
+ * (#317) in IndexedDB, following the same `useIdbQuery`/`useIdbMutation`
+ * pattern as other per-user preferences.
+ */
+export function useColumnSelection(format: string): UseColumnSelectionReturn {
+  const idbKey = `export-columns-${format}`
+  const { data, loading } = useIdbQuery<ExportColumnKey[]>('preferences', idbKey)
+  const { set } = useIdbMutation()
+  const [columns, setColumnsState] = useState<ExportColumnKey[]>(EXPORT_COLUMN_KEYS)
+
+  useEffect(() => {
+    if (!loading) setColumnsState(sanitizeColumns(data ?? undefined))
+  }, [data, loading])
+
+  const setColumns = useCallback(
+    (next: ExportColumnKey[]) => {
+      const sanitized = sanitizeColumns(next)
+      setColumnsState(sanitized)
+      void set('preferences', idbKey, sanitized)
+    },
+    [idbKey, set],
+  )
+
+  const applyPreset = useCallback(
+    (preset: ColumnPresetName) => setColumns(COLUMN_PRESETS[preset]),
+    [setColumns],
+  )
+
+  return { columns, setColumns, applyPreset, loading }
+}

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -3,6 +3,7 @@ import type { PriceData } from '../types'
 import {
   toCsv,
   priceDataToCsvRows,
+  priceDataToJsonRows,
   priceDataToXlsx,
   downloadFile,
   downloadBinaryFile,
@@ -13,10 +14,10 @@ import { useRateLimit } from './useRateLimit'
 export type ExportFormat = 'csv' | 'json' | 'xlsx'
 
 export interface UseExportReturn {
-  exportCSV: (items: PriceData[]) => void
-  exportJSON: (items: PriceData[]) => void
-  exportXLSX: (items: PriceData[]) => void
-  exportData: (format: ExportFormat, items: PriceData[]) => void
+  exportCSV: (items: PriceData[], columns?: string[]) => void
+  exportJSON: (items: PriceData[], columns?: string[]) => void
+  exportXLSX: (items: PriceData[], columns?: string[]) => void
+  exportData: (format: ExportFormat, items: PriceData[], columns?: string[]) => void
   /** Whether an export is currently allowed (not rate-limited). */
   exportAllowed: boolean
   /** Seconds until the rate-limit window resets (0 when allowed). */
@@ -34,9 +35,9 @@ export function useExport(): UseExportReturn {
   const { allowed: exportAllowed, cooldownSec: exportCooldownSec, consume } = useRateLimit('export')
 
   const exportCSV = useCallback(
-    (items: PriceData[]) => {
+    (items: PriceData[], columns?: string[]) => {
       if (!consume()) return
-      const { rows, headers } = priceDataToCsvRows(items)
+      const { rows, headers } = priceDataToCsvRows(items, columns)
       const csv = toCsv(rows, headers)
       downloadFile(csv, exportFilename('oracle-prices', 'csv'), 'text/csv')
     },
@@ -44,18 +45,18 @@ export function useExport(): UseExportReturn {
   )
 
   const exportJSON = useCallback(
-    (items: PriceData[]) => {
+    (items: PriceData[], columns?: string[]) => {
       if (!consume()) return
-      const json = JSON.stringify(items, null, 2)
+      const json = JSON.stringify(priceDataToJsonRows(items, columns), null, 2)
       downloadFile(json, exportFilename('oracle-prices', 'json'), 'application/json')
     },
     [consume],
   )
 
   const exportXLSX = useCallback(
-    (items: PriceData[]) => {
+    (items: PriceData[], columns?: string[]) => {
       if (!consume()) return
-      const xlsx = priceDataToXlsx(items)
+      const xlsx = priceDataToXlsx(items, columns)
       downloadBinaryFile(
         xlsx,
         exportFilename('oracle-prices', 'xlsx'),
@@ -66,22 +67,22 @@ export function useExport(): UseExportReturn {
   )
 
   const exportData = useCallback(
-    (format: ExportFormat, items: PriceData[]) => {
+    (format: ExportFormat, items: PriceData[], columns?: string[]) => {
       // Consume a single token for the aggregated exportData call so callers
       // using exportData directly are also rate-limited.
       if (!consume()) return
       if (format === 'json') {
-        const json = JSON.stringify(items, null, 2)
+        const json = JSON.stringify(priceDataToJsonRows(items, columns), null, 2)
         downloadFile(json, exportFilename('oracle-prices', 'json'), 'application/json')
       } else if (format === 'xlsx') {
-        const xlsx = priceDataToXlsx(items)
+        const xlsx = priceDataToXlsx(items, columns)
         downloadBinaryFile(
           xlsx,
           exportFilename('oracle-prices', 'xlsx'),
           'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         )
       } else {
-        const { rows, headers } = priceDataToCsvRows(items)
+        const { rows, headers } = priceDataToCsvRows(items, columns)
         const csv = toCsv(rows, headers)
         downloadFile(csv, exportFilename('oracle-prices', 'csv'), 'text/csv')
       }

--- a/src/hooks/useExportQueue.ts
+++ b/src/hooks/useExportQueue.ts
@@ -1,0 +1,138 @@
+import { useCallback, useRef, useState } from 'react'
+import {
+  toCsv,
+  priceDataToCsvRows,
+  priceDataToJsonRows,
+  priceDataToXlsx,
+  downloadFile,
+  downloadBinaryFile,
+  exportFilename,
+} from '../utils/export'
+import { useToast } from '../context/ToastContext'
+import { useRateLimit } from './useRateLimit'
+import type { PriceData } from '../types'
+import type { ExportFormat } from './useExport'
+
+export type ExportTaskStatus = 'processing' | 'done' | 'error' | 'cancelled'
+
+export interface ExportTask {
+  id: string
+  label: string
+  format: ExportFormat
+  status: ExportTaskStatus
+  processed: number
+  total: number
+  startedAt: number
+}
+
+/** Items are processed in chunks so progress and cancellation are meaningful even though CSV/JSON/XLSX generation itself is fast (#311). */
+const CHUNK_SIZE = 200
+
+export interface UseExportQueueReturn {
+  /** All queued/active/finished export tasks, oldest first. */
+  tasks: ExportTask[]
+  /** Queues a new export. Returns immediately; progress is tracked via `tasks`. */
+  enqueue: (format: ExportFormat, items: PriceData[], columns?: string[], label?: string) => void
+  /** Requests cancellation of an in-progress task. No-op once the task has finished. */
+  cancel: (id: string) => void
+  /** Removes a finished/cancelled/errored task from the list. */
+  dismiss: (id: string) => void
+}
+
+/**
+ * Runs price data exports through a visible queue with progress reporting
+ * and cancellation, on top of the existing CSV/JSON/XLSX builders in
+ * `utils/export.ts`. Shares the same `export` rate limiter as `useExport`.
+ */
+export function useExportQueue(): UseExportQueueReturn {
+  const [tasks, setTasks] = useState<ExportTask[]>([])
+  const cancelledRef = useRef<Set<string>>(new Set())
+  const { addToast } = useToast()
+  const { consume } = useRateLimit('export')
+
+  const updateTask = useCallback((id: string, patch: Partial<ExportTask>) => {
+    setTasks((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)))
+  }, [])
+
+  const runExport = useCallback(
+    async (id: string, format: ExportFormat, items: PriceData[], columns?: string[]) => {
+      const total = items.length
+
+      for (let processed = 0; processed < total || processed === 0; processed += CHUNK_SIZE) {
+        if (cancelledRef.current.has(id)) {
+          cancelledRef.current.delete(id)
+          updateTask(id, { status: 'cancelled' })
+          return
+        }
+        updateTask(id, { processed: Math.min(processed + CHUNK_SIZE, total) })
+        // Yield to the event loop so progress renders and cancel clicks are seen.
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        if (total === 0) break
+      }
+
+      if (cancelledRef.current.has(id)) {
+        cancelledRef.current.delete(id)
+        updateTask(id, { status: 'cancelled' })
+        return
+      }
+
+      try {
+        if (format === 'json') {
+          const json = JSON.stringify(priceDataToJsonRows(items, columns), null, 2)
+          downloadFile(json, exportFilename('oracle-prices', 'json'), 'application/json')
+        } else if (format === 'xlsx') {
+          const xlsx = priceDataToXlsx(items, columns)
+          downloadBinaryFile(
+            xlsx,
+            exportFilename('oracle-prices', 'xlsx'),
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          )
+        } else {
+          const { rows, headers } = priceDataToCsvRows(items, columns)
+          downloadFile(toCsv(rows, headers), exportFilename('oracle-prices', 'csv'), 'text/csv')
+        }
+        updateTask(id, { status: 'done', processed: total })
+        addToast({
+          type: 'success',
+          message: `Export ready — ${format.toUpperCase()} (${total} pair${total === 1 ? '' : 's'})`,
+        })
+      } catch (err) {
+        updateTask(id, { status: 'error' })
+        addToast({
+          type: 'error',
+          message: `Export failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        })
+      }
+    },
+    [updateTask, addToast],
+  )
+
+  const enqueue = useCallback(
+    (format: ExportFormat, items: PriceData[], columns?: string[], label?: string) => {
+      if (!consume()) return
+      const id = crypto.randomUUID()
+      const task: ExportTask = {
+        id,
+        label: label ?? `${items.length} pair${items.length === 1 ? '' : 's'} · ${format.toUpperCase()}`,
+        format,
+        status: 'processing',
+        processed: 0,
+        total: items.length,
+        startedAt: Date.now(),
+      }
+      setTasks((prev) => [...prev, task])
+      void runExport(id, format, items, columns)
+    },
+    [consume, runExport],
+  )
+
+  const cancel = useCallback((id: string) => {
+    cancelledRef.current.add(id)
+  }, [])
+
+  const dismiss = useCallback((id: string) => {
+    setTasks((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  return { tasks, enqueue, cancel, dismiss }
+}

--- a/src/hooks/useScheduledExports.ts
+++ b/src/hooks/useScheduledExports.ts
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useIdbQuery, useIdbMutation } from './useIdbQuery'
+import { useToast } from '../context/ToastContext'
+import {
+  toCsv,
+  priceDataToCsvRows,
+  priceDataToJsonRows,
+  priceDataToXlsx,
+  downloadFile,
+  downloadBinaryFile,
+  exportFilename,
+} from '../utils/export'
+import type { PriceData } from '../types'
+import type { ExportFormat } from './useExport'
+
+export type ExportFrequency = 'daily' | 'weekly' | 'monthly'
+
+export interface ExportSchedule {
+  id: string
+  label: string
+  /** Asset pairs to include. Empty array means "all pairs". */
+  pairs: string[]
+  format: ExportFormat
+  frequency: ExportFrequency
+  createdAt: number
+  lastRunAt: number | null
+  nextRunAt: number
+}
+
+export interface ScheduledExportHistoryEntry {
+  id: string
+  scheduleId: string
+  scheduleLabel: string
+  ranAt: number
+  format: ExportFormat
+  pairCount: number
+  trigger: 'scheduled' | 'manual'
+}
+
+const SCHEDULES_KEY = 'scheduled-exports'
+const HISTORY_KEY = 'scheduled-exports-history'
+const MAX_HISTORY = 50
+
+const FREQUENCY_MS: Record<ExportFrequency, number> = {
+  daily: 24 * 60 * 60 * 1000,
+  weekly: 7 * 24 * 60 * 60 * 1000,
+  monthly: 30 * 24 * 60 * 60 * 1000,
+}
+
+export function computeNextRun(frequency: ExportFrequency, from = Date.now()): number {
+  return from + FREQUENCY_MS[frequency]
+}
+
+export interface CreateScheduleInput {
+  label: string
+  pairs: string[]
+  format: ExportFormat
+  frequency: ExportFrequency
+}
+
+export interface UseScheduledExportsReturn {
+  schedules: ExportSchedule[]
+  history: ScheduledExportHistoryEntry[]
+  loading: boolean
+  createSchedule: (input: CreateScheduleInput) => void
+  deleteSchedule: (id: string) => void
+  runNow: (id: string) => void
+}
+
+/**
+ * Manages export schedules and their run history, persisted in IndexedDB
+ * (#318). There is no backend, so "scheduling" is a best-effort client-side
+ * approximation: due schedules are run (and rescheduled) whenever this hook
+ * is mounted with fresh price data — i.e. whenever the dashboard is open.
+ * Email delivery is out of scope; runs trigger a normal browser download.
+ */
+export function useScheduledExports(allPrices: PriceData[]): UseScheduledExportsReturn {
+  const { data: schedulesData, loading: schedulesLoading } = useIdbQuery<ExportSchedule[]>('preferences', SCHEDULES_KEY)
+  const { data: historyData, loading: historyLoading } = useIdbQuery<ScheduledExportHistoryEntry[]>('preferences', HISTORY_KEY)
+  const { set } = useIdbMutation()
+  const { addToast } = useToast()
+
+  const [schedules, setSchedules] = useState<ExportSchedule[]>([])
+  const [history, setHistory] = useState<ScheduledExportHistoryEntry[]>([])
+
+  useEffect(() => {
+    if (!schedulesLoading) setSchedules(schedulesData ?? [])
+  }, [schedulesData, schedulesLoading])
+
+  useEffect(() => {
+    if (!historyLoading) setHistory(historyData ?? [])
+  }, [historyData, historyLoading])
+
+  const persistSchedules = useCallback(
+    (next: ExportSchedule[]) => {
+      setSchedules(next)
+      void set('preferences', SCHEDULES_KEY, next)
+    },
+    [set],
+  )
+
+  const persistHistory = useCallback(
+    (entry: ScheduledExportHistoryEntry) => {
+      setHistory((prev) => {
+        const next = [...prev, entry].slice(-MAX_HISTORY)
+        void set('preferences', HISTORY_KEY, next)
+        return next
+      })
+    },
+    [set],
+  )
+
+  const downloadExport = useCallback((schedule: ExportSchedule, items: PriceData[]) => {
+    const base = schedule.label.trim() || 'scheduled-export'
+    if (schedule.format === 'json') {
+      downloadFile(JSON.stringify(priceDataToJsonRows(items), null, 2), exportFilename(base, 'json'), 'application/json')
+    } else if (schedule.format === 'xlsx') {
+      downloadBinaryFile(
+        priceDataToXlsx(items),
+        exportFilename(base, 'xlsx'),
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      )
+    } else {
+      const { rows, headers } = priceDataToCsvRows(items)
+      downloadFile(toCsv(rows, headers), exportFilename(base, 'csv'), 'text/csv')
+    }
+  }, [])
+
+  const executeSchedule = useCallback(
+    (schedule: ExportSchedule, prices: PriceData[], trigger: 'scheduled' | 'manual') => {
+      const items = schedule.pairs.length > 0 ? prices.filter((p) => schedule.pairs.includes(p.assetPair)) : prices
+      if (items.length === 0) return
+
+      downloadExport(schedule, items)
+      persistHistory({
+        id: crypto.randomUUID(),
+        scheduleId: schedule.id,
+        scheduleLabel: schedule.label,
+        ranAt: Date.now(),
+        format: schedule.format,
+        pairCount: items.length,
+        trigger,
+      })
+      addToast({
+        type: 'success',
+        message: trigger === 'scheduled' ? `Scheduled export ran: ${schedule.label}` : `Export ready: ${schedule.label}`,
+      })
+    },
+    [downloadExport, persistHistory, addToast],
+  )
+
+  // Best-effort automation: on load (and whenever prices refresh), run any
+  // schedule whose nextRunAt has passed, then reschedule it.
+  useEffect(() => {
+    if (schedulesLoading || allPrices.length === 0 || schedules.length === 0) return
+    const now = Date.now()
+    const due = schedules.filter((s) => s.nextRunAt <= now)
+    if (due.length === 0) return
+
+    due.forEach((schedule) => executeSchedule(schedule, allPrices, 'scheduled'))
+
+    persistSchedules(
+      schedules.map((s) =>
+        due.some((d) => d.id === s.id)
+          ? { ...s, lastRunAt: now, nextRunAt: computeNextRun(s.frequency, now) }
+          : s,
+      ),
+    )
+    // Only re-check when the schedule list or the underlying price snapshot changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [schedules, schedulesLoading, allPrices])
+
+  const createSchedule = useCallback(
+    (input: CreateScheduleInput) => {
+      const now = Date.now()
+      const schedule: ExportSchedule = {
+        id: crypto.randomUUID(),
+        label: input.label.trim() || `${input.format.toUpperCase()} export`,
+        pairs: input.pairs,
+        format: input.format,
+        frequency: input.frequency,
+        createdAt: now,
+        lastRunAt: null,
+        nextRunAt: computeNextRun(input.frequency, now),
+      }
+      persistSchedules([...schedules, schedule])
+    },
+    [schedules, persistSchedules],
+  )
+
+  const deleteSchedule = useCallback(
+    (id: string) => {
+      persistSchedules(schedules.filter((s) => s.id !== id))
+    },
+    [schedules, persistSchedules],
+  )
+
+  const runNow = useCallback(
+    (id: string) => {
+      const schedule = schedules.find((s) => s.id === id)
+      if (!schedule) return
+      executeSchedule(schedule, allPrices, 'manual')
+      const now = Date.now()
+      persistSchedules(
+        schedules.map((s) => (s.id === id ? { ...s, lastRunAt: now, nextRunAt: computeNextRun(s.frequency, now) } : s)),
+      )
+    },
+    [schedules, allPrices, executeSchedule, persistSchedules],
+  )
+
+  return {
+    schedules,
+    history,
+    loading: schedulesLoading || historyLoading,
+    createSchedule,
+    deleteSchedule,
+    runNow,
+  }
+}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -373,6 +373,20 @@ const en = {
     ariaLabel: 'Export data',
     exportAs: 'Export as {{format}}',
     langSelector: 'Code snippet language',
+    columns: {
+      button: 'Columns',
+      title: 'Select export columns',
+      preset: {
+        minimal: 'Minimal',
+        standard: 'Standard',
+        full: 'Full',
+      },
+      search: 'Filter columns…',
+      available: 'Available',
+      noMatches: 'No matching columns',
+      selectedOrder: 'Selected (drag to reorder)',
+      preview: 'Preview',
+    },
   },
 
   // ── SettingsPanel ─────────────────────────────────────────────────────────

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,9 +6,11 @@ import { useAlerts } from '../hooks/useAlerts'
 import { useExport } from '../hooks/useExport'
 import { useExportQueue } from '../hooks/useExportQueue'
 import { useColumnSelection } from '../hooks/useColumnSelection'
+import { useScheduledExports } from '../hooks/useScheduledExports'
 import { usePreferences } from '../preferences/PreferencesContext'
 import { ColumnSelectorModal } from '../components/ColumnSelectorModal'
 import { ExportProgressPanel } from '../components/ExportProgressPanel'
+import { ScheduledExportsPanel } from '../components/ScheduledExportsPanel'
 import { useSwipeGesture } from '../hooks/useSwipeGesture'
 import { usePullToRefresh } from '../hooks/usePullToRefresh'
 import { PriceCard } from '../components/PriceCard'
@@ -105,6 +107,8 @@ export function Dashboard() {
   const legacySource = searchParams.get('source') || 'all'
 
   const merged = mergePrices(prices, livePrices)
+  const scheduledExports = useScheduledExports(merged)
+  const [scheduledExportsOpen, setScheduledExportsOpen] = useState(false)
 
   const filtered = useMemo(() => {
     let result = merged
@@ -343,6 +347,18 @@ export function Dashboard() {
             </svg>
             {t('dashboard.alerts.title')}
           </button>
+          <button
+            type="button"
+            onClick={() => setScheduledExportsOpen(true)}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border border-gray-700 text-gray-400 hover:text-gray-200 hover:border-gray-600 transition-colors"
+            aria-label={t('scheduledExports.title', { defaultValue: 'Scheduled exports' }) as string}
+            title={t('scheduledExports.title', { defaultValue: 'Scheduled exports' }) as string}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            {t('scheduledExports.button', { defaultValue: 'Schedule' })}
+          </button>
           <ConnectionBadge status={wsStatus} rateLimitStatus={rateLimitStatus} retryAfterMs={rateLimitRetryAfterMs} />
         </div>
       </div>
@@ -513,6 +529,13 @@ export function Dashboard() {
       <NotificationChannelsModal isOpen={notifModalOpen} onClose={() => setNotifModalOpen(false)} />
 
       <ExportProgressPanel tasks={exportTasks} onCancel={cancelExport} onDismiss={dismissExport} />
+
+      <ScheduledExportsPanel
+        isOpen={scheduledExportsOpen}
+        onClose={() => setScheduledExportsOpen(false)}
+        availablePairs={prices.map((p) => p.assetPair)}
+        {...scheduledExports}
+      />
     </div>
   )
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,7 +4,9 @@ import { useTranslation } from 'react-i18next'
 import { usePriceContext } from '../context/PriceContext'
 import { useAlerts } from '../hooks/useAlerts'
 import { useExport } from '../hooks/useExport'
+import { useColumnSelection } from '../hooks/useColumnSelection'
 import { usePreferences } from '../preferences/PreferencesContext'
+import { ColumnSelectorModal } from '../components/ColumnSelectorModal'
 import { useSwipeGesture } from '../hooks/useSwipeGesture'
 import { usePullToRefresh } from '../hooks/usePullToRefresh'
 import { PriceCard } from '../components/PriceCard'
@@ -51,9 +53,11 @@ export function Dashboard() {
   const { t } = useTranslation()
   const { alerts, addAlert, removeAlert, hasAlertsForPair, activeCount, reEnableAlert, alertCreateAllowed, alertCreateCooldownSec } = useAlerts()
   const { exportCSV, exportAllowed, exportCooldownSec } = useExport()
+  const { columns: exportColumns, setColumns: setExportColumns, applyPreset: applyColumnPreset } = useColumnSelection('csv')
   const { preferences, updatePreference } = usePreferences()
   const [searchParams] = useSearchParams()
 
+  const [columnModalOpen, setColumnModalOpen] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
   const [modalPair, setModalPair] = useState('')
   const [dashboardView, setDashboardView] = useState<'card' | 'table'>('card')
@@ -371,11 +375,23 @@ export function Dashboard() {
           <div className="flex-1" />
           <button
             type="button"
+            onClick={() => setColumnModalOpen(true)}
+            title={t('export.columns.title', { defaultValue: 'Select export columns' }) as string}
+            className="flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-lg bg-gray-800 text-gray-300 hover:bg-gray-700 transition-colors border border-gray-700"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            {t('export.columns.button', { defaultValue: 'Columns' })}
+          </button>
+          <button
+            type="button"
             disabled={selected.size === 0 || !exportAllowed}
             title={!exportAllowed ? `Too many exports — try again in ${exportCooldownSec}s` : undefined}
             onClick={() => {
               const items = filtered.filter((p) => selected.has(p.assetPair))
-              exportCSV(items)
+              exportCSV(items, exportColumns)
             }}
             className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-gray-800 text-gray-300 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors border border-gray-700"
           >
@@ -387,6 +403,16 @@ export function Dashboard() {
               : t('dashboard.selection.exportCsv')}
           </button>
         </div>
+      )}
+
+      {columnModalOpen && (
+        <ColumnSelectorModal
+          format="csv"
+          columns={exportColumns}
+          onChange={setExportColumns}
+          onApplyPreset={applyColumnPreset}
+          onClose={() => setColumnModalOpen(false)}
+        />
       )}
 
       {pricesError && (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,9 +4,11 @@ import { useTranslation } from 'react-i18next'
 import { usePriceContext } from '../context/PriceContext'
 import { useAlerts } from '../hooks/useAlerts'
 import { useExport } from '../hooks/useExport'
+import { useExportQueue } from '../hooks/useExportQueue'
 import { useColumnSelection } from '../hooks/useColumnSelection'
 import { usePreferences } from '../preferences/PreferencesContext'
 import { ColumnSelectorModal } from '../components/ColumnSelectorModal'
+import { ExportProgressPanel } from '../components/ExportProgressPanel'
 import { useSwipeGesture } from '../hooks/useSwipeGesture'
 import { usePullToRefresh } from '../hooks/usePullToRefresh'
 import { PriceCard } from '../components/PriceCard'
@@ -52,7 +54,8 @@ export function Dashboard() {
   const navigate = useNavigate()
   const { t } = useTranslation()
   const { alerts, addAlert, removeAlert, hasAlertsForPair, activeCount, reEnableAlert, alertCreateAllowed, alertCreateCooldownSec } = useAlerts()
-  const { exportCSV, exportAllowed, exportCooldownSec } = useExport()
+  const { exportAllowed, exportCooldownSec } = useExport()
+  const { tasks: exportTasks, enqueue: enqueueExport, cancel: cancelExport, dismiss: dismissExport } = useExportQueue()
   const { columns: exportColumns, setColumns: setExportColumns, applyPreset: applyColumnPreset } = useColumnSelection('csv')
   const { preferences, updatePreference } = usePreferences()
   const [searchParams] = useSearchParams()
@@ -391,7 +394,7 @@ export function Dashboard() {
             title={!exportAllowed ? `Too many exports — try again in ${exportCooldownSec}s` : undefined}
             onClick={() => {
               const items = filtered.filter((p) => selected.has(p.assetPair))
-              exportCSV(items, exportColumns)
+              enqueueExport('csv', items, exportColumns)
             }}
             className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-gray-800 text-gray-300 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors border border-gray-700"
           >
@@ -508,6 +511,8 @@ export function Dashboard() {
       />
 
       <NotificationChannelsModal isOpen={notifModalOpen} onClose={() => setNotifModalOpen(false)} />
+
+      <ExportProgressPanel tasks={exportTasks} onCancel={cancelExport} onDismiss={dismissExport} />
     </div>
   )
 }

--- a/src/utils/chartExport.ts
+++ b/src/utils/chartExport.ts
@@ -32,10 +32,17 @@ export function exportChartAsSvg(container: HTMLElement, filename: string, bgCol
   return true
 }
 
-/** Exports the chart currently rendered inside `container` as a PNG file, rasterised via an offscreen canvas. */
-export async function exportChartAsPng(container: HTMLElement, filename: string, bgColor: string, scale = 2): Promise<boolean> {
+export interface RasterizedChart {
+  /** `data:image/png;base64,...` URL, embeddable directly (e.g. in a PDF). */
+  dataUrl: string
+  width: number
+  height: number
+}
+
+/** Rasterises the chart currently rendered inside `container` to a PNG data URL via an offscreen canvas. Returns null if no chart SVG was found. */
+export async function rasterizeChartToDataUrl(container: HTMLElement, bgColor: string, scale = 2): Promise<RasterizedChart | null> {
   const svg = findChartSvg(container)
-  if (!svg) return false
+  if (!svg) return null
 
   const { svgString, width, height } = cloneSvgWithBackground(svg, bgColor)
   const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' })
@@ -53,21 +60,24 @@ export async function exportChartAsPng(container: HTMLElement, filename: string,
     canvas.width = width * scale
     canvas.height = height * scale
     const ctx = canvas.getContext('2d')
-    if (!ctx) return false
+    if (!ctx) return null
     ctx.scale(scale, scale)
     ctx.drawImage(img, 0, 0, width, height)
 
-    const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'))
-    if (!blob) return false
-
-    const blobUrl = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = blobUrl
-    a.download = filename
-    a.click()
-    URL.revokeObjectURL(blobUrl)
-    return true
+    return { dataUrl: canvas.toDataURL('image/png'), width, height }
   } finally {
     URL.revokeObjectURL(url)
   }
+}
+
+/** Exports the chart currently rendered inside `container` as a PNG file, rasterised via an offscreen canvas. */
+export async function exportChartAsPng(container: HTMLElement, filename: string, bgColor: string, scale = 2): Promise<boolean> {
+  const rasterized = await rasterizeChartToDataUrl(container, bgColor, scale)
+  if (!rasterized) return false
+
+  const a = document.createElement('a')
+  a.href = rasterized.dataUrl
+  a.download = filename
+  a.click()
+  return true
 }

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,4 +1,5 @@
 import type { AlertHistoryEntry, PriceData, PriceHistoryEntry } from '../types'
+import { EXPORT_COLUMNS, sanitizeColumns } from './exportColumns'
 
 function isoTs(ts: number): string {
   return new Date(ts).toISOString()
@@ -41,17 +42,29 @@ export function toCsv(rows: Array<Record<string, unknown>>, headers: string[]): 
   return lines.join('\n')
 }
 
-/** Converts an array of {@link PriceData} to CSV-ready rows. Timestamps are serialised as ISO-8601 strings; sources joined with ";". */
-export function priceDataToCsvRows(prices: PriceData[]): { rows: Array<Record<string, unknown>>; headers: string[] } {
-  const headers = ['assetPair', 'price', 'timestamp', 'confidence', 'sources']
-  const rows = prices.map((p) => ({
-    assetPair: p.assetPair,
-    price: p.price,
-    timestamp: isoTs(p.timestamp),
-    confidence: p.confidence,
-    sources: p.sources.join(';'),
-  }))
+/** Converts an array of {@link PriceData} to CSV-ready rows. Timestamps are serialised as ISO-8601 strings; sources joined with ";". Optionally restricts/reorders columns (#317). */
+export function priceDataToCsvRows(
+  prices: PriceData[],
+  columns?: string[],
+): { rows: Array<Record<string, unknown>>; headers: string[] } {
+  const headers = sanitizeColumns(columns)
+  const values: Record<string, (p: PriceData) => unknown> = {
+    assetPair: (p) => p.assetPair,
+    price: (p) => p.price,
+    timestamp: (p) => isoTs(p.timestamp),
+    confidence: (p) => p.confidence,
+    sources: (p) => p.sources.join(';'),
+  }
+  const rows = prices.map((p) =>
+    Object.fromEntries(headers.map((h) => [h, values[h](p)])),
+  )
   return { rows, headers }
+}
+
+/** Restricts an array of {@link PriceData} to the given columns, for JSON export (#317). */
+export function priceDataToJsonRows(prices: PriceData[], columns?: string[]): Array<Record<string, unknown>> {
+  const { rows } = priceDataToCsvRows(prices, columns)
+  return rows.map((r, i) => (columns === undefined ? { ...prices[i] } : r))
 }
 
 /** Converts a pair's {@link PriceHistoryEntry} array to CSV-ready rows, injecting the asset pair name into each row. */
@@ -386,16 +399,21 @@ function buildZip(files: Array<{ name: string; content: string }>): Uint8Array {
   return result
 }
 
-/** Converts an array of {@link PriceData} to a single-sheet .xlsx Uint8Array. */
-export function priceDataToXlsx(prices: PriceData[]): Uint8Array {
-  const headers = ['Asset Pair', 'Price', 'Timestamp', 'Confidence', 'Sources']
-  const rows = prices.map((p) => ({
-    'Asset Pair': p.assetPair,
-    'Price': p.price,
-    'Timestamp': isoTs(p.timestamp),
-    'Confidence': p.confidence,
-    'Sources': p.sources.join(';'),
-  }))
+/** Converts an array of {@link PriceData} to a single-sheet .xlsx Uint8Array. Optionally restricts/reorders columns (#317). */
+export function priceDataToXlsx(prices: PriceData[], columns?: string[]): Uint8Array {
+  const keys = sanitizeColumns(columns)
+  const labels = Object.fromEntries(EXPORT_COLUMNS.map((c) => [c.key, c.label]))
+  const headers = keys.map((k) => labels[k])
+  const values: Record<string, (p: PriceData) => unknown> = {
+    assetPair: (p) => p.assetPair,
+    price: (p) => p.price,
+    timestamp: (p) => isoTs(p.timestamp),
+    confidence: (p) => p.confidence,
+    sources: (p) => p.sources.join(';'),
+  }
+  const rows = prices.map((p) =>
+    Object.fromEntries(keys.map((k, i) => [headers[i], values[k](p)])),
+  )
   return buildXlsx([{ name: 'Price Data', headers, rows }])
 }
 

--- a/src/utils/exportColumns.ts
+++ b/src/utils/exportColumns.ts
@@ -1,0 +1,34 @@
+/** Column definitions for the price data export (#317). */
+
+export type ExportColumnKey = 'assetPair' | 'price' | 'timestamp' | 'confidence' | 'sources'
+
+export interface ExportColumnDef {
+  key: ExportColumnKey
+  label: string
+}
+
+/** All columns available for price data exports, in their default order. */
+export const EXPORT_COLUMNS: ExportColumnDef[] = [
+  { key: 'assetPair', label: 'Asset Pair' },
+  { key: 'price', label: 'Price' },
+  { key: 'timestamp', label: 'Timestamp' },
+  { key: 'confidence', label: 'Confidence' },
+  { key: 'sources', label: 'Sources' },
+]
+
+export const EXPORT_COLUMN_KEYS: ExportColumnKey[] = EXPORT_COLUMNS.map((c) => c.key)
+
+export type ColumnPresetName = 'minimal' | 'standard' | 'full'
+
+export const COLUMN_PRESETS: Record<ColumnPresetName, ExportColumnKey[]> = {
+  minimal: ['assetPair', 'price'],
+  standard: ['assetPair', 'price', 'timestamp', 'confidence'],
+  full: ['assetPair', 'price', 'timestamp', 'confidence', 'sources'],
+}
+
+/** Keeps only recognised column keys, in the order supplied. Falls back to all columns when empty/invalid. */
+export function sanitizeColumns(columns: string[] | undefined | null): ExportColumnKey[] {
+  if (!columns || columns.length === 0) return EXPORT_COLUMN_KEYS
+  const valid = columns.filter((c): c is ExportColumnKey => EXPORT_COLUMN_KEYS.includes(c as ExportColumnKey))
+  return valid.length > 0 ? valid : EXPORT_COLUMN_KEYS
+}

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -1,0 +1,125 @@
+import { jsPDF } from 'jspdf'
+import type { PriceHistoryEntry } from '../types'
+import type { RasterizedChart } from './chartExport'
+
+export interface ExportPriceHistoryPdfOptions {
+  pair: string
+  history: PriceHistoryEntry[]
+  chart: RasterizedChart | null
+  filename: string
+}
+
+const MARGIN = 12
+const ROW_HEIGHT = 6
+const TABLE_TOP = 26
+
+function isoTs(ts: number): string {
+  return new Date(ts).toISOString()
+}
+
+function drawTableHeader(doc: jsPDF, pair: string, colX: Record<string, number>): void {
+  const pageWidth = doc.internal.pageSize.getWidth()
+  doc.setFontSize(14)
+  doc.setTextColor(20)
+  doc.text(`${pair} Price Report`, MARGIN, 14)
+  doc.setFontSize(8)
+  doc.setTextColor(110)
+  doc.text(`Generated ${new Date().toLocaleString()} · Source: Stellar Unified Price Oracle`, MARGIN, 20)
+
+  doc.setFontSize(9)
+  doc.setTextColor(60)
+  doc.setFont('helvetica', 'bold')
+  doc.text('Asset Pair', colX.assetPair, TABLE_TOP)
+  doc.text('Price', colX.price, TABLE_TOP)
+  doc.text('Timestamp (UTC)', colX.timestamp, TABLE_TOP)
+  doc.text('Confidence', colX.confidence, TABLE_TOP)
+  doc.text('Sources', colX.sources, TABLE_TOP)
+  doc.setFont('helvetica', 'normal')
+  doc.setDrawColor(210)
+  doc.line(MARGIN, TABLE_TOP + 2, pageWidth - MARGIN, TABLE_TOP + 2)
+}
+
+function addFootersAndPageNumbers(doc: jsPDF, label: string): void {
+  const pageCount = doc.getNumberOfPages()
+  for (let i = 1; i <= pageCount; i++) {
+    doc.setPage(i)
+    const width = doc.internal.pageSize.getWidth()
+    const height = doc.internal.pageSize.getHeight()
+    doc.setFontSize(8)
+    doc.setTextColor(130)
+    doc.text(`Page ${i} of ${pageCount}`, width - MARGIN, height - 6, { align: 'right' })
+    doc.text(label, MARGIN, height - 6)
+  }
+}
+
+/**
+ * Builds a PDF report combining a paginated price data table (landscape) with
+ * an embedded chart image (portrait), and triggers a download (#316).
+ */
+export function exportPriceHistoryPdf({ pair, history, chart, filename }: ExportPriceHistoryPdfOptions): void {
+  const doc = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' })
+  doc.setProperties({
+    title: `${pair} Price Report`,
+    subject: 'Stellar Unified Price Oracle price data export',
+    author: 'Stellar Unified Price Oracle',
+    creator: 'Stellar Unified Price Oracle',
+  })
+
+  const pageWidth = doc.internal.pageSize.getWidth()
+  const pageHeight = doc.internal.pageSize.getHeight()
+  const colX = {
+    assetPair: MARGIN,
+    price: MARGIN + 55,
+    timestamp: MARGIN + 100,
+    confidence: MARGIN + 175,
+    sources: MARGIN + 215,
+  }
+  const sourcesColWidth = pageWidth - MARGIN - colX.sources
+
+  drawTableHeader(doc, pair, colX)
+  let y = TABLE_TOP + ROW_HEIGHT + 2
+  doc.setFontSize(8)
+  doc.setTextColor(40)
+
+  for (const entry of history) {
+    if (y > pageHeight - MARGIN - 4) {
+      doc.addPage('a4', 'landscape')
+      drawTableHeader(doc, pair, colX)
+      y = TABLE_TOP + ROW_HEIGHT + 2
+    }
+    doc.text(pair, colX.assetPair, y)
+    doc.text(String(entry.price), colX.price, y)
+    doc.text(isoTs(entry.timestamp), colX.timestamp, y)
+    doc.text(`${(entry.confidence * 100).toFixed(1)}%`, colX.confidence, y)
+    doc.text(entry.sources.join('; '), colX.sources, y, { maxWidth: sourcesColWidth })
+    y += ROW_HEIGHT
+  }
+
+  if (history.length === 0) {
+    doc.setTextColor(130)
+    doc.text('No price history available for this range.', MARGIN, y)
+  }
+
+  if (chart) {
+    doc.addPage('a4', 'portrait')
+    const pw = doc.internal.pageSize.getWidth()
+    const ph = doc.internal.pageSize.getHeight()
+    doc.setFontSize(14)
+    doc.setTextColor(20)
+    doc.text(`${pair} Price Chart`, MARGIN, 14)
+
+    const maxWidth = pw - MARGIN * 2
+    const maxHeight = ph - 24 - MARGIN
+    const aspect = chart.width / chart.height
+    let imgWidth = maxWidth
+    let imgHeight = imgWidth / aspect
+    if (imgHeight > maxHeight) {
+      imgHeight = maxHeight
+      imgWidth = imgHeight * aspect
+    }
+    doc.addImage(chart.dataUrl, 'PNG', MARGIN, 22, imgWidth, imgHeight)
+  }
+
+  addFootersAndPageNumbers(doc, `${pair} · Stellar Unified Price Oracle`)
+  doc.save(filename)
+}


### PR DESCRIPTION
## Summary
- Add a progress indicator with cancellation and queueing for price data exports (#311)
- Add PDF export of a pair's price history with an embedded chart image (#316)
- Add custom column selection (presets + drag-to-reorder) for CSV/JSON/XLSX exports (#317)
- Add scheduled automated exports with IndexedDB persistence and run history (#318)

## Details
- **#311**: `useExportQueue` + `ExportProgressPanel` show per-export progress, estimated time remaining, and a cancel button; multiple exports can be queued; a toast fires on completion.
- **#316**: `pdfExport.ts` (via `jspdf`) generates a paginated landscape price table plus a portrait page with the chart embedded as an image, with title/author/date metadata. Available from the chart's existing export menu.
- **#317**: `ColumnSelectorModal` + `useColumnSelection` let users pick/reorder export columns, with Minimal/Standard/Full presets persisted per format.
- **#318**: `useScheduledExports` persists schedules and history in IndexedDB and computes next-run times for daily/weekly/monthly frequencies. Since there's no backend, delivery is via browser download (not email), and due schedules run on a best-effort basis while the dashboard is open.

## Test plan
- [ ] `npm install --legacy-peer-deps` (pre-existing peer-dep conflict between `eslint` and `eslint-plugin-react-hooks`, unrelated to this change)
- [ ] Manually verify bulk CSV export from the Dashboard selection toolbar shows progress and can be cancelled
- [ ] Manually verify column selection persists across reloads and affects CSV/JSON/XLSX output
- [ ] Manually verify "Export as PDF" on a price chart produces a readable table + chart PDF
- [ ] Manually verify creating a scheduled export, "Run now", and history entries
- Note: the test suite currently fails to run for unrelated pre-existing reasons (`@testing-library/dom` resolution, etc.) — `src/utils/export.test.ts` is one of the few suites that still runs and passes with these changes.

Closes #311
Closes #316
Closes #317
Closes #318
