### PR TITLE
feat(realtime): compression metrics, backpressure pause/resume, offline cache, SSE fallback

### DIFF
--- a/src/api/realtimeClient.ts
+++ b/src/api/realtimeClient.ts
@@ -1,0 +1,132 @@
+/**
+ * Realtime price feed client (#471).
+ *
+ * Wraps {@link WebSocketClient} and transparently falls back to
+ * {@link SseClient} when the WebSocket transport is exhausted without ever
+ * successfully connecting (e.g. a network that blocks the WS upgrade). This
+ * is the class `PriceContext` talks to — its public surface mirrors
+ * `WebSocketClient` so callers don't need to know which transport is active.
+ * Both transports emit the identical `WsMessage` shape, so the
+ * optimistic-update + REST-confirm path is unaffected by which one is live.
+ * The active transport is exposed via `diagnostics.transport` for the UI
+ * (see `ConnectionBadge`'s "SSE" indicator).
+ */
+import { config } from '../config'
+import type { WsMessage } from '../types'
+import { WebSocketClient, type ConnectionStatus, type ConnectionDiagnostics } from './websocket'
+import { SseClient, deriveSseUrl } from './sseTransport'
+
+type MessageHandler = (msg: WsMessage) => void
+type StatusHandler = (status: ConnectionStatus) => void
+
+export class RealtimeClient {
+  private ws: WebSocketClient | null = null
+  private sse: SseClient | null = null
+  private transport: 'ws' | 'sse' = 'ws'
+  private everConnected = false
+  private destroyed = false
+  private readonly subscribedPairs = new Set<string>()
+
+  private readonly messageHandlersRef: Set<MessageHandler> = new Set()
+  private readonly statusHandlersRef: Set<StatusHandler> = new Set()
+
+  private _status: ConnectionStatus = 'disconnected'
+  get status(): ConnectionStatus {
+    return this._status
+  }
+
+  get diagnostics(): ConnectionDiagnostics {
+    const active = this.transport === 'ws' ? this.ws?.diagnostics : this.sse?.diagnostics
+    return {
+      retryCount: active?.retryCount ?? 0,
+      lastConnectedAt: active?.lastConnectedAt ?? null,
+      totalDisconnections: active?.totalDisconnections ?? 0,
+      protocolVersion: active?.protocolVersion ?? null,
+      protocolUpgradeRequired: active?.protocolUpgradeRequired ?? false,
+      isPaused: active?.isPaused ?? false,
+      transport: this.transport,
+    }
+  }
+
+  private setStatus(status: ConnectionStatus) {
+    this._status = status
+    this.statusHandlersRef.forEach((h) => h(status))
+  }
+
+  connect() {
+    if (this.destroyed) return
+    this.startWs()
+  }
+
+  private startWs() {
+    const client = new WebSocketClient()
+    this.ws = client
+    this.transport = 'ws'
+
+    client.onMessage((msg) => this.messageHandlersRef.forEach((h) => h(msg)))
+    client.onStatusChange((status) => {
+      if (status === 'connected') this.everConnected = true
+      // Fall back to SSE only if the WS transport never once connected —
+      // an established connection that later dies should keep retrying WS.
+      if (status === 'dead' && !this.everConnected) {
+        this.fallBackToSse()
+        return
+      }
+      this.setStatus(status)
+    })
+
+    if (this.subscribedPairs.size > 0) client.subscribe(Array.from(this.subscribedPairs))
+    client.connect()
+  }
+
+  private fallBackToSse() {
+    if (typeof EventSource === 'undefined') {
+      // No SSE support in this environment either — surface the original dead state.
+      this.setStatus('dead')
+      return
+    }
+
+    this.ws?.disconnect()
+    this.ws = null
+    this.transport = 'sse'
+
+    const sse = new SseClient(deriveSseUrl(config.wsUrl))
+    this.sse = sse
+    sse.onMessage((msg) => this.messageHandlersRef.forEach((h) => h(msg)))
+    sse.onStatusChange((status) => this.setStatus(status))
+
+    if (this.subscribedPairs.size > 0) sse.subscribe(Array.from(this.subscribedPairs))
+    sse.connect()
+  }
+
+  disconnect() {
+    this.destroyed = true
+    this.ws?.disconnect()
+    this.sse?.disconnect()
+    this.setStatus('disconnected')
+  }
+
+  subscribe(pairs: string | string[]) {
+    const arr = typeof pairs === 'string' ? [pairs] : pairs
+    arr.forEach((p) => this.subscribedPairs.add(p))
+    if (this.transport === 'ws') this.ws?.subscribe(arr)
+    else this.sse?.subscribe(arr)
+  }
+
+  unsubscribe(pairs: string | string[]) {
+    const arr = typeof pairs === 'string' ? [pairs] : pairs
+    arr.forEach((p) => this.subscribedPairs.delete(p))
+    if (this.transport === 'ws') this.ws?.unsubscribe(arr)
+    else this.sse?.unsubscribe(arr)
+  }
+
+  onMessage(handler: MessageHandler): () => void {
+    this.messageHandlersRef.add(handler)
+    return () => this.messageHandlersRef.delete(handler)
+  }
+
+  onStatusChange(handler: StatusHandler): () => void {
+    this.statusHandlersRef.add(handler)
+    return () => this.statusHandlersRef.delete(handler)
+  }
+}

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -198,11 +198,20 @@ export const WsWelcomeMessageSchema = z.object({
   protocolVersion: z.number().int().min(0),
 })
 
+/** Server ack confirming inbound updates were paused/resumed for this connection (#469). */
+export const WsPausedMessageSchema = z.object({ type: z.literal('paused') })
+export const WsResumedMessageSchema = z.object({ type: z.literal('resumed') })
+
 /**
  * Discriminated union of all known WebSocket message types.
  * Add new variants here as the server protocol evolves.
  */
-export const WsMessageSchema = z.discriminatedUnion('type', [WsPriceUpdateSchema, WsWelcomeMessageSchema])
+export const WsMessageSchema = z.discriminatedUnion('type', [
+  WsPriceUpdateSchema,
+  WsWelcomeMessageSchema,
+  WsPausedMessageSchema,
+  WsResumedMessageSchema,
+])
 
 // ── Type inference from schemas ──────────────────────────────────────────────
 

--- a/src/api/sseTransport.ts
+++ b/src/api/sseTransport.ts
@@ -1,0 +1,203 @@
+/**
+ * Server-Sent Events fallback transport for the price feed (#471).
+ *
+ * Some corporate/enterprise networks block the WebSocket upgrade handshake
+ * outright. {@link SseClient} streams the same `price_update` event shape as
+ * {@link WebSocketClient} over a plain `EventSource`, so `PriceContext`'s
+ * optimistic-update + REST-confirm path is unaffected by which transport is
+ * actually active.
+ *
+ * It reuses `WebSocketClient`'s reconnect backoff and heartbeat-timeout
+ * constants (imported from `./websocket`) so both transports fail over with
+ * identical timing/jitter — only the underlying wire mechanism differs.
+ *
+ * SSE has no client→server channel, so `subscribe`/`unsubscribe` are encoded
+ * as a `pairs` query parameter and applied by reopening the stream.
+ */
+import type { WsMessage } from '../types'
+import { wsAnalytics } from '../utils/wsAnalytics'
+import { WsMessageSchema } from './schemas'
+import {
+  type ConnectionStatus,
+  type ConnectionDiagnostics,
+  MAX_RETRIES,
+  HEARTBEAT_INTERVAL_MS,
+  HEARTBEAT_TIMEOUT_MS,
+  jitteredBackoff,
+} from './websocket'
+
+type MessageHandler = (msg: WsMessage) => void
+type StatusHandler = (status: ConnectionStatus) => void
+
+/** Derives the SSE endpoint from the configured WS URL: swap scheme, sibling `/events` path. */
+export function deriveSseUrl(wsUrl: string): string {
+  const httpUrl = wsUrl.replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://')
+  const [base, query] = httpUrl.split('?')
+  const path = base.endsWith('/') ? `${base}events` : `${base}/events`
+  return query ? `${path}?${query}` : path
+}
+
+export class SseClient {
+  private es: EventSource | null = null
+  private readonly messageHandlersRef: Set<MessageHandler> = new Set()
+  private readonly statusHandlersRef: Set<StatusHandler> = new Set()
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempt = 0
+  private destroyed = false
+  private readonly subscribedPairs = new Set<string>()
+  private heartbeatCheckTimer: ReturnType<typeof setInterval> | null = null
+  private lastMessageAt = 0
+
+  private _retryCount = 0
+  private _lastConnectedAt: number | null = null
+  private _totalDisconnections = 0
+  private _status: ConnectionStatus = 'disconnected'
+
+  constructor(private readonly baseUrl: string) {}
+
+  get status(): ConnectionStatus {
+    return this._status
+  }
+
+  get diagnostics(): ConnectionDiagnostics {
+    return {
+      retryCount: this._retryCount,
+      lastConnectedAt: this._lastConnectedAt,
+      totalDisconnections: this._totalDisconnections,
+      transport: 'sse',
+    }
+  }
+
+  private setStatus(status: ConnectionStatus) {
+    this._status = status
+    this.statusHandlersRef.forEach((h) => h(status))
+  }
+
+  private buildUrl(): string {
+    if (this.subscribedPairs.size === 0) return this.baseUrl
+    const pairs = encodeURIComponent(Array.from(this.subscribedPairs).join(','))
+    return `${this.baseUrl}${this.baseUrl.includes('?') ? '&' : '?'}pairs=${pairs}`
+  }
+
+  connect() {
+    if (this.destroyed || typeof EventSource === 'undefined') return
+    this.setStatus('connecting')
+
+    const es = new EventSource(this.buildUrl())
+    this.es = es
+
+    es.onopen = () => {
+      this.reconnectAttempt = 0
+      this._retryCount = 0
+      this._lastConnectedAt = Date.now()
+      this.lastMessageAt = Date.now()
+      this.setStatus('connected')
+      this.startHeartbeatCheck()
+    }
+
+    es.onmessage = (e: MessageEvent<string>) => {
+      this.lastMessageAt = Date.now()
+      try {
+        const raw = JSON.parse(e.data) as Record<string, unknown>
+        const parsed = WsMessageSchema.safeParse(raw)
+        if (!parsed.success) return
+        const msg = parsed.data
+        if (msg.type === 'welcome' || msg.type === 'paused' || msg.type === 'resumed') return
+        this.messageHandlersRef.forEach((h) => h(msg))
+      } catch {
+        // ignore malformed messages
+      }
+    }
+
+    es.onerror = () => {
+      wsAnalytics.recordError('sse')
+      this.teardown()
+      this.scheduleReconnect()
+    }
+  }
+
+  private teardown() {
+    this.stopHeartbeatCheck()
+    this.es?.close()
+    this.es = null
+    this._totalDisconnections++
+    wsAnalytics.recordDisconnect()
+    this.setStatus('disconnected')
+  }
+
+  private startHeartbeatCheck() {
+    this.stopHeartbeatCheck()
+    this.heartbeatCheckTimer = setInterval(() => {
+      if (Date.now() - this.lastMessageAt > HEARTBEAT_INTERVAL_MS + HEARTBEAT_TIMEOUT_MS) {
+        // No traffic at all within the window — treat the stream as half-open.
+        this.teardown()
+        this.scheduleReconnect()
+      }
+    }, HEARTBEAT_INTERVAL_MS)
+  }
+
+  private stopHeartbeatCheck() {
+    if (this.heartbeatCheckTimer) {
+      clearInterval(this.heartbeatCheckTimer)
+      this.heartbeatCheckTimer = null
+    }
+  }
+
+  private scheduleReconnect() {
+    if (this.destroyed || this.reconnectTimer) return
+    if (this.reconnectAttempt >= MAX_RETRIES) {
+      this.setStatus('dead')
+      return
+    }
+    this.setStatus('waiting')
+    const delay = jitteredBackoff(this.reconnectAttempt)
+    this._retryCount = this.reconnectAttempt + 1
+    this.reconnectAttempt++
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      if (!this.destroyed) {
+        this.setStatus('reconnecting')
+        this.connect()
+      }
+    }, delay)
+  }
+
+  disconnect() {
+    this.destroyed = true
+    this.reconnectAttempt = 0
+    this.stopHeartbeatCheck()
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
+    this.es?.close()
+    this.es = null
+    this.setStatus('disconnected')
+  }
+
+  /** Adds pairs and reopens the stream with the full current pair set (SSE can't patch a subscription in place). */
+  subscribe(pairs: string | string[]) {
+    const arr = typeof pairs === 'string' ? [pairs] : pairs
+    arr.forEach((p) => this.subscribedPairs.add(p))
+    this.reopen()
+  }
+
+  unsubscribe(pairs: string | string[]) {
+    const arr = typeof pairs === 'string' ? [pairs] : pairs
+    arr.forEach((p) => this.subscribedPairs.delete(p))
+    this.reopen()
+  }
+
+  private reopen() {
+    if (this.destroyed || !this.es) return
+    this.es.close()
+    this.connect()
+  }
+
+  onMessage(handler: MessageHandler): () => void {
+    this.messageHandlersRef.add(handler)
+    return () => this.messageHandlersRef.delete(handler)
+  }
+
+  onStatusChange(handler: StatusHandler): () => void {
+    this.statusHandlersRef.add(handler)
+    return () => this.statusHandlersRef.delete(handler)
+  }
+}

--- a/src/api/websocket.ts
+++ b/src/api/websocket.ts
@@ -1,5 +1,11 @@
 import { config } from '../config'
-import type { WsMessage, WsSubscribeMessage, WsUnsubscribeMessage } from '../types'
+import type {
+  WsMessage,
+  WsSubscribeMessage,
+  WsUnsubscribeMessage,
+  WsPauseMessage,
+  WsResumeMessage,
+} from '../types'
 import { wsAnalytics } from '../utils/wsAnalytics'
 import { recordWsMessageTiming } from '../utils/performanceMonitor'
 import { WS_PROTOCOL_VERSION } from './version'
@@ -16,6 +22,7 @@ type StatusHandler = (status: ConnectionStatus) => void
  * - `disconnected` — cleanly closed (e.g. explicit {@link WebSocketClient.disconnect})
  * - `waiting`      — in the backoff window before the next reconnect attempt
  * - `dead`         — max retries exhausted; no further reconnect will occur
+ * - `paused`       — connected, but inbound updates are paused under backpressure (#469)
  */
 export type ConnectionStatus =
   | 'connecting'
@@ -24,6 +31,7 @@ export type ConnectionStatus =
   | 'reconnecting'
   | 'waiting'
   | 'dead'
+  | 'paused'
 
 /** Diagnostics exposed via the client for use in UI components. */
 export interface ConnectionDiagnostics {
@@ -37,6 +45,10 @@ export interface ConnectionDiagnostics {
   protocolVersion?: number | null
   /** True when the server speaks a newer protocol than this client supports (#472). */
   protocolUpgradeRequired?: boolean
+  /** True while inbound updates are auto-paused under backpressure (#469). */
+  isPaused?: boolean
+  /** Which realtime transport is currently active (#471). Only set by {@link RealtimeClient}. */
+  transport?: 'ws' | 'sse'
 }
 
 const supportsDecompression = typeof DecompressionStream !== 'undefined'
@@ -65,23 +77,32 @@ async function decompress(data: Blob): Promise<string> {
   }
 }
 
-// Reconnection configuration
-const INITIAL_DELAY_MS = 1_000
-const MAX_DELAY_MS = 30_000
-const MAX_RETRIES = 20
+// Reconnection configuration. Exported (#471) so the SSE fallback transport
+// (`sseTransport.ts`) shares the exact same backoff/heartbeat behaviour.
+export const INITIAL_DELAY_MS = 1_000
+export const MAX_DELAY_MS = 30_000
+export const MAX_RETRIES = 20
 
 // Heartbeat configuration
-const HEARTBEAT_INTERVAL_MS = 30_000
-const HEARTBEAT_TIMEOUT_MS = 10_000
+export const HEARTBEAT_INTERVAL_MS = 30_000
+export const HEARTBEAT_TIMEOUT_MS = 10_000
 
 /**
  * Full-jitter exponential backoff: returns a random value in [0, min(initial * 2^attempt, max)].
  * This avoids thundering-herd reconnect storms.
  */
-function jitteredBackoff(attempt: number): number {
+export function jitteredBackoff(attempt: number): number {
   const cap = Math.min(INITIAL_DELAY_MS * Math.pow(2, attempt), MAX_DELAY_MS)
   return Math.random() * cap
 }
+
+// Backpressure configuration (#469). The browser dispatches WS messages
+// synchronously, so there is no literal inbound "queue" to inspect — instead
+// we approximate queue depth with the inbound message rate over a rolling
+// window, which is what actually saturates the UI when a flood hits.
+const BACKPRESSURE_WINDOW_MS = 1_000
+const BACKPRESSURE_HIGH_WATER_MARK = 40 // msgs/sec — auto-pause above this
+const BACKPRESSURE_LOW_WATER_MARK = 10 // msgs/sec — auto-resume at/below this
 
 /**
  * Manages a single WebSocket connection to the price feed server.
@@ -99,6 +120,11 @@ function jitteredBackoff(attempt: number): number {
  * - **Rate-limit awareness**: pauses reconnection when `rateLimitManager` reports
  *   a `limited` status and resumes after the retry-after window
  * - **Diagnostics**: `retryCount`, `lastConnectedAt`, `totalDisconnections`
+ * - **Compression metrics (#468)**: when the server sends a compressed (Blob) frame,
+ *   the wire size vs. decoded size is recorded via `wsAnalytics.recordCompression`
+ * - **Backpressure (#469)**: auto-sends `{action:'pause'}` when the inbound message
+ *   rate exceeds a high-water mark, `{action:'resume'}` once it drains — surfaced as
+ *   the `paused` connection status and `diagnostics.isPaused`
  */
 export class WebSocketClient {
   private ws: WebSocket | null = null
@@ -132,6 +158,11 @@ export class WebSocketClient {
   private heartbeatInterval: ReturnType<typeof setInterval> | null = null
   private heartbeatTimeout: ReturnType<typeof setTimeout> | null = null
 
+  // Backpressure (#469) — rolling inbound message count + auto pause/resume state
+  private backpressureTimer: ReturnType<typeof setInterval> | null = null
+  private inboundCount = 0
+  private _isPaused = false
+
   // Diagnostics
   private _retryCount = 0
   private _lastConnectedAt: number | null = null
@@ -152,6 +183,7 @@ export class WebSocketClient {
       totalDisconnections: this._totalDisconnections,
       protocolVersion: this._protocolVersion,
       protocolUpgradeRequired: this._protocolUpgradeRequired,
+      isPaused: this._isPaused,
     }
   }
 
@@ -192,6 +224,52 @@ export class WebSocketClient {
       clearTimeout(this.heartbeatTimeout)
       this.heartbeatTimeout = null
     }
+  }
+
+  // ── Backpressure (#469) ─────────────────────────────────────────────────────
+
+  private startBackpressureMonitor() {
+    this.stopBackpressureMonitor()
+    this.inboundCount = 0
+    this.backpressureTimer = setInterval(() => {
+      const rate = this.inboundCount
+      this.inboundCount = 0
+      if (!this._isPaused && rate > BACKPRESSURE_HIGH_WATER_MARK) {
+        this.pauseInbound()
+      } else if (this._isPaused && rate <= BACKPRESSURE_LOW_WATER_MARK) {
+        this.resumeInbound()
+      }
+    }, BACKPRESSURE_WINDOW_MS)
+  }
+
+  private stopBackpressureMonitor() {
+    if (this.backpressureTimer) {
+      clearInterval(this.backpressureTimer)
+      this.backpressureTimer = null
+    }
+    this._isPaused = false
+  }
+
+  /** Tells the server to pause this subscription (high-water mark exceeded) and reflects it in `status`. */
+  private pauseInbound() {
+    this._isPaused = true
+    this.sendRaw(JSON.stringify({ action: 'pause' } satisfies WsPauseMessage))
+    this.setStatus('paused')
+  }
+
+  /**
+   * Tells the server to resume this subscription (drained below the low-water mark) and
+   * re-sends the current subscription set so the server can replay anything missed (#469).
+   */
+  private resumeInbound() {
+    this._isPaused = false
+    this.sendRaw(JSON.stringify({ action: 'resume' } satisfies WsResumeMessage))
+    if (this.subscribedPairs.size > 0) {
+      this.sendRaw(
+        JSON.stringify({ action: 'subscribe', assetPairs: Array.from(this.subscribedPairs) }),
+      )
+    }
+    this.setStatus('connected')
   }
 
   // ── Raw send (bypasses queue logic) ────────────────────────────────────────
@@ -259,6 +337,7 @@ export class WebSocketClient {
 
       // Start heartbeat
       this.startHeartbeat()
+      this.startBackpressureMonitor()
     }
 
     // Fix: capture a reference to the stable handler Sets (not individual callbacks).
@@ -271,12 +350,16 @@ export class WebSocketClient {
 
       // Any inbound message resets the heartbeat timeout
       this.resetHeartbeatTimeout()
+      // Backpressure (#469) — count this arrival toward the current rolling window
+      this.inboundCount++
 
       try {
         let text: string
         if (e.data instanceof Blob) {
           text = supportsDecompression ? await decompress(e.data) : await e.data.text()
           this.useCompression = true
+          // #468 – permessage-deflate savings: wire size (compressed Blob) vs. decoded text size.
+          wsAnalytics.recordCompression(e.data.size, new TextEncoder().encode(text).length)
         } else {
           text = e.data as string
         }
@@ -308,6 +391,12 @@ export class WebSocketClient {
           return
         }
 
+        // #469 – server acks for our pause/resume requests are informational only;
+        // the client already flipped its local state optimistically when it sent them.
+        if (msg.type === 'paused' || msg.type === 'resumed') {
+          return
+        }
+
         messageHandlersRef.forEach((h) => h(msg))
 
         // Record end-to-end processing time for this message
@@ -320,6 +409,7 @@ export class WebSocketClient {
     this.ws.onclose = () => {
       this.useCompression = false
       this.stopHeartbeat()
+      this.stopBackpressureMonitor()
       wsAnalytics.recordDisconnect()
       this._totalDisconnections++
       this.setStatus('disconnected')
@@ -371,6 +461,7 @@ export class WebSocketClient {
     this.destroyed = true
     this.reconnectAttempt = 0
     this.stopHeartbeat()
+    this.stopBackpressureMonitor()
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
     this.ws?.close()
     this.ws = null

--- a/src/components/ConnectionBadge.tsx
+++ b/src/components/ConnectionBadge.tsx
@@ -35,6 +35,7 @@
  * | `waiting`     | orange | Exponential back-off window before next attempt  |
  * | `dead`        | red    | Max retries exhausted, manual reload required    |
  * | `disconnected`| red    | Offline, REST polling only                       |
+ * | `paused`      | orange | Inbound updates paused under backpressure (#469) |
  *
  * ## Edge cases
  * - **Rate limited** — overrides the status colour with orange and shows a countdown
@@ -85,6 +86,13 @@ const STATUS_MAP: Record<ConnectionStatus, { label: string; color: string; toolt
     label: 'Offline',
     color: 'bg-red-500',
     tooltip: 'WebSocket is offline. Prices are updated via REST polling only.',
+  },
+  paused: {
+    label: 'Paused',
+    color: 'bg-orange-500',
+    tooltip:
+      'Inbound updates are paused — the client asked the server to pause this subscription ' +
+      'while it catches up. Resumes automatically once the backlog drains.',
   },
 }
 
@@ -145,6 +153,9 @@ export const ConnectionBadge = memo(function ConnectionBadge({
     label = `${s.label} (${diagnostics.retryCount}/${20})`
   }
 
+  // #471 – visible indicator when the client has fallen back from WebSocket to SSE.
+  const isSseFallback = diagnostics?.transport === 'sse'
+
   const ariaLabel = isRateLimited ? 'API rate limited' : `WebSocket ${s.label}`
 
   let tooltipText = isRateLimited
@@ -153,6 +164,11 @@ export const ConnectionBadge = memo(function ConnectionBadge({
 
   if (!isRateLimited && diagnostics && diagnostics.retryCount > 0) {
     tooltipText += ` (attempt ${diagnostics.retryCount} of 20)`
+  }
+
+  if (isSseFallback) {
+    tooltipText +=
+      ' Falling back to Server-Sent Events — the WebSocket upgrade failed or was blocked by the network.'
   }
 
   return (
@@ -167,6 +183,14 @@ export const ConnectionBadge = memo(function ConnectionBadge({
           aria-hidden="true"
         />
         {label}
+        {isSseFallback && (
+          <span
+            className="px-1 rounded bg-amber-500/20 text-amber-400 text-[10px] font-semibold uppercase tracking-wide"
+            title="Streaming over Server-Sent Events (WebSocket fallback)"
+          >
+            SSE
+          </span>
+        )}
       </span>
     </Tooltip>
   )

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, type ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { usePreferences } from '../preferences/PreferencesContext'
+import { usePriceContext } from '../context/PriceContext'
 import {
   REFRESH_INTERVAL_OPTIONS,
   CHART_RANGE_OPTIONS,
@@ -8,7 +9,7 @@ import {
   CHART_TIMEZONE_OPTIONS,
   FORMAT_LOCALE_OPTIONS,
 } from '../preferences/constants'
-import { SUPPORTED_LANGUAGES, LANGUAGE_LABELS, orderByRecentlyUsed, type SupportedLanguage } from '../i18n'
+import { SUPPORTED_LANGUAGES, LANGUAGE_LABELS, type SupportedLanguage } from '../i18n'
 import { clearAllData, getLocalStorageSize, writeRaw, STORAGE_KEYS } from '../utils/storage'
 import { loadSoundPreferences, saveSoundPreferences } from '../utils/soundPreferences'
 import { playAlertSound, unlockAudioContext } from '../utils/alertSound'
@@ -60,9 +61,11 @@ function AccessibilityToggle({
 export function SettingsPanel({ onClose }: SettingsPanelProps): ReactElement {
   const { preferences, updatePreference, undo, redo, canUndo, canRedo, clearHistory } =
     usePreferences()
+  const { clearPriceCache } = usePriceContext()
   const { t, i18n } = useTranslation()
   const [clearStatus, setClearStatus] = useState<'idle' | 'confirming' | 'clearing' | 'done'>('idle')
   const [soundPrefs, setSoundPrefs] = useState(loadSoundPreferences)
+  const [priceCacheStatus, setPriceCacheStatus] = useState<'idle' | 'clearing' | 'done'>('idle')
 
   const storageSize = getLocalStorageSize()
 
@@ -81,6 +84,13 @@ export function SettingsPanel({ onClose }: SettingsPanelProps): ReactElement {
   const handleClearCancel = useCallback(() => {
     setClearStatus('idle')
   }, [])
+
+  const handleClearPriceCache = useCallback(async () => {
+    setPriceCacheStatus('clearing')
+    await clearPriceCache()
+    setPriceCacheStatus('done')
+    setTimeout(() => setPriceCacheStatus('idle'), 1500)
+  }, [clearPriceCache])
 
   const handleSoundEnabledChange = useCallback((enabled: boolean) => {
     setSoundPrefs((prev) => {
@@ -369,6 +379,21 @@ export function SettingsPanel({ onClose }: SettingsPanelProps): ReactElement {
                 Includes alert thresholds, notification config, theme preference, and cached
                 price data. No passwords, API keys, or personal information are stored.
               </p>
+
+              {/* Offline price snapshot (#470) — scoped clear, distinct from "clear everything" below. */}
+              <button
+                type="button"
+                onClick={() => void handleClearPriceCache()}
+                disabled={priceCacheStatus === 'clearing'}
+                className="w-full px-4 py-2 rounded-lg text-sm font-medium bg-gray-800 text-gray-300 hover:bg-gray-700 transition-colors disabled:opacity-40"
+                aria-label="Clear cached offline price snapshot"
+              >
+                {priceCacheStatus === 'done'
+                  ? 'Offline price cache cleared'
+                  : priceCacheStatus === 'clearing'
+                    ? 'Clearing…'
+                    : 'Clear cached offline prices'}
+              </button>
 
               {clearStatus === 'idle' && (
                 <button

--- a/src/components/WsAnalyticsPanel.tsx
+++ b/src/components/WsAnalyticsPanel.tsx
@@ -13,6 +13,13 @@ function fmt(ts: number) {
   return new Date(ts).toLocaleTimeString()
 }
 
+/** Formats a byte count compactly, e.g. 1536 -> "1.5 KB" (#468). */
+function fmtBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
 export const WsAnalyticsPanel = memo(function WsAnalyticsPanel() {
   const [summary, setSummary] = useState<WsAnalyticsSummary>(() => wsAnalytics.getSummary())
 
@@ -74,6 +81,15 @@ export const WsAnalyticsPanel = memo(function WsAnalyticsPanel() {
           <div className="text-gray-400">Avg latency</div>
           <div className="font-mono text-white">
             {summary.avgLatencyMs != null ? `${summary.avgLatencyMs.toFixed(0)}ms` : '—'}
+          </div>
+        </div>
+        {/* #468 – permessage-deflate savings */}
+        <div className="bg-gray-800 rounded p-2">
+          <div className="text-gray-400">Compression saved</div>
+          <div className="font-mono text-white">
+            {summary.compressionBytesSaved > 0
+              ? `${fmtBytes(summary.compressionBytesSaved)} (${((summary.compressionRatio ?? 0) * 100).toFixed(0)}%)`
+              : '—'}
           </div>
         </div>
       </div>

--- a/src/context/PriceContext.tsx
+++ b/src/context/PriceContext.tsx
@@ -1,11 +1,14 @@
 import { createContext, useContext, useEffect, useRef, useState, useCallback, type ReactNode } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { WebSocketClient, type ConnectionStatus } from '../api/websocket'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import type { ConnectionStatus, ConnectionDiagnostics } from '../api/websocket'
+import { RealtimeClient } from '../api/realtimeClient'
 import { fetchAllPrices, fetchPricesBatched } from '../api/rest'
 import { rateLimitManager, type RateLimitStatus } from '../api/rateLimit'
 import { useOutboundQueue } from '../hooks/useOutboundQueue'
+import { offlinePriceStore } from '../services/offlinePriceStore'
 import { config } from '../config'
 import type { LivePriceEntry, PriceData } from '../types'
+import { useToast } from './ToastContext'
 
 /**
  * Internal event emitter for per-pair live price updates.
@@ -55,6 +58,8 @@ export interface PriceContextValue {
   livePrices: Map<string, LivePriceEntry>
   /** Current WebSocket connection status. */
   wsStatus: ConnectionStatus
+  /** Connection diagnostics — retry count, negotiated protocol, active transport (#471), pause state (#469). */
+  diagnostics: ConnectionDiagnostics
   /** Current API rate-limit status. */
   rateLimitStatus: RateLimitStatus
   /** Remaining retry window for rate limiting in milliseconds. */
@@ -79,6 +84,12 @@ export interface PriceContextValue {
   unsubscribe: (pairs: string[]) => void
   /** Internal: emit live price update for a specific pair (do not use directly). */
   _emitPriceUpdate: (pair: string, entry: LivePriceEntry) => void
+  /** `true` when `prices` is being served from the persisted offline snapshot rather than a live REST fetch (#470). */
+  isOfflineSnapshot: boolean
+  /** When `isOfflineSnapshot` is true, the timestamp the cached snapshot was saved at; otherwise `null`. */
+  offlineSnapshotSavedAt: number | null
+  /** Clears the persisted offline price snapshot (manual "clear cache" action, #470). */
+  clearPriceCache: () => Promise<void>
 }
 
 const PriceContext = createContext<PriceContextValue | null>(null)
@@ -114,15 +125,37 @@ export function PriceProvider({ children }: { children: ReactNode }) {
 
   const [livePrices, setLivePrices] = useState<Map<string, LivePriceEntry>>(new Map())
   const [wsStatus, setWsStatus] = useState<ConnectionStatus>('disconnected')
+  const [diagnostics, setDiagnostics] = useState<ConnectionDiagnostics>({
+    retryCount: 0,
+    lastConnectedAt: null,
+    totalDisconnections: 0,
+    transport: 'ws',
+  })
   const [rateLimitStatus, setRateLimitStatus] = useState<RateLimitStatus>(
     rateLimitManager.status,
   )
   const [rateLimitRetryAfterMs, setRateLimitRetryAfterMs] = useState(
     rateLimitManager.retryAfterMs,
   )
-  const wsRef = useRef<WebSocketClient | null>(null)
+  const wsRef = useRef<RealtimeClient | null>(null)
   const requestIdsRef = useRef<Map<string, number>>(new Map())
   const cleanupTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  // Offline-first price cache (#470): last confirmed snapshot, persisted to IndexedDB
+  // and used as the display source when the REST fetch has no data (first offline load).
+  const [offlineSnapshot, setOfflineSnapshot] = useState<{ prices: PriceData[]; savedAt: number } | null>(null)
+  const wasOfflineRef = useRef(false)
+  const { addToast } = useToast()
+
+  useEffect(() => {
+    let cancelled = false
+    void offlinePriceStore.load().then((snapshot) => {
+      if (!cancelled) setOfflineSnapshot(snapshot)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const clearCleanupTimer = (pair: string): void => {
     const timer = cleanupTimersRef.current.get(pair)
@@ -198,10 +231,13 @@ export function PriceProvider({ children }: { children: ReactNode }) {
       }
     }
 
-    const client = new WebSocketClient()
+    const client = new RealtimeClient()
     wsRef.current = client
 
-    const unsubStatus = client.onStatusChange(setWsStatus)
+    const unsubStatus = client.onStatusChange((status) => {
+      setWsStatus(status)
+      setDiagnostics(client.diagnostics)
+    })
     const unsubMsg = client.onMessage((msg) => {
       if (msg.type === 'price_update') {
         setLivePrices((prev) => {
@@ -281,20 +317,62 @@ export function PriceProvider({ children }: { children: ReactNode }) {
     }
   }, [prices])
 
+  // Offline-first (#470): debounced persist of the latest REST-confirmed snapshot,
+  // bounded by the shared IndexedDB LRU cache and read back on the next disconnect/reload.
+  useEffect(() => {
+    offlinePriceStore.persist(prices)
+  }, [prices])
+
+  // REST has no data (first load while offline, or the fetch failed) — fall back to the
+  // last persisted snapshot so the dashboard renders last-known prices instead of going blank.
+  const isOfflineSnapshot =
+    prices.length === 0 && !pricesLoading && (offlineSnapshot?.prices.length ?? 0) > 0
+  const displayPrices = prices.length > 0 ? prices : (offlineSnapshot?.prices ?? prices)
+
+  // Reconciliation: once REST data comes back after a spell showing the offline
+  // snapshot, surface which pairs changed while we were disconnected (#470).
+  useEffect(() => {
+    if (isOfflineSnapshot) {
+      wasOfflineRef.current = true
+      return
+    }
+    if (!wasOfflineRef.current || prices.length === 0 || !offlineSnapshot) return
+    wasOfflineRef.current = false
+
+    const cachedByPair = new Map(offlineSnapshot.prices.map((p) => [p.assetPair, p]))
+    const updatedPairs = prices.filter((p) => {
+      const cached = cachedByPair.get(p.assetPair)
+      return !cached || p.timestamp > cached.timestamp
+    })
+    if (updatedPairs.length > 0) {
+      const preview = updatedPairs.slice(0, 3).map((p) => p.assetPair).join(', ')
+      addToast({
+        type: 'info',
+        message: `Back online — ${updatedPairs.length} pair${updatedPairs.length === 1 ? '' : 's'} updated while offline (${preview}${updatedPairs.length > 3 ? '…' : ''}).`,
+        priority: 'normal',
+      })
+    }
+  }, [isOfflineSnapshot, prices, offlineSnapshot, addToast])
+
   const subscribe = (pairs: string[]): void => wsRef.current?.subscribe(pairs)
   const unsubscribe = (pairs: string[]): void => wsRef.current?.unsubscribe(pairs)
   const handleRefetchPrices = (): void => { void refetchPrices() }
   const emitPriceUpdate = useCallback((pair: string, entry: LivePriceEntry): void => {
     priceUpdateEmitter.emit(pair, entry)
   }, [])
+  const clearPriceCache = useCallback(async (): Promise<void> => {
+    await offlinePriceStore.clear()
+    setOfflineSnapshot(null)
+  }, [])
 
   const value: PriceContextValue = {
-    prices,
+    prices: displayPrices,
     pricesLoading,
     pricesError,
     pricesValidating,
     livePrices,
     wsStatus,
+    diagnostics,
     rateLimitStatus,
     rateLimitRetryAfterMs,
     outboundQueued: outbound.queued,
@@ -304,6 +382,9 @@ export function PriceProvider({ children }: { children: ReactNode }) {
     subscribe,
     unsubscribe,
     _emitPriceUpdate: emitPriceUpdate,
+    isOfflineSnapshot,
+    offlineSnapshotSavedAt: offlineSnapshot?.savedAt ?? null,
+    clearPriceCache,
   }
 
   return (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -31,6 +31,7 @@ import { FilterPanel, readFilterState, countActiveFilters } from '../components/
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { PairSearchBar } from '../components/PairSearchBar'
 import { LazyPriceTable, preloadPriceTable } from '../utils/chunks'
+import { StaleDataWarningBanner } from '../components/StaleDataWarningBanner'
 import type { AlertFormData, LivePriceEntry, PriceData } from '../types'
 import { buildConditionGroupFromFormData } from '../utils/alertEvaluator'
 
@@ -57,9 +58,12 @@ export function Dashboard() {
     pricesValidating,
     livePrices,
     wsStatus,
+    diagnostics,
     rateLimitStatus,
     rateLimitRetryAfterMs,
     refetchPrices,
+    isOfflineSnapshot,
+    offlineSnapshotSavedAt,
   } = usePriceContext()
   const navigate = useNavigate()
   const { t } = useTranslation()
@@ -389,7 +393,12 @@ export function Dashboard() {
             </svg>
             {t('scheduledExports.button', { defaultValue: 'Schedule' })}
           </button>
-          <ConnectionBadge status={wsStatus} rateLimitStatus={rateLimitStatus} retryAfterMs={rateLimitRetryAfterMs} />
+          <ConnectionBadge
+            status={wsStatus}
+            rateLimitStatus={rateLimitStatus}
+            retryAfterMs={rateLimitRetryAfterMs}
+            diagnostics={diagnostics}
+          />
         </div>
       </div>
 
@@ -468,6 +477,13 @@ export function Dashboard() {
         <div className="mb-6 p-4 bg-red-900/30 border border-red-800 rounded-xl text-sm text-red-400" role="alert">
           {pricesError.message}
         </div>
+      )}
+
+      {/* Offline-first (#470): rendering the last persisted snapshot instead of a blank dashboard. */}
+      {isOfflineSnapshot && offlineSnapshotSavedAt != null && (
+        <StaleDataWarningBanner
+          thresholdMinutes={Math.max(1, Math.round((Date.now() - offlineSnapshotSavedAt) / 60_000))}
+        />
       )}
 
       {pricesLoading && prices.length === 0 ? (

--- a/src/services/offlinePriceStore.ts
+++ b/src/services/offlinePriceStore.ts
@@ -1,0 +1,52 @@
+/**
+ * Offline-first price snapshot store (#470).
+ *
+ * Persists the latest confirmed price snapshot to the shared IndexedDB cache
+ * (`prices` store, see `hooks/useIndexedDB.ts`) so the dashboard can render
+ * last-known prices — with a stale badge — instead of going blank when the
+ * network drops. Writes are debounced so a burst of WS-confirmed updates
+ * doesn't hammer IndexedDB. Size is bounded by the shared cache's 50 MB LRU
+ * eviction, and the snapshot survives reloads because it's real IndexedDB.
+ */
+import { idbCache } from '../hooks/useIndexedDB'
+import type { PriceData } from '../types'
+
+const STORE = 'prices' as const
+const SNAPSHOT_KEY = 'offline-snapshot'
+/** Long TTL — a real outage can last hours, so don't let the snapshot expire mid-use. */
+const SNAPSHOT_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const DEBOUNCE_MS = 2_000
+
+export interface OfflineSnapshot {
+  prices: PriceData[]
+  savedAt: number
+}
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+export const offlinePriceStore = {
+  /** Debounced write of the latest confirmed price snapshot to IndexedDB. */
+  persist(prices: PriceData[]): void {
+    if (prices.length === 0) return
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null
+      const snapshot: OfflineSnapshot = { prices, savedAt: Date.now() }
+      void idbCache.set(STORE, SNAPSHOT_KEY, snapshot)
+    }, DEBOUNCE_MS)
+  },
+
+  /** Loads the last persisted snapshot, or `null` if none exists / it expired. */
+  async load(): Promise<OfflineSnapshot | null> {
+    return idbCache.get<OfflineSnapshot>(STORE, SNAPSHOT_KEY, SNAPSHOT_TTL_MS)
+  },
+
+  /** Clears the cached offline snapshot — the manual "clear cache" action in Settings. */
+  async clear(): Promise<void> {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+    await idbCache.delete(STORE, SNAPSHOT_KEY)
+  },
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,10 @@ export type {
   WsWelcomeMessage,
   WsPriceUpdate,
   WsMessage,
+  WsPauseMessage,
+  WsResumeMessage,
+  WsPausedMessage,
+  WsResumedMessage,
 } from './price'
 
 export { isPriceData } from './price'

--- a/src/types/price.ts
+++ b/src/types/price.ts
@@ -96,6 +96,26 @@ export interface WsUnsubscribeMessage {
   assetPairs: string[]
 }
 
+/** Client request to pause inbound price updates under backpressure (#469). */
+export interface WsPauseMessage {
+  action: 'pause'
+}
+
+/** Client request to resume inbound price updates once backpressure clears (#469). */
+export interface WsResumeMessage {
+  action: 'resume'
+}
+
+/** Server ack confirming inbound updates have been paused for this connection (#469). */
+export interface WsPausedMessage {
+  type: 'paused'
+}
+
+/** Server ack confirming inbound updates have resumed for this connection (#469). */
+export interface WsResumedMessage {
+  type: 'resumed'
+}
+
 /** A real-time price update received via WebSocket. */
 export interface WsPriceUpdate {
   type: 'price_update'
@@ -112,7 +132,7 @@ export interface WsPriceUpdate {
 }
 
 /** Union of all possible WebSocket message types. */
-export type WsMessage = WsPriceUpdate | WsWelcomeMessage
+export type WsMessage = WsPriceUpdate | WsWelcomeMessage | WsPausedMessage | WsResumedMessage
 
 // ---------------------------------------------------------------------------
 // Type guards

--- a/src/utils/wsAnalytics.ts
+++ b/src/utils/wsAnalytics.ts
@@ -19,6 +19,10 @@ export interface WsAnalyticsSummary {
   protocolVersion: number | null
   /** True when the server is newer than this client supports (#472). */
   protocolUpgradeRequired: boolean
+  /** Total bytes saved by permessage-deflate compression across all compressed messages (#468). */
+  compressionBytesSaved: number
+  /** Ratio of bytes saved to uncompressed size, e.g. 0.6 = 60% smaller on the wire, or `null` with no samples yet (#468). */
+  compressionRatio: number | null
   events: WsEvent[]
 }
 
@@ -31,6 +35,9 @@ let connectTime: number | null = null
 let latencySamples: number[] = []
 let protocolVersion: number | null = null
 let protocolUpgradeRequired = false
+// #468 – permessage-deflate savings, accumulated across every compressed message received.
+let compressedBytesTotal = 0
+let decompressedBytesTotal = 0
 
 function summarise(): WsAnalyticsSummary {
   const counts = { connect: 0, disconnect: 0, reconnect: 0, error: 0 }
@@ -56,6 +63,11 @@ function summarise(): WsAnalyticsSummary {
     avgLatencyMs: avg,
     protocolVersion,
     protocolUpgradeRequired,
+    compressionBytesSaved: decompressedBytesTotal - compressedBytesTotal,
+    compressionRatio:
+      decompressedBytesTotal > 0
+        ? (decompressedBytesTotal - compressedBytesTotal) / decompressedBytesTotal
+        : null,
     events: [...events],
   }
 }
@@ -93,6 +105,14 @@ export const wsAnalytics = {
     const s = summarise()
     listeners.forEach((l) => l(s))
   },
+  /** Records one permessage-deflate compressed message's wire size vs. its decompressed size (#468). */
+  recordCompression(compressedBytes: number, decompressedBytes: number) {
+    if (decompressedBytes <= 0) return
+    compressedBytesTotal += compressedBytes
+    decompressedBytesTotal += decompressedBytes
+    const s = summarise()
+    listeners.forEach((l) => l(s))
+  },
   subscribe(listener: Listener): () => void {
     listeners.add(listener)
     listener(summarise())
@@ -108,5 +128,7 @@ export const wsAnalytics = {
     events.length = 0
     latencySamples = []
     connectTime = null
+    compressedBytesTotal = 0
+    decompressedBytesTotal = 0
   },
 }


### PR DESCRIPTION
Closes #468, closes #469, closes #470, closes #471

## #468 — Negotiate WebSocket permessage-deflate compression
- Record wire size vs. decoded size for every compressed (Blob) frame received
- Surface total bytes saved + compression ratio in `WsAnalyticsPanel`
- Falls back gracefully when the server doesn't compress (unchanged text frames handled as before)

## #469 — Backpressure signalling (pause/resume subscription)
- `WebSocketClient` tracks the inbound message rate and auto-sends `{action:'pause'}` once it exceeds a high-water mark, `{action:'resume'}` once it drains (server acks `{type:'paused'|'resumed'}` are recognized and consumed)
- New `'paused'` `ConnectionStatus`, rendered in `ConnectionBadge`
- Resends the tracked subscription set on resume so the server can replay anything missed
- Backward-compatible protocol addition — `WS_PROTOCOL_VERSION` unchanged

## #470 — Offline-first mode with IndexedDB price store
- New `offlinePriceStore`: debounced persist of the latest confirmed price snapshot into the existing IndexedDB `prices` cache (bounded by its LRU eviction, survives reloads)
- `PriceContext` falls back to the cached snapshot when the REST fetch has no data, rendered via the existing `StaleDataWarningBanner`
- Reconciliation toast on reconnect naming pairs that updated while offline
- "Clear cached offline prices" action added to Settings

## #471 — Server-Sent Events fallback transport
- New `SseClient` (EventSource-based) streaming the same `price_update` event shape
- New `RealtimeClient` wraps `WebSocketClient` + `SseClient`, falling back to SSE only if the WS transport never once connects; shares `WebSocketClient`'s backoff/heartbeat constants
- `ConnectionBadge` shows an "SSE" tag when the fallback transport is active
- `PriceContext`'s optimistic-update + REST-confirm path is transport-agnostic — both transports emit the identical message shape

---

Note: this repo's `tsc -b` / `vite build` already fail on `main` due to many pre-existing, unrelated errors across files this PR doesn't touch (e.g. `vite.config.ts`, `src/api/rest.ts`, several `*.test.tsx` files). The files changed in this PR typecheck and lint cleanly in isolation. Per instructions, tests were intentionally skipped for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)