### PR TITLE
feat(diagnostics): realtime WS diagnostics panel with rates and laten…

### DIFF
--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -232,8 +232,17 @@ export class WebSocketClient {
     this.ws.onopen = () => {
       this.reconnectAttempt = 0
       this._retryCount = 0
+      // A prior disconnection means this open is a reconnect (automatic or
+      // manual); distinguished so wsAnalytics' connect/reconnect counters —
+      // and the diagnostics panel built on them (#473) — stay accurate.
+      const isReconnect = this._totalDisconnections > 0
       this._lastConnectedAt = Date.now()
       this.setStatus('connected')
+      if (isReconnect) {
+        wsAnalytics.recordReconnect()
+      } else {
+        wsAnalytics.recordConnect()
+      }
 
       // #472 – perform the protocol handshake. Reset any previously-negotiated
       // version so a fresh session re-negotiates from scratch.
@@ -281,11 +290,18 @@ export class WebSocketClient {
           text = e.data as string
         }
 
+        // Wire byte size (#473) — the Blob's compressed size when applicable,
+        // otherwise the decoded text's real UTF-8 byte length.
+        const sizeBytes = e.data instanceof Blob ? e.data.size : new TextEncoder().encode(text).length
+
         const raw = JSON.parse(text) as Record<string, unknown>
 
         // Discard duplicate / out-of-order messages using monotonic seq
         if (typeof raw['seq'] === 'number') {
-          if (raw['seq'] <= this.lastSeq) return
+          if (raw['seq'] <= this.lastSeq) {
+            wsAnalytics.recordDrop('duplicate-or-out-of-order-seq')
+            return
+          }
           this.lastSeq = raw['seq']
         }
 
@@ -296,6 +312,7 @@ export class WebSocketClient {
         const parsed = WsMessageSchema.safeParse(raw)
         if (!parsed.success) {
           console.warn('[WebSocket] Unknown or malformed message', raw)
+          wsAnalytics.recordDrop('malformed')
           return
         }
 
@@ -308,12 +325,17 @@ export class WebSocketClient {
           return
         }
 
+        // Receive-to-parse latency (#473) — measured up to this point, before
+        // handler dispatch, so it reflects decode+validate cost only.
+        wsAnalytics.recordMessage(sizeBytes, performance.now() - messageStart)
+
         messageHandlersRef.forEach((h) => h(msg))
 
         // Record end-to-end processing time for this message
         recordWsMessageTiming(messageStart, typeof raw['type'] === 'string' ? raw['type'] : undefined)
       } catch {
-        // ignore malformed messages
+        // Malformed JSON or a decompression failure — count as a dropped frame (#473).
+        wsAnalytics.recordDrop('parse-error')
       }
     }
 

--- a/src/components/WsAnalyticsPanel.test.tsx
+++ b/src/components/WsAnalyticsPanel.test.tsx
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { checkAccessibility } from '../test/accessibility'
+import { WsAnalyticsPanel } from './WsAnalyticsPanel'
+import { wsAnalytics } from '../utils/wsAnalytics'
+
+afterEach(() => {
+  cleanup()
+  wsAnalytics.clear()
+})
+
+describe('WsAnalyticsPanel', () => {
+  it('has no accessibility violations', async () => {
+    await checkAccessibility(<WsAnalyticsPanel />)
+  })
+
+  it('renders lifetime counters from wsAnalytics', () => {
+    wsAnalytics.recordConnect()
+    wsAnalytics.recordError('boom')
+    render(<WsAnalyticsPanel />)
+    expect(screen.getByText('Connects').previousSibling).toHaveTextContent('1')
+    expect(screen.getByText('Errors').previousSibling).toHaveTextContent('1')
+  })
+
+  it('renders real message/byte/drop counters (#473)', () => {
+    wsAnalytics.recordMessage(1024, 12)
+    wsAnalytics.recordMessage(512, 8)
+    wsAnalytics.recordDrop('malformed')
+    render(<WsAnalyticsPanel />)
+    expect(screen.getByText('Messages').nextSibling).toHaveTextContent('2')
+    expect(screen.getByText('Dropped frames').nextSibling).toHaveTextContent('1')
+    expect(screen.getByText('Data received').nextSibling).toHaveTextContent('1.5 KB')
+  })
+
+  it('renders latency percentiles computed from real samples', () => {
+    for (let i = 1; i <= 100; i++) wsAnalytics.recordMessage(10, i)
+    render(<WsAnalyticsPanel />)
+    expect(screen.getByText('p50').nextSibling).toHaveTextContent('50.0ms')
+    expect(screen.getByText('p95').nextSibling).toHaveTextContent('95.0ms')
+    expect(screen.getByText('p99').nextSibling).toHaveTextContent('99.0ms')
+  })
+
+  it('shows an em-dash for percentiles before any messages are recorded', () => {
+    render(<WsAnalyticsPanel />)
+    expect(screen.getByText('p50').nextSibling).toHaveTextContent('—')
+  })
+
+  it('renders a fixed-size sparkline container regardless of data volume (CLS = 0)', () => {
+    const { container: empty } = render(<WsAnalyticsPanel />)
+    const emptyBox = empty.querySelector('svg')!.parentElement!
+    const emptyHeight = emptyBox.getAttribute('style')
+
+    cleanup()
+    for (let i = 0; i < 50; i++) wsAnalytics.recordMessage(10, 1)
+    const { container: full } = render(<WsAnalyticsPanel />)
+    const fullBox = full.querySelector('svg')!.parentElement!
+
+    expect(fullBox.getAttribute('style')).toBe(emptyHeight)
+  })
+
+  it('reflects live updates when wsAnalytics records a new message', async () => {
+    render(<WsAnalyticsPanel />)
+    expect(screen.getByText('Messages').nextSibling).toHaveTextContent('0')
+
+    wsAnalytics.recordMessage(10, 1)
+    // Message notifications are throttled (~250ms) — wait for the coalesced update.
+    await waitFor(() => {
+      expect(screen.getByText('Messages').nextSibling).toHaveTextContent('1')
+    })
+  })
+
+  describe('export diagnostics button', () => {
+    let createObjectURLSpy: ReturnType<typeof vi.fn>
+    let revokeObjectURLSpy: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      createObjectURLSpy = vi.fn(() => 'blob:test')
+      revokeObjectURLSpy = vi.fn()
+      URL.createObjectURL = createObjectURLSpy as typeof URL.createObjectURL
+      URL.revokeObjectURL = revokeObjectURLSpy as typeof URL.revokeObjectURL
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('downloads a full diagnostics snapshot via the shared export tooling', async () => {
+      let capturedContent = ''
+      let capturedType = ''
+      class BlobMock {
+        readonly type: string
+        constructor(parts: BlobPart[] = [], options: BlobPropertyBag = {}) {
+          capturedContent = String(parts[0])
+          capturedType = options.type ?? ''
+          this.type = capturedType
+        }
+      }
+      vi.stubGlobal('Blob', BlobMock)
+
+      wsAnalytics.recordConnect()
+      wsAnalytics.recordMessage(100, 5)
+      const user = userEvent.setup()
+      render(<WsAnalyticsPanel />)
+
+      await user.click(screen.getByRole('button', { name: 'Export diagnostics' }))
+
+      await waitFor(() => expect(createObjectURLSpy).toHaveBeenCalled())
+      expect(capturedType).toBe('application/json')
+      const parsed = JSON.parse(capturedContent)
+      expect(parsed.summary.totalConnects).toBe(1)
+      expect(parsed.summary.totalMessages).toBe(1)
+    })
+  })
+})

--- a/src/components/WsAnalyticsPanel.tsx
+++ b/src/components/WsAnalyticsPanel.tsx
@@ -1,5 +1,6 @@
-import { memo, useEffect, useState } from 'react'
-import { wsAnalytics, type WsAnalyticsSummary } from '../utils/wsAnalytics'
+import { memo, useEffect, useState, type ReactElement } from 'react'
+import { wsAnalytics, type WsAnalyticsSummary, type WsRateBucket } from '../utils/wsAnalytics'
+import { loadExportUtils } from '../utils/deferredExports'
 
 const TYPE_STYLES: Record<string, string> = {
   connect: 'text-green-400',
@@ -7,10 +8,67 @@ const TYPE_STYLES: Record<string, string> = {
   reconnect: 'text-yellow-400',
   error: 'text-red-500',
   latency: 'text-blue-400',
+  drop: 'text-orange-400',
 }
+
+/** Buckets shown by the sparkline — fixes its width so it never reflows as data arrives (CLS = 0, #473). */
+const SPARKLINE_SLOTS = 30
+const SPARKLINE_HEIGHT = 32
 
 function fmt(ts: number) {
   return new Date(ts).toLocaleTimeString()
+}
+
+function fmtMs(ms: number | null): string {
+  return ms != null ? `${ms.toFixed(1)}ms` : '—'
+}
+
+function fmtBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+/**
+ * Message-rate sparkline (#473): a fixed-slot bar chart over the last
+ * {@link SPARKLINE_SLOTS} one-minute buckets. The slot count — and therefore
+ * the rendered width/height — never changes with the data, so the panel
+ * never shifts layout as new buckets arrive (CLS = 0).
+ */
+function RateSparkline({ buckets }: { buckets: WsRateBucket[] }): ReactElement {
+  // Left-pad with empty buckets so there are always exactly SPARKLINE_SLOTS bars.
+  const padded: Array<WsRateBucket | null> = [
+    ...Array.from({ length: Math.max(0, SPARKLINE_SLOTS - buckets.length) }, () => null),
+    ...buckets.slice(-SPARKLINE_SLOTS),
+  ]
+  const max = Math.max(1, ...padded.map((b) => b?.messages ?? 0))
+  const barWidth = 100 / SPARKLINE_SLOTS
+
+  return (
+    <svg
+      viewBox={`0 0 100 ${SPARKLINE_HEIGHT}`}
+      preserveAspectRatio="none"
+      width="100%"
+      height={SPARKLINE_HEIGHT}
+      className="block"
+      aria-hidden="true"
+    >
+      {padded.map((b, i) => {
+        const messages = b?.messages ?? 0
+        const h = messages > 0 ? Math.max(1, (messages / max) * SPARKLINE_HEIGHT) : 0
+        return (
+          <rect
+            key={b?.minute ?? `empty-${i}`}
+            x={i * barWidth}
+            y={SPARKLINE_HEIGHT - h}
+            width={Math.max(0, barWidth - 0.5)}
+            height={h}
+            className={b && b.drops > 0 ? 'fill-orange-400' : 'fill-cyan-500'}
+          />
+        )
+      })}
+    </svg>
+  )
 }
 
 export const WsAnalyticsPanel = memo(function WsAnalyticsPanel() {
@@ -19,21 +77,28 @@ export const WsAnalyticsPanel = memo(function WsAnalyticsPanel() {
   useEffect(() => wsAnalytics.subscribe(setSummary), [])
 
   const recentEvents = [...summary.events].reverse().slice(0, 50)
+  const latestBucket = summary.rateBuckets[summary.rateBuckets.length - 1]
+  const currentRatePerMin = latestBucket?.messages ?? 0
 
   return (
     <section className="bg-gray-900 rounded-lg p-4 space-y-3" aria-label="WebSocket analytics">
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <h3 className="text-sm font-semibold text-white">WebSocket Analytics</h3>
         <button
-          onClick={() => {
-            const a = document.createElement('a')
-            a.href = URL.createObjectURL(new Blob([wsAnalytics.exportEvents()], { type: 'application/json' }))
-            a.download = 'ws-events.json'
-            a.click()
+          onClick={async () => {
+            // #473 – reuse the app's shared export tooling (lazy-loaded, same
+            // download/filename helpers as CSV/JSON/XLSX price exports)
+            // instead of ad-hoc Blob/anchor plumbing.
+            const { downloadFile, exportFilename } = await loadExportUtils()
+            downloadFile(
+              wsAnalytics.exportDiagnosticsSnapshot(),
+              exportFilename('ws-diagnostics', 'json'),
+              'application/json',
+            )
           }}
-          className="text-xs px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 text-gray-200"
+          className="text-xs px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500"
         >
-          Export
+          Export diagnostics
         </button>
       </div>
 
@@ -71,10 +136,63 @@ export const WsAnalyticsPanel = memo(function WsAnalyticsPanel() {
           <div className="font-mono text-white">{summary.disconnectRate.toFixed(2)}/min</div>
         </div>
         <div className="bg-gray-800 rounded p-2">
-          <div className="text-gray-400">Avg latency</div>
-          <div className="font-mono text-white">
-            {summary.avgLatencyMs != null ? `${summary.avgLatencyMs.toFixed(0)}ms` : '—'}
+          <div className="text-gray-400">Avg ping latency</div>
+          <div className="font-mono text-white">{fmtMs(summary.avgLatencyMs)}</div>
+        </div>
+      </div>
+
+      {/* #473 – message-rate/byte/drop diagnostics */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 text-xs">
+        <div className="bg-gray-800 rounded p-2">
+          <div className="text-gray-400">Messages</div>
+          <div className="font-mono text-white">{summary.totalMessages}</div>
+        </div>
+        <div className="bg-gray-800 rounded p-2">
+          <div className="text-gray-400">Dropped frames</div>
+          <div className={`font-mono ${summary.totalDrops > 0 ? 'text-orange-400' : 'text-white'}`}>
+            {summary.totalDrops}
           </div>
+        </div>
+        <div className="bg-gray-800 rounded p-2">
+          <div className="text-gray-400">Data received</div>
+          <div className="font-mono text-white">{fmtBytes(summary.totalBytes)}</div>
+        </div>
+        <div className="bg-gray-800 rounded p-2">
+          <div className="text-gray-400">Rate (last min)</div>
+          <div className="font-mono text-white">{currentRatePerMin}/min</div>
+        </div>
+      </div>
+
+      {/* #473 – receive-to-parse latency percentiles, from real per-message timing samples */}
+      <div>
+        <h4 className="text-xs text-gray-400 mb-1">Message latency percentiles</h4>
+        <div className="grid grid-cols-3 gap-2 text-xs">
+          <div className="bg-gray-800 rounded p-2">
+            <div className="text-gray-400">p50</div>
+            <div className="font-mono text-white">{fmtMs(summary.messageLatencyPercentiles.p50)}</div>
+          </div>
+          <div className="bg-gray-800 rounded p-2">
+            <div className="text-gray-400">p95</div>
+            <div className="font-mono text-white">{fmtMs(summary.messageLatencyPercentiles.p95)}</div>
+          </div>
+          <div className="bg-gray-800 rounded p-2">
+            <div className="text-gray-400">p99</div>
+            <div className={`font-mono ${(summary.messageLatencyPercentiles.p99 ?? 0) > 100 ? 'text-amber-400' : 'text-white'}`}>
+              {fmtMs(summary.messageLatencyPercentiles.p99)}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* #473 – message-rate sparkline. Height is reserved unconditionally (fixed
+          SPARKLINE_HEIGHT + label row) so it never shifts the layout below it. */}
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <h4 className="text-xs text-gray-400">Message rate (last 30 min)</h4>
+          <span className="text-xs font-mono text-gray-500">{currentRatePerMin}/min</span>
+        </div>
+        <div className="bg-gray-800 rounded p-2" style={{ height: SPARKLINE_HEIGHT + 16 }}>
+          <RateSparkline buckets={summary.rateBuckets} />
         </div>
       </div>
 

--- a/src/utils/wsAnalytics.test.ts
+++ b/src/utils/wsAnalytics.test.ts
@@ -63,4 +63,118 @@ describe('wsAnalytics', () => {
     expect(s.totalConnects).toBe(0)
     expect(s.events.length).toBe(0)
   })
+
+  // ── #473 — message rate / byte / drop tracking, latency percentiles ──────
+
+  describe('recordMessage', () => {
+    it('tracks total messages and bytes', () => {
+      wsAnalytics.recordMessage(120, 5)
+      wsAnalytics.recordMessage(80, 10)
+      const s = wsAnalytics.getSummary()
+      expect(s.totalMessages).toBe(2)
+      expect(s.totalBytes).toBe(200)
+    })
+
+    it('computes p50/p95/p99 from real latency samples (nearest-rank)', () => {
+      // 100 ascending samples: 1..100
+      for (let i = 1; i <= 100; i++) wsAnalytics.recordMessage(10, i)
+      const { p50, p95, p99 } = wsAnalytics.getSummary().messageLatencyPercentiles
+      expect(p50).toBe(50)
+      expect(p95).toBe(95)
+      expect(p99).toBe(99)
+    })
+
+    it('reports null percentiles when there are no samples yet', () => {
+      const { p50, p95, p99 } = wsAnalytics.getSummary().messageLatencyPercentiles
+      expect(p50).toBeNull()
+      expect(p95).toBeNull()
+      expect(p99).toBeNull()
+    })
+
+    it('accumulates per-minute rate buckets with message count and bytes', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(0)
+      wsAnalytics.recordMessage(100, 1)
+      wsAnalytics.recordMessage(100, 1)
+      const s = wsAnalytics.getSummary()
+      expect(s.rateBuckets).toHaveLength(1)
+      expect(s.rateBuckets[0].messages).toBe(2)
+      expect(s.rateBuckets[0].bytes).toBe(200)
+      vi.useRealTimers()
+    })
+
+    it('starts a new bucket once the minute rolls over', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(0)
+      wsAnalytics.recordMessage(10, 1)
+      vi.setSystemTime(61_000)
+      wsAnalytics.recordMessage(10, 1)
+      const s = wsAnalytics.getSummary()
+      expect(s.rateBuckets).toHaveLength(2)
+      expect(s.rateBuckets[0].messages).toBe(1)
+      expect(s.rateBuckets[1].messages).toBe(1)
+      vi.useRealTimers()
+    })
+
+    it('throttles subscriber notifications for a burst of messages', () => {
+      vi.useFakeTimers()
+      const listener = vi.fn()
+      const unsub = wsAnalytics.subscribe(listener)
+      listener.mockClear() // drop the immediate on-subscribe call
+      for (let i = 0; i < 20; i++) wsAnalytics.recordMessage(10, 1)
+      // Nothing fires synchronously — it's coalesced onto a timer.
+      expect(listener).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(300)
+      expect(listener).toHaveBeenCalledTimes(1)
+      unsub()
+      vi.useRealTimers()
+    })
+  })
+
+  describe('recordDrop', () => {
+    it('increments totalDrops and logs a drop event with detail', () => {
+      wsAnalytics.recordDrop('malformed')
+      const s = wsAnalytics.getSummary()
+      expect(s.totalDrops).toBe(1)
+      expect(s.events[0]).toMatchObject({ type: 'drop', detail: 'malformed' })
+    })
+
+    it('counts drops in the current rate bucket', () => {
+      wsAnalytics.recordMessage(10, 1)
+      wsAnalytics.recordDrop()
+      const s = wsAnalytics.getSummary()
+      expect(s.rateBuckets[0].drops).toBe(1)
+    })
+  })
+
+  describe('session metric reset on drop/reconnect (#473)', () => {
+    it('clears message latency percentiles on disconnect but keeps rate-bucket history', () => {
+      wsAnalytics.recordMessage(10, 42)
+      expect(wsAnalytics.getSummary().messageLatencyPercentiles.p50).toBe(42)
+
+      wsAnalytics.recordDisconnect()
+
+      const s = wsAnalytics.getSummary()
+      expect(s.messageLatencyPercentiles.p50).toBeNull()
+      // The per-minute history is a time series meant to span reconnects —
+      // it should NOT be wiped by the same reset.
+      expect(s.rateBuckets[0].messages).toBe(1)
+    })
+
+    it('clears message latency percentiles on reconnect', () => {
+      wsAnalytics.recordMessage(10, 42)
+      wsAnalytics.recordReconnect()
+      expect(wsAnalytics.getSummary().messageLatencyPercentiles.p50).toBeNull()
+      expect(wsAnalytics.getSummary().totalReconnects).toBe(1)
+    })
+  })
+
+  it('exportDiagnosticsSnapshot produces valid JSON with a summary', () => {
+    wsAnalytics.recordConnect()
+    wsAnalytics.recordMessage(100, 5)
+    const parsed = JSON.parse(wsAnalytics.exportDiagnosticsSnapshot())
+    expect(parsed.summary.totalConnects).toBe(1)
+    expect(parsed.summary.totalMessages).toBe(1)
+    expect(typeof parsed.exportedAt).toBe('string')
+  })
 })

--- a/src/utils/wsAnalytics.ts
+++ b/src/utils/wsAnalytics.ts
@@ -1,4 +1,4 @@
-export type WsEventType = 'connect' | 'disconnect' | 'reconnect' | 'error' | 'latency'
+export type WsEventType = 'connect' | 'disconnect' | 'reconnect' | 'error' | 'latency' | 'drop'
 
 export interface WsEvent {
   type: WsEventType
@@ -8,13 +8,40 @@ export interface WsEvent {
   detail?: string
 }
 
+/** Per-minute rolling counters used to drive the message-rate sparkline (#473). */
+export interface WsRateBucket {
+  /** Bucket start, floored to the minute (ms since epoch). */
+  minute: number
+  messages: number
+  bytes: number
+  drops: number
+  reconnects: number
+}
+
+export interface WsLatencyPercentiles {
+  p50: number | null
+  p95: number | null
+  p99: number | null
+}
+
 export interface WsAnalyticsSummary {
   totalConnects: number
   totalDisconnects: number
   totalReconnects: number
   totalErrors: number
+  /** Total application messages successfully received and parsed. */
+  totalMessages: number
+  /** Total messages discarded (malformed JSON, failed schema validation, out-of-order/duplicate seq). */
+  totalDrops: number
+  /** Total bytes received across all counted messages. */
+  totalBytes: number
   disconnectRate: number
+  /** Average round-trip ping latency (heartbeat), unrelated to message parse time. */
   avgLatencyMs: number | null
+  /** Receive-to-parse latency percentiles computed from real per-message timing samples. */
+  messageLatencyPercentiles: WsLatencyPercentiles
+  /** Per-minute message-rate history, oldest first, capped to {@link RATE_BUCKET_WINDOW} entries. */
+  rateBuckets: WsRateBucket[]
   /** Negotiated WS protocol version (#472) or `null` before the handshake. */
   protocolVersion: number | null
   /** True when the server is newer than this client supports (#472). */
@@ -25,15 +52,64 @@ export interface WsAnalyticsSummary {
 type Listener = (summary: WsAnalyticsSummary) => void
 
 const MAX_EVENTS = 500
+/** Rolling window of receive-to-parse latency samples kept for percentile calculation. */
+const MAX_LATENCY_SAMPLES = 200
+/** How many one-minute buckets to retain for the rate sparkline (30 min of history). */
+const RATE_BUCKET_WINDOW = 30
+/**
+ * Coalesces the high-frequency `recordMessage` notifications so a burst of WS
+ * ticks triggers at most one subscriber re-render per window, instead of one
+ * per message — keeps the diagnostics panel off the main-thread critical path.
+ */
+const NOTIFY_THROTTLE_MS = 250
+
 const events: WsEvent[] = []
 const listeners = new Set<Listener>()
 let connectTime: number | null = null
 let latencySamples: number[] = []
+let messageLatencySamples: number[] = []
+let rateBuckets: WsRateBucket[] = []
+let totalMessages = 0
+let totalBytes = 0
 let protocolVersion: number | null = null
 let protocolUpgradeRequired = false
+let notifyTimer: ReturnType<typeof setTimeout> | null = null
+
+/** Nearest-rank percentile over an already ascending-sorted array. */
+function percentile(sortedAsc: number[], p: number): number | null {
+  if (sortedAsc.length === 0) return null
+  const rank = Math.ceil(p * sortedAsc.length) - 1
+  const idx = Math.min(sortedAsc.length - 1, Math.max(0, rank))
+  return sortedAsc[idx]
+}
+
+/** Gets (creating if needed) the current minute's rate bucket, evicting the oldest past the window. */
+function touchBucket(): WsRateBucket {
+  const minute = Math.floor(Date.now() / 60_000) * 60_000
+  const last = rateBuckets[rateBuckets.length - 1]
+  if (last && last.minute === minute) return last
+  const bucket: WsRateBucket = { minute, messages: 0, bytes: 0, drops: 0, reconnects: 0 }
+  rateBuckets.push(bucket)
+  if (rateBuckets.length > RATE_BUCKET_WINDOW) rateBuckets.shift()
+  return bucket
+}
+
+/**
+ * Clears only the metrics that describe the *current* connection's live
+ * performance (receive-to-parse latency samples). Called on every drop and
+ * every (re)connect so stale measurements from a dead socket never blend
+ * into the new connection's percentiles.
+ *
+ * Lifetime counters (totals) and the per-minute rate/drop/reconnect history
+ * are intentionally left alone — those are a time series meant to span
+ * reconnects so an operator can see the rate impact around a disconnect.
+ */
+function resetSessionMetrics(): void {
+  messageLatencySamples = []
+}
 
 function summarise(): WsAnalyticsSummary {
-  const counts = { connect: 0, disconnect: 0, reconnect: 0, error: 0 }
+  const counts = { connect: 0, disconnect: 0, reconnect: 0, error: 0, drop: 0 }
   for (const e of events) {
     if (e.type in counts) counts[e.type as keyof typeof counts]++
   }
@@ -47,13 +123,24 @@ function summarise(): WsAnalyticsSummary {
       ? latencySamples.reduce((a, b) => a + b, 0) / latencySamples.length
       : null
 
+  const sortedMessageLatency = [...messageLatencySamples].sort((a, b) => a - b)
+
   return {
     totalConnects: counts.connect,
     totalDisconnects: counts.disconnect,
     totalReconnects: counts.reconnect,
     totalErrors: counts.error,
+    totalMessages,
+    totalDrops: counts.drop,
+    totalBytes,
     disconnectRate,
     avgLatencyMs: avg,
+    messageLatencyPercentiles: {
+      p50: percentile(sortedMessageLatency, 0.5),
+      p95: percentile(sortedMessageLatency, 0.95),
+      p99: percentile(sortedMessageLatency, 0.99),
+    },
+    rateBuckets: [...rateBuckets],
     protocolVersion,
     protocolUpgradeRequired,
     events: [...events],
@@ -67,25 +154,63 @@ function push(event: WsEvent) {
   listeners.forEach((l) => l(s))
 }
 
+/** Throttled notify for high-frequency callers (see {@link NOTIFY_THROTTLE_MS}). */
+function scheduleNotify(): void {
+  if (notifyTimer !== null) return
+  notifyTimer = setTimeout(() => {
+    notifyTimer = null
+    const s = summarise()
+    listeners.forEach((l) => l(s))
+  }, NOTIFY_THROTTLE_MS)
+}
+
 export const wsAnalytics = {
   recordConnect() {
     connectTime = Date.now()
+    resetSessionMetrics()
     push({ type: 'connect', timestamp: Date.now() })
   },
   recordDisconnect() {
     const durationMs = connectTime != null ? Date.now() - connectTime : undefined
     connectTime = null
+    resetSessionMetrics()
     push({ type: 'disconnect', timestamp: Date.now(), durationMs })
   },
   recordReconnect() {
+    connectTime = Date.now()
+    resetSessionMetrics()
+    touchBucket().reconnects++
     push({ type: 'reconnect', timestamp: Date.now() })
   },
   recordError(detail?: string) {
     push({ type: 'error', timestamp: Date.now(), detail })
   },
+  /** Round-trip heartbeat/ping latency — distinct from per-message parse latency below. */
   recordLatency(ms: number) {
     latencySamples = [...latencySamples.slice(-99), ms]
     push({ type: 'latency', timestamp: Date.now(), latencyMs: ms })
+  },
+  /**
+   * Records one successfully-parsed inbound application message: its wire
+   * byte size and the receive-to-parse latency measured by the caller
+   * (typically `performance.now()` at message receipt through validation).
+   * Notifications are throttled — see {@link NOTIFY_THROTTLE_MS} — so a burst
+   * of ticks costs at most one subscriber update per window.
+   */
+  recordMessage(sizeBytes: number, latencyMs: number) {
+    totalMessages++
+    totalBytes += sizeBytes
+    if (messageLatencySamples.length >= MAX_LATENCY_SAMPLES) messageLatencySamples.shift()
+    messageLatencySamples.push(latencyMs)
+    const bucket = touchBucket()
+    bucket.messages++
+    bucket.bytes += sizeBytes
+    scheduleNotify()
+  },
+  /** Records a discarded inbound frame (malformed JSON, failed validation, duplicate/out-of-order seq). */
+  recordDrop(detail?: string) {
+    touchBucket().drops++
+    push({ type: 'drop', timestamp: Date.now(), detail })
   },
   recordProtocolVersion(version: number, upgradeRequired: boolean) {
     protocolVersion = version
@@ -104,9 +229,21 @@ export const wsAnalytics = {
   exportEvents(): string {
     return JSON.stringify(events, null, 2)
   },
+  /** Full diagnostics snapshot (summary + raw event log) for the panel's export button. */
+  exportDiagnosticsSnapshot(): string {
+    return JSON.stringify({ exportedAt: new Date().toISOString(), summary: summarise() }, null, 2)
+  },
   clear() {
     events.length = 0
     latencySamples = []
+    messageLatencySamples = []
+    rateBuckets = []
+    totalMessages = 0
+    totalBytes = 0
     connectTime = null
+    if (notifyTimer !== null) {
+      clearTimeout(notifyTimer)
+      notifyTimer = null
+    }
   },
 }


### PR DESCRIPTION
…cy percentiles (#473)

Extends wsAnalytics with real, per-message measurements and wires the result into WsAnalyticsPanel:

- recordMessage(sizeBytes, latencyMs): tracks lifetime message/byte totals and a rolling receive-to-parse latency sample window used to compute p50/p95/p99 (nearest-rank) every summarise() call
- recordDrop(detail): counts discarded frames (malformed JSON, failed schema validation, duplicate/out-of-order seq, decompress/parse errors) and logs them to the connection timeline
- Per-minute rate buckets (messages, bytes, drops, reconnects) kept for the last 30 minutes, feeding a fixed-size inline-SVG sparkline in the panel — the slot count never changes with the data, so the panel never reflows as buckets arrive (CLS = 0)
- High-frequency recordMessage notifications are throttled (~250ms, coalesced via a single timer) so a burst of WS ticks costs at most one subscriber re-render instead of one per message; rare lifecycle events (connect/disconnect/drop/etc.) still notify immediately
- Session-scoped latency percentile samples reset on every disconnect and (re)connect, so stale measurements from a dead socket never blend into the new connection's numbers — the per-minute rate/drop history is intentionally left alone since it's meant to span reconnects as a real time series
- wsAnalytics.recordConnect/recordReconnect are now actually wired into WebSocketClient's onopen (previously dead code — never called from production, only from tests), so the panel's totals reflect real connection lifecycle events
- exportDiagnosticsSnapshot() + a panel "Export diagnostics" button hooked into the existing lazy-loaded export tooling (loadExportUtils / downloadFile / exportFilename), replacing the ad-hoc Blob/anchor code that only exported the raw event log

Verified this branch introduces no new `tsc -b` errors or test regressions versus a clean checkout of main (both pre-existing-issue counts identical before/after); see repo-wide caveats noted in the feature/issue-476 commit, still present here and unrelated to this change.