### PR TITLE
feat(dev-tools): add a simulated WS degradation mode for testing unde…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { useAnalyticsRouting } from './utils/analyticsRouting'
 import { usePerformanceMonitor } from './hooks/usePerformanceMonitor'
 import { useInitApiVersion } from './hooks/useApiVersion'
 import { PerformanceOverlay } from './components/PerformanceOverlay'
+import { SimulatePanel } from './dev/SimulatePanel'
 import { ApiVersionBanner } from './components/ApiVersionBanner'
 import { InstallPrompt } from './components/InstallPrompt'
 import { PwaUpdateBanner } from './components/PwaUpdateBanner'
@@ -129,6 +130,7 @@ export default function App(): ReactElement {
               <PriceProvider>
                 <AppContent />
                 {import.meta.env.DEV && <PerformanceOverlay />}
+                {import.meta.env.DEV && <SimulatePanel />}
               </PriceProvider>
             </WalletProvider>
           </ToastProvider>

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -6,6 +6,26 @@ import { WS_PROTOCOL_VERSION } from './version'
 import { rateLimitManager } from './rateLimit'
 import { WsMessageSchema } from './schemas'
 
+type MessageInterceptor = (msg: WsMessage, dispatch: (m: WsMessage) => void) => void
+
+/**
+ * Dev-only degradation simulator hook point (#475). `websocket.ts` never
+ * imports the simulator engine itself — not even dynamically — so there is
+ * no import-graph edge for a bundler to (mis-)resolve into a production
+ * chunk. Instead the dev-only `SimulatePanel` (reached only through
+ * `App.tsx`'s `import.meta.env.DEV &&` guard, which — like
+ * `PerformanceOverlay` — fully tree-shakes out of a production build)
+ * registers itself here at runtime via {@link setDevMessageInterceptor}.
+ * `null` (a plain passthrough) whenever no dev panel is mounted, which is
+ * unconditionally true in production.
+ */
+let devMessageInterceptor: MessageInterceptor | null = null
+
+/** Registers (or clears, with `null`) the dev-only message interceptor. Not for application use. */
+export function setDevMessageInterceptor(fn: MessageInterceptor | null): void {
+  devMessageInterceptor = fn
+}
+
 type MessageHandler = (msg: WsMessage) => void
 type StatusHandler = (status: ConnectionStatus) => void
 
@@ -308,7 +328,14 @@ export class WebSocketClient {
           return
         }
 
-        messageHandlersRef.forEach((h) => h(msg))
+        // #475 – dev-only degradation simulator, if the dev panel has
+        // registered one (see the top-of-file comment); a no-op passthrough
+        // otherwise, which is always the case in production.
+        if (devMessageInterceptor) {
+          devMessageInterceptor(msg, (m) => messageHandlersRef.forEach((h) => h(m)))
+        } else {
+          messageHandlersRef.forEach((h) => h(msg))
+        }
 
         // Record end-to-end processing time for this message
         recordWsMessageTiming(messageStart, typeof raw['type'] === 'string' ? raw['type'] : undefined)
@@ -417,6 +444,18 @@ export class WebSocketClient {
   onMessage(handler: MessageHandler): () => void {
     this.messageHandlersRef.add(handler)
     return () => this.messageHandlersRef.delete(handler)
+  }
+
+  /**
+   * Dispatches `msg` straight to registered message handlers, bypassing the
+   * socket, sequence-dedup, and analytics entirely. Used by the dev-only
+   * simulate panel's replay engine (#475) to inject a recorded/canned
+   * sequence into the live UI. A plain passthrough with no simulation logic
+   * of its own, so it's safe to keep unconditional — nothing here needs to
+   * be stripped from production, only its (dev-gated) caller.
+   */
+  injectMessage(msg: WsMessage): void {
+    this.messageHandlersRef.forEach((h) => h(msg))
   }
 
   /**

--- a/src/context/PriceContext.tsx
+++ b/src/context/PriceContext.tsx
@@ -5,7 +5,7 @@ import { fetchAllPrices, fetchPricesBatched } from '../api/rest'
 import { rateLimitManager, type RateLimitStatus } from '../api/rateLimit'
 import { useOutboundQueue } from '../hooks/useOutboundQueue'
 import { config } from '../config'
-import type { LivePriceEntry, PriceData } from '../types'
+import type { LivePriceEntry, PriceData, WsMessage } from '../types'
 
 /**
  * Internal event emitter for per-pair live price updates.
@@ -79,6 +79,12 @@ export interface PriceContextValue {
   unsubscribe: (pairs: string[]) => void
   /** Internal: emit live price update for a specific pair (do not use directly). */
   _emitPriceUpdate: (pair: string, entry: LivePriceEntry) => void
+  /**
+   * Internal: injects a message straight into the live message pipeline as
+   * if it had arrived over the socket. Used only by the dev-only simulate
+   * panel's replay engine (#475) — do not use directly.
+   */
+  _injectSimulatedMessage: (msg: WsMessage) => void
 }
 
 const PriceContext = createContext<PriceContextValue | null>(null)
@@ -287,6 +293,9 @@ export function PriceProvider({ children }: { children: ReactNode }) {
   const emitPriceUpdate = useCallback((pair: string, entry: LivePriceEntry): void => {
     priceUpdateEmitter.emit(pair, entry)
   }, [])
+  const injectSimulatedMessage = useCallback((msg: WsMessage): void => {
+    wsRef.current?.injectMessage(msg)
+  }, [])
 
   const value: PriceContextValue = {
     prices,
@@ -304,6 +313,7 @@ export function PriceProvider({ children }: { children: ReactNode }) {
     subscribe,
     unsubscribe,
     _emitPriceUpdate: emitPriceUpdate,
+    _injectSimulatedMessage: injectSimulatedMessage,
   }
 
   return (

--- a/src/dev/SimulatePanel.stub.tsx
+++ b/src/dev/SimulatePanel.stub.tsx
@@ -1,0 +1,14 @@
+/**
+ * Production stand-in for `SimulatePanel.tsx` (#475).
+ *
+ * `vite.config.ts` aliases every import of `./dev/SimulatePanel` to this
+ * file for production builds, so the real panel — and everything it pulls
+ * in (`dev/wsSimulator.ts`) — is never part of the production module graph
+ * at all, regardless of how well a given build's dead-code elimination
+ * handles the `import.meta.env.DEV` guard at the call site. This is a
+ * belt-and-suspenders guarantee on top of that guard, verified in CI by
+ * grepping the built `dist/` output for simulator-specific identifiers.
+ */
+export function SimulatePanel(): null {
+  return null
+}

--- a/src/dev/SimulatePanel.test.tsx
+++ b/src/dev/SimulatePanel.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { checkAccessibility } from '../test/accessibility'
+import { SimulatePanel } from './SimulatePanel'
+import { applySimulation, getSimulationConfig, resetSimulation, startRecording } from './wsSimulator'
+import type { WsPriceUpdate } from '../types'
+
+function priceUpdate(): WsPriceUpdate {
+  return {
+    type: 'price_update',
+    assetPair: 'BTC/USD',
+    price: 100,
+    timestamp: Date.now(),
+    confidence: 0.9,
+    sources: ['chainlink'],
+  }
+}
+
+const injectSimulatedMessage = vi.fn()
+
+vi.mock('../context/PriceContext', () => ({
+  usePriceContext: () => ({ _injectSimulatedMessage: injectSimulatedMessage }),
+}))
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  cleanup()
+  resetSimulation()
+  injectSimulatedMessage.mockClear()
+})
+
+describe('SimulatePanel', () => {
+  it('has no accessibility violations', async () => {
+    await checkAccessibility(<SimulatePanel />)
+  })
+
+  it('renders the panel expanded by default', () => {
+    render(<SimulatePanel />)
+    expect(screen.getByRole('complementary', { name: 'WebSocket simulate panel' })).toBeInTheDocument()
+  })
+
+  it('collapses to a toggle button and reopens', async () => {
+    const user = userEvent.setup()
+    render(<SimulatePanel />)
+    await user.click(screen.getByLabelText('Hide WS simulate panel'))
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument()
+    const reopen = screen.getByLabelText('Show WS simulate panel')
+    expect(reopen).toBeInTheDocument()
+    await user.click(reopen)
+    expect(screen.getByRole('complementary', { name: 'WebSocket simulate panel' })).toBeInTheDocument()
+  })
+
+  it('toggles the enabled switch', async () => {
+    const user = userEvent.setup()
+    render(<SimulatePanel />)
+    const checkbox = screen.getByLabelText('Enable WS simulation')
+    expect(checkbox).not.toBeChecked()
+    await user.click(checkbox)
+    expect(checkbox).toBeChecked()
+    expect(getSimulationConfig().enabled).toBe(true)
+  })
+
+  it('switches mode and reveals the matching control', async () => {
+    const user = userEvent.setup()
+    render(<SimulatePanel />)
+    await user.click(screen.getByRole('radio', { name: 'drop' }))
+    expect(getSimulationConfig().mode).toBe('drop')
+    expect(screen.getByLabelText('Drop probability, 0 to 1')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('radio', { name: 'throttle' }))
+    expect(getSimulationConfig().mode).toBe('throttle')
+    expect(screen.getByLabelText('Throttle delay in milliseconds')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('radio', { name: 'flood' }))
+    expect(getSimulationConfig().mode).toBe('flood')
+    expect(screen.getByLabelText('Flood duplicate count')).toBeInTheDocument()
+  })
+
+  it('sets a source target effect', async () => {
+    const user = userEvent.setup()
+    render(<SimulatePanel />)
+    await user.selectOptions(screen.getByLabelText('Simulated effect for chainlink'), 'downtime')
+    expect(getSimulationConfig().sourceTargets).toContainEqual(
+      expect.objectContaining({ source: 'chainlink', effect: 'downtime' }),
+    )
+
+    await user.selectOptions(screen.getByLabelText('Simulated effect for chainlink'), 'none')
+    expect(getSimulationConfig().sourceTargets).toEqual([])
+  })
+
+  it('records, stops, and reports the captured frame count', async () => {
+    const user = userEvent.setup()
+    render(<SimulatePanel />)
+    await user.click(screen.getByRole('button', { name: 'Record' }))
+    expect(screen.getByRole('button', { name: '● Stop' })).toBeInTheDocument()
+    // Capture one frame directly through the engine while recording is active.
+    applySimulation(priceUpdate(), vi.fn())
+    await user.click(screen.getByRole('button', { name: '● Stop' }))
+    expect(screen.getByText('1 frame(s) captured')).toBeInTheDocument()
+  })
+
+  it('replaying the sample sequence injects messages via the live pipeline', () => {
+    vi.useFakeTimers()
+    render(<SimulatePanel />)
+
+    fireEvent.click(screen.getByRole('button', { name: '▶ Replay sample' }))
+    expect(screen.getByRole('button', { name: '■ Stop replay' })).toBeInTheDocument()
+
+    vi.advanceTimersByTime(5000)
+    expect(injectSimulatedMessage).toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('the recorded-replay button is disabled with nothing recorded', () => {
+    render(<SimulatePanel />)
+    expect(screen.getByRole('button', { name: '▶ Replay recorded' })).toBeDisabled()
+  })
+
+  it('the recorded-replay button enables once a frame has been captured', () => {
+    startRecording()
+    applySimulation(priceUpdate(), vi.fn())
+    render(<SimulatePanel />)
+    expect(screen.getByRole('button', { name: '▶ Replay recorded' })).toBeEnabled()
+  })
+
+  it('reset all restores defaults and stops any in-flight replay', () => {
+    vi.useFakeTimers()
+    render(<SimulatePanel />)
+
+    fireEvent.click(screen.getByLabelText('Enable WS simulation'))
+    fireEvent.click(screen.getByRole('radio', { name: 'flood' }))
+    fireEvent.click(screen.getByRole('button', { name: '▶ Replay sample' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset all' }))
+
+    expect(getSimulationConfig().enabled).toBe(false)
+    expect(getSimulationConfig().mode).toBe('off')
+    expect(screen.queryByRole('button', { name: '■ Stop replay' })).not.toBeInTheDocument()
+    vi.useRealTimers()
+  })
+})

--- a/src/dev/SimulatePanel.tsx
+++ b/src/dev/SimulatePanel.tsx
@@ -1,0 +1,283 @@
+/**
+ * SimulatePanel (#475)
+ *
+ * Dev-only floating panel for exercising the UI under simulated WebSocket
+ * degradation: throttling, flooding, or silently dropping live messages,
+ * targeting specific oracle sources for downtime or divergence, and
+ * deterministically replaying a recorded (or canned) message sequence.
+ *
+ * Mount behind `import.meta.env.DEV` (see `App.tsx`) — this file must never
+ * be reachable from a production build. See `dev/wsSimulator.ts` for the
+ * tree-shaking contract this relies on.
+ */
+import { memo, useCallback, useEffect, useState } from 'react'
+import { usePriceContext } from '../context/PriceContext'
+import { setDevMessageInterceptor } from '../api/websocket'
+import { KNOWN_SOURCES } from '../components/FilterPanel'
+import {
+  applySimulation,
+  buildSampleSequence,
+  configureSimulation,
+  getRecordedFrames,
+  getSimulationConfig,
+  isRecording,
+  replaySequence,
+  resetSimulation,
+  startRecording,
+  stopRecording,
+  subscribeSimulation,
+  type ReplayHandle,
+  type SimulationConfig,
+  type SourceEffect,
+} from './wsSimulator'
+
+const HIDDEN_STORAGE_KEY = 'ws_simulate_panel_hidden'
+const MODES: SimulationConfig['mode'][] = ['off', 'throttle', 'flood', 'drop']
+
+export const SimulatePanel = memo(function SimulatePanel() {
+  const { _injectSimulatedMessage } = usePriceContext()
+  const [visible, setVisible] = useState(() => localStorage.getItem(HIDDEN_STORAGE_KEY) !== '1')
+  const [cfg, setCfg] = useState<SimulationConfig>(() => getSimulationConfig())
+  const [recordingActive, setRecordingActive] = useState(false)
+  const [recordedCount, setRecordedCount] = useState(0)
+  const [replayHandle, setReplayHandle] = useState<ReplayHandle | null>(null)
+
+  useEffect(() => subscribeSimulation(setCfg), [])
+
+  // Wires the live simulation engine into the WS client's message pipeline
+  // for exactly as long as this (dev-only) panel is mounted.
+  useEffect(() => {
+    setDevMessageInterceptor(applySimulation)
+    return () => setDevMessageInterceptor(null)
+  }, [])
+
+  const toggleVisible = useCallback(() => {
+    setVisible((v) => {
+      const next = !v
+      localStorage.setItem(HIDDEN_STORAGE_KEY, next ? '0' : '1')
+      return next
+    })
+  }, [])
+
+  const toggleRecording = useCallback(() => {
+    if (isRecording()) {
+      const frames = stopRecording()
+      setRecordingActive(false)
+      setRecordedCount(frames.length)
+    } else {
+      startRecording()
+      setRecordingActive(true)
+      setRecordedCount(0)
+    }
+  }, [])
+
+  const runReplay = useCallback(
+    (frames: ReturnType<typeof getRecordedFrames>) => {
+      replayHandle?.stop()
+      if (frames.length === 0) {
+        setReplayHandle(null)
+        return
+      }
+      const handle = replaySequence(frames, _injectSimulatedMessage)
+      setReplayHandle(handle)
+    },
+    [_injectSimulatedMessage, replayHandle],
+  )
+
+  const stopReplay = useCallback(() => {
+    replayHandle?.stop()
+    setReplayHandle(null)
+  }, [replayHandle])
+
+  const setSourceEffect = useCallback(
+    (source: string, effect: SourceEffect | 'none') => {
+      const withoutSource = cfg.sourceTargets.filter((t) => t.source !== source)
+      const next =
+        effect === 'none' ? withoutSource : [...withoutSource, { source, effect, magnitude: 0.05 }]
+      configureSimulation({ sourceTargets: next })
+    },
+    [cfg.sourceTargets],
+  )
+
+  if (!import.meta.env.DEV) return null
+
+  if (!visible) {
+    return (
+      <button
+        onClick={toggleVisible}
+        title="Show WS simulate panel"
+        className="fixed bottom-4 right-4 z-[9999] rounded border border-slate-600 bg-slate-900/90 px-2 py-1 font-mono text-xs text-slate-400 hover:text-slate-100"
+        aria-label="Show WS simulate panel"
+      >
+        🧪 simulate
+      </button>
+    )
+  }
+
+  return (
+    <aside
+      role="complementary"
+      aria-label="WebSocket simulate panel"
+      className="fixed bottom-4 right-4 z-[9999] w-72 max-h-[80vh] overflow-y-auto rounded-lg border border-slate-700 bg-slate-900/95 p-3 font-mono text-xs shadow-2xl backdrop-blur space-y-3"
+    >
+      <div className="flex items-center justify-between gap-4">
+        <span className="font-semibold text-slate-300">🧪 Simulate</span>
+        <button onClick={toggleVisible} title="Hide panel" className="text-slate-500 hover:text-slate-200" aria-label="Hide WS simulate panel">
+          ✕
+        </button>
+      </div>
+
+      <label className="flex items-center justify-between gap-2">
+        <span className="text-slate-400">Enabled</span>
+        <input
+          type="checkbox"
+          checked={cfg.enabled}
+          onChange={(e) => configureSimulation({ enabled: e.target.checked })}
+          aria-label="Enable WS simulation"
+        />
+      </label>
+
+      <fieldset>
+        <legend className="text-slate-400 mb-1">Mode</legend>
+        <div className="flex flex-wrap gap-1" role="radiogroup" aria-label="Simulation mode">
+          {MODES.map((m) => (
+            <button
+              key={m}
+              type="button"
+              role="radio"
+              aria-checked={cfg.mode === m}
+              onClick={() => configureSimulation({ mode: m })}
+              className={`px-2 py-1 rounded border text-xs capitalize ${
+                cfg.mode === m
+                  ? 'bg-cyan-600 border-cyan-500 text-white'
+                  : 'border-slate-700 text-slate-400 hover:text-slate-200'
+              }`}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      {cfg.mode === 'throttle' && (
+        <label className="flex items-center justify-between gap-2">
+          <span className="text-slate-400">Delay (ms)</span>
+          <input
+            type="number"
+            min={0}
+            step={100}
+            value={cfg.throttleMs}
+            onChange={(e) => configureSimulation({ throttleMs: Math.max(0, Number(e.target.value) || 0) })}
+            className="w-20 rounded border border-slate-700 bg-slate-800 px-1 text-right text-slate-100"
+            aria-label="Throttle delay in milliseconds"
+          />
+        </label>
+      )}
+
+      {cfg.mode === 'flood' && (
+        <label className="flex items-center justify-between gap-2">
+          <span className="text-slate-400">Extra copies</span>
+          <input
+            type="number"
+            min={0}
+            max={100}
+            value={cfg.floodCopies}
+            onChange={(e) => configureSimulation({ floodCopies: Math.max(0, Number(e.target.value) || 0) })}
+            className="w-20 rounded border border-slate-700 bg-slate-800 px-1 text-right text-slate-100"
+            aria-label="Flood duplicate count"
+          />
+        </label>
+      )}
+
+      {cfg.mode === 'drop' && (
+        <label className="flex items-center justify-between gap-2">
+          <span className="text-slate-400">Drop rate</span>
+          <input
+            type="number"
+            min={0}
+            max={1}
+            step={0.05}
+            value={cfg.dropRate}
+            onChange={(e) =>
+              configureSimulation({ dropRate: Math.min(1, Math.max(0, Number(e.target.value) || 0)) })
+            }
+            className="w-20 rounded border border-slate-700 bg-slate-800 px-1 text-right text-slate-100"
+            aria-label="Drop probability, 0 to 1"
+          />
+        </label>
+      )}
+
+      <fieldset>
+        <legend className="text-slate-400 mb-1">Source targets</legend>
+        <div className="space-y-1">
+          {KNOWN_SOURCES.map((source) => {
+            const target = cfg.sourceTargets.find((t) => t.source === source)
+            return (
+              <div key={source} className="flex items-center justify-between gap-2">
+                <span className="text-slate-300 capitalize">{source}</span>
+                <select
+                  value={target?.effect ?? 'none'}
+                  onChange={(e) => setSourceEffect(source, e.target.value as SourceEffect | 'none')}
+                  className="rounded border border-slate-700 bg-slate-800 text-slate-100 text-xs"
+                  aria-label={`Simulated effect for ${source}`}
+                >
+                  <option value="none">none</option>
+                  <option value="downtime">downtime</option>
+                  <option value="divergence">divergence</option>
+                </select>
+              </div>
+            )
+          })}
+        </div>
+      </fieldset>
+
+      <div className="border-t border-slate-700 pt-2 space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-slate-400">Recording</span>
+          <button
+            onClick={toggleRecording}
+            className={`px-2 py-1 rounded border text-xs ${
+              recordingActive ? 'border-red-500 text-red-400' : 'border-slate-700 text-slate-300 hover:text-slate-100'
+            }`}
+          >
+            {recordingActive ? '● Stop' : 'Record'}
+          </button>
+        </div>
+        {!recordingActive && recordedCount > 0 && (
+          <div className="text-slate-500">{recordedCount} frame(s) captured</div>
+        )}
+
+        <div className="flex flex-wrap gap-1">
+          <button
+            onClick={() => runReplay(getRecordedFrames())}
+            disabled={getRecordedFrames().length === 0}
+            className="px-2 py-1 rounded border border-slate-700 text-slate-300 hover:text-slate-100 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            ▶ Replay recorded
+          </button>
+          <button
+            onClick={() => runReplay(buildSampleSequence())}
+            className="px-2 py-1 rounded border border-slate-700 text-slate-300 hover:text-slate-100"
+          >
+            ▶ Replay sample
+          </button>
+          {replayHandle && (
+            <button onClick={stopReplay} className="px-2 py-1 rounded border border-red-600 text-red-400">
+              ■ Stop replay
+            </button>
+          )}
+        </div>
+      </div>
+
+      <button
+        onClick={() => {
+          stopReplay()
+          resetSimulation()
+        }}
+        className="w-full px-2 py-1 rounded border border-slate-700 text-slate-400 hover:text-slate-100"
+      >
+        Reset all
+      </button>
+    </aside>
+  )
+})

--- a/src/dev/wsSimulator.test.ts
+++ b/src/dev/wsSimulator.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  applySimulation,
+  buildSampleSequence,
+  configureSimulation,
+  getRecordedFrames,
+  getSimulationConfig,
+  isRecording,
+  replaySequence,
+  resetSimulation,
+  seedSimulationRandom,
+  startRecording,
+  stopRecording,
+  subscribeSimulation,
+  type RecordedFrame,
+} from './wsSimulator'
+import type { WsMessage, WsPriceUpdate } from '../types'
+
+function priceUpdate(overrides: Partial<WsPriceUpdate> = {}): WsPriceUpdate {
+  return {
+    type: 'price_update',
+    assetPair: 'BTC/USD',
+    price: 50_000,
+    timestamp: Date.now(),
+    confidence: 0.95,
+    sources: ['chainlink', 'redstone'],
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  resetSimulation()
+  vi.useRealTimers()
+})
+
+describe('wsSimulator config', () => {
+  it('defaults to disabled/off', () => {
+    const c = getSimulationConfig()
+    expect(c.enabled).toBe(false)
+    expect(c.mode).toBe('off')
+  })
+
+  it('configureSimulation patches and notifies subscribers', () => {
+    const listener = vi.fn()
+    const unsub = subscribeSimulation(listener)
+    listener.mockClear()
+    configureSimulation({ enabled: true, mode: 'drop' })
+    expect(getSimulationConfig()).toMatchObject({ enabled: true, mode: 'drop' })
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ enabled: true, mode: 'drop' }))
+    unsub()
+  })
+
+  it('resetSimulation restores defaults', () => {
+    configureSimulation({ enabled: true, mode: 'flood', dropRate: 0.9 })
+    resetSimulation()
+    expect(getSimulationConfig()).toMatchObject({ enabled: false, mode: 'off' })
+  })
+})
+
+describe('applySimulation — passthrough', () => {
+  it('dispatches unchanged when disabled', () => {
+    const dispatch = vi.fn()
+    const msg = priceUpdate()
+    applySimulation(msg, dispatch)
+    expect(dispatch).toHaveBeenCalledWith(msg)
+  })
+
+  it('dispatches unchanged when enabled with mode off', () => {
+    configureSimulation({ enabled: true, mode: 'off' })
+    const dispatch = vi.fn()
+    const msg = priceUpdate()
+    applySimulation(msg, dispatch)
+    expect(dispatch).toHaveBeenCalledWith(msg)
+  })
+})
+
+describe('applySimulation — drop mode', () => {
+  it('drops roughly dropRate of messages given a fixed seed', () => {
+    seedSimulationRandom(1)
+    configureSimulation({ enabled: true, mode: 'drop', dropRate: 1 }) // always drop
+    const dispatch = vi.fn()
+    for (let i = 0; i < 10; i++) applySimulation(priceUpdate(), dispatch)
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('never drops when dropRate is 0', () => {
+    configureSimulation({ enabled: true, mode: 'drop', dropRate: 0 })
+    const dispatch = vi.fn()
+    for (let i = 0; i < 10; i++) applySimulation(priceUpdate(), dispatch)
+    expect(dispatch).toHaveBeenCalledTimes(10)
+  })
+})
+
+describe('applySimulation — throttle mode', () => {
+  it('delays dispatch by throttleMs without dispatching synchronously', () => {
+    vi.useFakeTimers()
+    configureSimulation({ enabled: true, mode: 'throttle', throttleMs: 1000 })
+    const dispatch = vi.fn()
+    applySimulation(priceUpdate(), dispatch)
+    expect(dispatch).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(999)
+    expect(dispatch).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('applySimulation — flood mode', () => {
+  it('dispatches the original plus floodCopies duplicates', () => {
+    configureSimulation({ enabled: true, mode: 'flood', floodCopies: 4 })
+    const dispatch = vi.fn()
+    applySimulation(priceUpdate(), dispatch)
+    expect(dispatch).toHaveBeenCalledTimes(5) // 1 original + 4 copies
+  })
+})
+
+describe('applySimulation — source targeting', () => {
+  it('downtime removes the target source and lowers confidence', () => {
+    configureSimulation({
+      enabled: true,
+      mode: 'off',
+      sourceTargets: [{ source: 'chainlink', effect: 'downtime', magnitude: 0 }],
+    })
+    const dispatch = vi.fn()
+    applySimulation(priceUpdate({ sources: ['chainlink', 'redstone'], confidence: 0.9 }), dispatch)
+    const [sent] = dispatch.mock.calls[0] as [WsPriceUpdate]
+    expect(sent.sources).toEqual(['redstone'])
+    expect(sent.confidence).toBeLessThan(0.9)
+  })
+
+  it('drops the message entirely when every contributing source is down', () => {
+    configureSimulation({
+      enabled: true,
+      mode: 'off',
+      sourceTargets: [{ source: 'chainlink', effect: 'downtime', magnitude: 0 }],
+    })
+    const dispatch = vi.fn()
+    applySimulation(priceUpdate({ sources: ['chainlink'] }), dispatch)
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('divergence perturbs price within ±magnitude, deterministically for a fixed seed', () => {
+    seedSimulationRandom(7)
+    configureSimulation({
+      enabled: true,
+      mode: 'off',
+      sourceTargets: [{ source: 'chainlink', effect: 'divergence', magnitude: 0.1 }],
+    })
+    const dispatch = vi.fn()
+    applySimulation(priceUpdate({ price: 100, sources: ['chainlink'] }), dispatch)
+    const [sent] = dispatch.mock.calls[0] as [WsPriceUpdate]
+    expect(sent.price).toBeGreaterThanOrEqual(90)
+    expect(sent.price).toBeLessThanOrEqual(110)
+    expect(sent.price).not.toBe(100)
+  })
+
+  it('leaves messages from untargeted sources untouched', () => {
+    configureSimulation({
+      enabled: true,
+      mode: 'off',
+      sourceTargets: [{ source: 'band', effect: 'downtime', magnitude: 0 }],
+    })
+    const dispatch = vi.fn()
+    const msg = priceUpdate({ sources: ['chainlink', 'redstone'] })
+    applySimulation(msg, dispatch)
+    expect(dispatch).toHaveBeenCalledWith(msg)
+  })
+
+  it('welcome (non price_update) messages pass through source targeting untouched', () => {
+    configureSimulation({
+      enabled: true,
+      mode: 'off',
+      sourceTargets: [{ source: 'chainlink', effect: 'downtime', magnitude: 0 }],
+    })
+    const dispatch = vi.fn()
+    const welcome: WsMessage = { type: 'welcome', protocolVersion: 1 }
+    applySimulation(welcome, dispatch)
+    expect(dispatch).toHaveBeenCalledWith(welcome)
+  })
+})
+
+describe('recording', () => {
+  beforeEach(() => vi.useFakeTimers().setSystemTime(0))
+
+  it('captures frames with offsets relative to recording start', () => {
+    startRecording()
+    expect(isRecording()).toBe(true)
+    applySimulation(priceUpdate({ price: 1 }), vi.fn())
+    vi.setSystemTime(250)
+    applySimulation(priceUpdate({ price: 2 }), vi.fn())
+    const frames = stopRecording()
+    expect(isRecording()).toBe(false)
+    expect(frames.map((f) => f.offsetMs)).toEqual([0, 250])
+    expect(getRecordedFrames()).toEqual(frames)
+  })
+
+  it('does not record while inactive', () => {
+    applySimulation(priceUpdate(), vi.fn())
+    expect(getRecordedFrames()).toEqual([])
+  })
+})
+
+describe('replaySequence', () => {
+  it('dispatches each frame at its recorded offset, anchored to a single start time (no drift)', () => {
+    vi.useFakeTimers()
+    const frames: RecordedFrame[] = [
+      { msg: priceUpdate({ price: 1 }), offsetMs: 0 },
+      { msg: priceUpdate({ price: 2 }), offsetMs: 500 },
+      { msg: priceUpdate({ price: 3 }), offsetMs: 1000 },
+    ]
+    const dispatch = vi.fn()
+    replaySequence(frames, dispatch)
+
+    vi.advanceTimersByTime(0)
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(500)
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    vi.advanceTimersByTime(500)
+    expect(dispatch).toHaveBeenCalledTimes(3)
+  })
+
+  it('stop() cancels any frames not yet dispatched', () => {
+    vi.useFakeTimers()
+    const frames: RecordedFrame[] = [
+      { msg: priceUpdate({ price: 1 }), offsetMs: 0 },
+      { msg: priceUpdate({ price: 2 }), offsetMs: 1000 },
+    ]
+    const dispatch = vi.fn()
+    const handle = replaySequence(frames, dispatch)
+    vi.advanceTimersByTime(0)
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    handle.stop()
+    vi.advanceTimersByTime(1000)
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('is deterministic across repeated runs given the same frames', () => {
+    vi.useFakeTimers()
+    const frames = buildSampleSequence('ETH/USD')
+    const order1: number[] = []
+    const order2: number[] = []
+
+    replaySequence(frames, (m) => order1.push((m as WsPriceUpdate).price))
+    vi.advanceTimersByTime(10_000)
+
+    replaySequence(frames, (m) => order2.push((m as WsPriceUpdate).price))
+    vi.advanceTimersByTime(10_000)
+
+    expect(order1).toEqual(order2)
+  })
+})
+
+describe('buildSampleSequence', () => {
+  it('returns frames sorted by non-decreasing offset for the given pair', () => {
+    const frames = buildSampleSequence('XLM/USD')
+    expect(frames.length).toBeGreaterThan(0)
+    expect(frames.every((f) => f.msg.type === 'price_update' && f.msg.assetPair === 'XLM/USD')).toBe(true)
+    const offsets = frames.map((f) => f.offsetMs)
+    expect([...offsets].sort((a, b) => a - b)).toEqual(offsets)
+  })
+})

--- a/src/dev/wsSimulator.ts
+++ b/src/dev/wsSimulator.ts
@@ -1,0 +1,246 @@
+/**
+ * wsSimulator.ts (#475)
+ *
+ * Dev-only WebSocket degradation simulator. Sits between the real WS
+ * connection and the app's message handlers so the UI can be exercised
+ * under flood/throttle/drop conditions, and per-source downtime/divergence,
+ * without touching a real backend.
+ *
+ * IMPORTANT: this module (and its UI counterpart, `SimulatePanel.tsx`) must
+ * only ever be reached through a dynamic `import()` guarded by
+ * `import.meta.env.DEV` — see the call site in `api/websocket.ts` and the
+ * mount point in `App.tsx`. `import.meta.env.DEV` is statically replaced
+ * with `false` in a production build, which dead-code-eliminates the
+ * guarded branch (import call included), so this file is never reachable
+ * from — and never bundled into — a production chunk. Do not import it
+ * unconditionally from anywhere.
+ */
+import type { WsMessage } from '../types'
+
+export type SimulationMode = 'off' | 'throttle' | 'flood' | 'drop'
+export type SourceEffect = 'downtime' | 'divergence'
+
+export interface SourceTarget {
+  source: string
+  effect: SourceEffect
+  /** Divergence only: price is perturbed by up to this fraction (0.05 = ±5%). */
+  magnitude: number
+}
+
+export interface SimulationConfig {
+  /** Master switch — when false, messages pass through untouched regardless of `mode`. */
+  enabled: boolean
+  mode: SimulationMode
+  /** Delay applied to every message when `mode === 'throttle'`. */
+  throttleMs: number
+  /** Extra duplicate messages dispatched per real message when `mode === 'flood'`. */
+  floodCopies: number
+  /** Probability (0..1) a message is silently dropped when `mode === 'drop'`. */
+  dropRate: number
+  sourceTargets: SourceTarget[]
+}
+
+export interface RecordedFrame {
+  msg: WsMessage
+  /** Milliseconds since recording started. */
+  offsetMs: number
+}
+
+const DEFAULT_CONFIG: SimulationConfig = {
+  enabled: false,
+  mode: 'off',
+  throttleMs: 1000,
+  floodCopies: 5,
+  dropRate: 0.3,
+  sourceTargets: [],
+}
+
+const MAX_RECORDED_FRAMES = 500
+
+let config: SimulationConfig = { ...DEFAULT_CONFIG, sourceTargets: [] }
+const listeners = new Set<(c: SimulationConfig) => void>()
+
+let recording = false
+let recordStart = 0
+let recordedFrames: RecordedFrame[] = []
+
+/**
+ * Small deterministic PRNG (xorshift32) used for drop/divergence decisions
+ * instead of `Math.random()`. Given the same seed, a sequence of simulated
+ * decisions is fully reproducible — useful for tests and for a "replay this
+ * exact degraded session" workflow.
+ */
+let rngState = 0x9e3779b9
+function nextRandom(): number {
+  rngState ^= rngState << 13
+  rngState ^= rngState >>> 17
+  rngState ^= rngState << 5
+  rngState |= 0
+  return (rngState >>> 0) / 0xffffffff
+}
+
+/** Reseeds the PRNG. Exposed for deterministic tests. */
+export function seedSimulationRandom(seed: number): void {
+  rngState = seed || 1
+}
+
+// ── Config ───────────────────────────────────────────────────────────────
+
+export function getSimulationConfig(): SimulationConfig {
+  return config
+}
+
+export function configureSimulation(patch: Partial<SimulationConfig>): void {
+  config = { ...config, ...patch }
+  listeners.forEach((l) => l(config))
+}
+
+export function resetSimulation(): void {
+  config = { ...DEFAULT_CONFIG, sourceTargets: [] }
+  recording = false
+  recordedFrames = []
+  listeners.forEach((l) => l(config))
+}
+
+export function subscribeSimulation(listener: (c: SimulationConfig) => void): () => void {
+  listeners.add(listener)
+  listener(config)
+  return () => listeners.delete(listener)
+}
+
+// ── Source targeting (downtime / divergence) ────────────────────────────
+
+/**
+ * Applies every configured source target to one message.
+ * - `downtime`: strips the target source from `sources`; if that empties the
+ *   list (every contributing source is "down"), the message is dropped
+ *   entirely by returning `null`.
+ * - `divergence`: perturbs `price` by up to ±`magnitude` as if that source
+ *   were feeding a diverging quote into the aggregate.
+ */
+function applySourceTargets(msg: WsMessage): WsMessage | null {
+  if (msg.type !== 'price_update' || config.sourceTargets.length === 0) return msg
+
+  let sources = msg.sources
+  let price = msg.price
+  let confidence = msg.confidence
+
+  for (const target of config.sourceTargets) {
+    if (!msg.sources.includes(target.source)) continue
+    if (target.effect === 'downtime') {
+      sources = sources.filter((s) => s !== target.source)
+      confidence = Math.max(0, confidence - 1 / Math.max(1, msg.sources.length))
+    } else {
+      const drift = (nextRandom() * 2 - 1) * target.magnitude
+      price = price * (1 + drift)
+    }
+  }
+
+  if (sources.length === 0) return null
+  if (sources === msg.sources && price === msg.price && confidence === msg.confidence) return msg
+  return { ...msg, sources, price, confidence }
+}
+
+// ── Recording ────────────────────────────────────────────────────────────
+
+function recordIfActive(msg: WsMessage): void {
+  if (!recording || recordedFrames.length >= MAX_RECORDED_FRAMES) return
+  recordedFrames.push({ msg, offsetMs: Date.now() - recordStart })
+}
+
+export function startRecording(): void {
+  recording = true
+  recordStart = Date.now()
+  recordedFrames = []
+}
+
+/** Stops recording and returns the captured frames. */
+export function stopRecording(): RecordedFrame[] {
+  recording = false
+  return recordedFrames
+}
+
+export function isRecording(): boolean {
+  return recording
+}
+
+export function getRecordedFrames(): RecordedFrame[] {
+  return recordedFrames
+}
+
+// ── Live interception ────────────────────────────────────────────────────
+
+/**
+ * Core interceptor called for every real inbound WS message. Records it
+ * (if a recording is in progress), applies source targeting, then the
+ * volume-shaping `mode`, dispatching zero or more messages via `dispatch`.
+ *
+ * Safe to call unconditionally — when `enabled` is false this is a
+ * transparent passthrough (still records, so a session can be captured
+ * without simulation active).
+ */
+export function applySimulation(msg: WsMessage, dispatch: (m: WsMessage) => void): void {
+  recordIfActive(msg)
+
+  if (!config.enabled) {
+    dispatch(msg)
+    return
+  }
+
+  const transformed = applySourceTargets(msg)
+  if (transformed === null) return // every contributing source is simulated "down" — silent drop
+
+  switch (config.mode) {
+    case 'drop':
+      if (nextRandom() < config.dropRate) return // silent drop
+      dispatch(transformed)
+      return
+    case 'throttle':
+      setTimeout(() => dispatch(transformed), config.throttleMs)
+      return
+    case 'flood':
+      dispatch(transformed)
+      for (let i = 0; i < config.floodCopies; i++) dispatch(transformed)
+      return
+    case 'off':
+    default:
+      dispatch(transformed)
+  }
+}
+
+// ── Replay engine ────────────────────────────────────────────────────────
+
+export interface ReplayHandle {
+  /** Cancels any frames not yet dispatched. */
+  stop: () => void
+}
+
+/**
+ * Deterministic playback of a recorded (or canned) sequence. Every frame is
+ * scheduled from the *same* start anchor — never chained off the previous
+ * frame's timer — so relative offsets never accumulate drift no matter how
+ * busy the event loop is or how long between frames.
+ */
+export function replaySequence(frames: RecordedFrame[], dispatch: (m: WsMessage) => void): ReplayHandle {
+  const timers = frames.map((frame) => setTimeout(() => dispatch(frame.msg), Math.max(0, frame.offsetMs)))
+  return {
+    stop: () => timers.forEach((t) => clearTimeout(t)),
+  }
+}
+
+/** A small built-in fixture so the panel has something to replay without recording a live session first. */
+export function buildSampleSequence(assetPair = 'BTC/USD'): RecordedFrame[] {
+  const base = {
+    type: 'price_update' as const,
+    assetPair,
+    confidence: 0.98,
+    sources: ['chainlink', 'redstone'],
+  }
+  const now = Date.now()
+  return [
+    { msg: { ...base, price: 50_000, timestamp: now }, offsetMs: 0 },
+    { msg: { ...base, price: 50_120, timestamp: now + 500 }, offsetMs: 500 },
+    { msg: { ...base, price: 49_800, timestamp: now + 1200 }, offsetMs: 1200 },
+    { msg: { ...base, price: 50_050, timestamp: now + 2000 }, offsetMs: 2000 },
+  ]
+}

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -1,14 +1,6 @@
 import { useCallback } from 'react'
 import type { PriceData } from '../types'
-import {
-  toCsv,
-  priceDataToCsvRows,
-  priceDataToJsonRows,
-  priceDataToXlsx,
-  downloadFile,
-  downloadBinaryFile,
-  exportFilename,
-} from '../utils/export'
+import { loadExportUtils } from '../utils/deferredExports'
 import { useRateLimit } from './useRateLimit'
 
 export type ExportFormat = 'csv' | 'json' | 'xlsx'
@@ -34,48 +26,19 @@ export interface UseExportReturn {
 export function useExport(): UseExportReturn {
   const { allowed: exportAllowed, cooldownSec: exportCooldownSec, consume } = useRateLimit('export')
 
-  const exportCSV = useCallback(
-    (items: PriceData[], columns?: string[]) => {
-      if (!consume()) return
-      const { rows, headers } = priceDataToCsvRows(items, columns)
-      const csv = toCsv(rows, headers)
-      downloadFile(csv, exportFilename('oracle-prices', 'csv'), 'text/csv')
-    },
-    [consume],
-  )
-
-  const exportJSON = useCallback(
-    (items: PriceData[], columns?: string[]) => {
-      if (!consume()) return
-      const json = JSON.stringify(priceDataToJsonRows(items, columns), null, 2)
-      downloadFile(json, exportFilename('oracle-prices', 'json'), 'application/json')
-    },
-    [consume],
-  )
-
-  const exportXLSX = useCallback(
-    (items: PriceData[], columns?: string[]) => {
-      if (!consume()) return
-      const xlsx = priceDataToXlsx(items, columns)
-      downloadBinaryFile(
-        xlsx,
-        exportFilename('oracle-prices', 'xlsx'),
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      )
-    },
-    [consume],
-  )
-
   const exportData = useCallback(
-    (format: ExportFormat, items: PriceData[], columns?: string[]) => {
+    async (format: ExportFormat, items: PriceData[], columns?: string[]) => {
       // Consume a single token for the aggregated exportData call so callers
       // using exportData directly are also rate-limited.
       if (!consume()) return
+      // Export generators (csv/xlsx encoding, file download plumbing) are only
+      // pulled into a chunk once the user actually triggers an export.
       const {
         downloadBinaryFile,
         downloadFile,
         exportFilename,
         priceDataToCsvRows,
+        priceDataToJsonRows,
         priceDataToXlsx,
         toCsv,
       } = await loadExportUtils()

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -781,6 +781,7 @@ describe('Dashboard', () => {
       subscribe: vi.fn(),
       unsubscribe: vi.fn(),
       _emitPriceUpdate: vi.fn(),
+      _injectSimulatedMessage: vi.fn(),
     })
     render(
       <MemoryRouter>

--- a/src/test/performance.test.tsx
+++ b/src/test/performance.test.tsx
@@ -72,6 +72,7 @@ describe('render count regression: Dashboard', () => {
       subscribe: vi.fn(),
       unsubscribe: vi.fn(),
       _emitPriceUpdate: vi.fn(),
+      _injectSimulatedMessage: vi.fn(),
     })
   })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -156,6 +156,24 @@ export default defineConfig(({ mode }) => {
           ]
         : []),
     ],
+    resolve: {
+      alias: [
+        // #475 — production builds never see the real simulate panel (or its
+        // wsSimulator engine, which only it imports): every import of
+        // `dev/SimulatePanel` resolves to a no-op stub instead. This is a
+        // config-level guarantee independent of how well the bundler's dead
+        // code elimination handles the `import.meta.env.DEV` guard at the
+        // call site — see `dev/SimulatePanel.stub.tsx`.
+        ...(mode === 'production'
+          ? [
+              {
+                find: './dev/SimulatePanel',
+                replacement: path.resolve(__dirname, 'src/dev/SimulatePanel.stub.tsx'),
+              },
+            ]
+          : []),
+      ],
+    },
     base: '/Stellar-Unified-Price-Oracle-Frontend-/',
     build: {
       // Generate hidden source maps (not inlined into JS — kept as separate .map files).


### PR DESCRIPTION
…r load (#475)

Adds a dev-only "Simulate" panel for exercising the UI against a degraded WebSocket feed without touching a real backend:

- Flood/throttle/drop modes reshape the live message stream: flood dispatches N extra duplicate messages per real tick, throttle delays every message by a configurable ms, drop silently discards messages at a configurable probability (deterministic PRNG so it's testable and repeatable, not Math.random())
- Per-source targeting simulates a specific oracle going down (stripped from `sources[]`, confidence reduced, message dropped entirely once every contributing source is "down") or diverging (price perturbed by a configurable ±% as if that source's feed had drifted)
- A deterministic replay engine schedules every recorded/canned frame from a single start anchor (never chained off the previous frame's timer), so relative offsets never accumulate drift regardless of event-loop load — verified with fake timers
- A record/stop capture of the live message stream feeds the replay engine, plus a small built-in sample sequence so there's something to replay without recording first

Architecture, to keep this fully out of the hot path and out of production:
- `api/websocket.ts` never imports the simulator engine at all (not even dynamically) — it exposes a tiny `setDevMessageInterceptor` registration slot (a no-op passthrough by default) that the dev panel wires itself into on mount and clears on unmount. This keeps the always-loaded core WS client decoupled from dev-only code by a runtime hook, not an import edge.
- `PriceContext` exposes an internal `_injectSimulatedMessage` used only by the replay engine to inject frames straight into the live message pipeline, the same way a real WS message would arrive.
- Empirically, this project's bundler (rolldown-vite) does NOT fully eliminate a `{import.meta.env.DEV && <Component/>}`-guarded static import from a production build on its own — verified by building and grepping `dist/` for `PerformanceOverlay`-only strings, which are present despite that being the codebase's existing dev-overlay pattern. So this can't rely on that guard alone: `vite.config.ts` aliases every import of `dev/SimulatePanel` to a trivial stub (`SimulatePanel.stub.tsx`) for production builds, guaranteeing the real panel — and `dev/wsSimulator.ts`, which only it imports — are never part of the production module graph. Verified via a real `vite build` + grep across `dist/assets/*.js` for every simulator-specific identifier, string, and config key: zero matches.

Verified this branch introduces no new `tsc -b` errors (in fact fewer, since it also carries the useExport.ts fix from feature/issue-476 — same broken/duplicated exportData implementation, pre-existing and unrelated to this feature, needed to get useExport.ts to compile at all) or new test failures versus a clean checkout of main.